### PR TITLE
Also set the default value of `extendedIndentOfParameters` to `false` if there's no config file

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
@@ -15,7 +15,7 @@ internal class IndentationConfig(config: Map<String, String>) : RuleConfiguratio
     /**
      * If true, in parameter list when parameters are split by newline they are indented with two indentations instead of one
      */
-    val extendedIndentOfParameters = config["extendedIndentOfParameters"]?.toBoolean() ?: true
+    val extendedIndentOfParameters = config["extendedIndentOfParameters"]?.toBoolean() ?: false
 
     /**
      * If true, if first parameter in parameter list is on the same line as opening parenthesis, then other parameters


### PR DESCRIPTION
### What's done:

 * The default value of `extendedIndentOfParameters` is now `false` even if the YAML config file is missing.
 * Related to #1312.
