### PR TITLE
Set the default values of `extendedIndentAfterOperators` and `extendedIndentBeforeDot` to `false`

### DIFF
--- a/diktat-analysis.yml
+++ b/diktat-analysis.yml
@@ -206,7 +206,7 @@
     # If true: if first parameter in parameter list is on the same line as opening parenthesis, then other parameters can be aligned with it
     alignedParameters: true
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     # If true: when dot qualified expression starts on a new line, this line will be indented with two indentations instead of one
     extendedIndentBeforeDot: false
     # The indentation size for each file

--- a/diktat-common/src/main/kotlin/org/cqfn/diktat/common/config/reader/JsonResourceConfigReader.kt
+++ b/diktat-common/src/main/kotlin/org/cqfn/diktat/common/config/reader/JsonResourceConfigReader.kt
@@ -46,7 +46,7 @@ abstract class JsonResourceConfigReader<T> {
      * @return [BufferedReader] representing loaded resource
      */
     protected open fun getConfigFile(resourceFileName: String): BufferedReader? =
-            classLoader.getResourceAsStream(resourceFileName)?.bufferedReader()
+        classLoader.getResourceAsStream(resourceFileName)?.bufferedReader()
 
     /**
      * you can specify your own parser, in example for parsing stream as a json

--- a/diktat-common/src/main/kotlin/org/cqfn/diktat/common/config/rules/RulesConfigReader.kt
+++ b/diktat-common/src/main/kotlin/org/cqfn/diktat/common/config/rules/RulesConfigReader.kt
@@ -202,13 +202,13 @@ fun List<RulesConfig>.isRuleEnabled(rule: Rule): Boolean {
  * @return true if the code block is marked with annotation that is in `ignored list` in the rule
  */
 fun List<RulesConfig>.isAnnotatedWithIgnoredAnnotation(rule: Rule, annotations: Set<String>): Boolean =
-        getRuleConfig(rule)
-            ?.ignoreAnnotated
-            ?.map { it.trim() }
-            ?.map { it.trim('"') }
-            ?.intersect(annotations)
-            ?.isNotEmpty()
-            ?: false
+    getRuleConfig(rule)
+        ?.ignoreAnnotated
+        ?.map { it.trim() }
+        ?.map { it.trim('"') }
+        ?.intersect(annotations)
+        ?.isNotEmpty()
+        ?: false
 
 /**
  * Parse string into KotlinVersion

--- a/diktat-common/src/test/resources/test-rules-config.yml
+++ b/diktat-common/src/test/resources/test-rules-config.yml
@@ -127,7 +127,7 @@
     newlineAtEnd: true
     extendedIndentOfParameters: false
     alignedParameters: true
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     indentationSize: 4
 - name: EMPTY_BLOCK_STRUCTURE_ERROR
   enabled: true

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -193,7 +193,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
 
     @Suppress("MagicNumber")
     private fun isMainClassPropertySupported(gradleVersionString: String) =
-            GradleVersion.version(gradleVersionString) >= GradleVersion.version("6.4")
+        GradleVersion.version(gradleVersionString) >= GradleVersion.version("6.4")
 
     private fun MutableList<String>.addInput(file: File) {
         add(file.toRelativeString(project.projectDir))
@@ -226,7 +226,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
     }
 
     private fun getJavaExecJvmVersion(): JavaVersion = if (GradleVersion.version(gradleVersionString) >= GradleVersion.version("6.7") &&
-            javaLauncher.isPresent
+        javaLauncher.isPresent
     ) {
         // Java Launchers are available since 6.7, but may not always be configured
         javaLauncher.map { it.metadata.jvmVersion }.map(JavaVersion::toVersion).get()
@@ -247,10 +247,10 @@ fun Project.registerDiktatCheckTask(diktatExtension: DiktatExtension,
                                     diktatConfiguration: Configuration,
                                     patternSet: PatternSet
 ): TaskProvider<DiktatJavaExecTaskBase> =
-        tasks.register(
-            DIKTAT_CHECK_TASK, DiktatJavaExecTaskBase::class.java, gradle.gradleVersion,
-            diktatExtension, diktatConfiguration, patternSet
-        )
+    tasks.register(
+        DIKTAT_CHECK_TASK, DiktatJavaExecTaskBase::class.java, gradle.gradleVersion,
+        diktatExtension, diktatConfiguration, patternSet
+    )
 
 /**
  * @param diktatExtension [DiktatExtension] with some values for task configuration
@@ -262,7 +262,7 @@ fun Project.registerDiktatFixTask(diktatExtension: DiktatExtension,
                                   diktatConfiguration: Configuration,
                                   patternSet: PatternSet
 ): TaskProvider<DiktatJavaExecTaskBase> =
-        tasks.register(
-            DIKTAT_FIX_TASK, DiktatJavaExecTaskBase::class.java, gradle.gradleVersion,
-            diktatExtension, diktatConfiguration, patternSet, listOf("-F ")
-        )
+    tasks.register(
+        DIKTAT_FIX_TASK, DiktatJavaExecTaskBase::class.java, gradle.gradleVersion,
+        diktatExtension, diktatConfiguration, patternSet, listOf("-F ")
+    )

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/Utils.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/Utils.kt
@@ -34,4 +34,4 @@ class KotlinClosure1<in T : Any?, V : Any>(
     "KDOC_WITHOUT_RETURN_TAG"
 )
 fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> =
-        KotlinClosure1(action, this, this)
+    KotlinClosure1(action, this, this)

--- a/diktat-maven-plugin/src/main/kotlin/org/cqfn/diktat/plugin/maven/DiktatBaseMojo.kt
+++ b/diktat-maven-plugin/src/main/kotlin/org/cqfn/diktat/plugin/maven/DiktatBaseMojo.kt
@@ -109,7 +109,7 @@ abstract class DiktatBaseMojo : AbstractMojo() {
             throw MojoExecutionException("Configuration file $diktatConfigFile doesn't exist")
         }
         log.info("Running diKTat plugin with configuration file $configFile and inputs $inputs" +
-                if (excludes.isNotEmpty()) " and excluding $excludes" else ""
+            if (excludes.isNotEmpty()) " and excluding $excludes" else ""
         )
 
         val ruleSets by lazy {
@@ -236,24 +236,24 @@ abstract class DiktatBaseMojo : AbstractMojo() {
     ) {
         val text = file.readText()
         val params =
-                KtLint.ExperimentalParams(
-                    fileName = file.relativeTo(mavenProject.basedir).path,
-                    text = text,
-                    ruleSets = ruleSets,
-                    userData = mapOf("file_path" to file.path),
-                    script = file.extension.equals("kts", ignoreCase = true),
-                    cb = { lintError, isCorrected ->
-                        if (baselineErrors.none {
-                            // ktlint's BaselineReporter stores only these fields
-                            it.line == lintError.line && it.col == lintError.col &&
-                                    it.ruleId == lintError.ruleId
-                        }) {
-                            reporterImpl.onLintError(file.path, lintError, isCorrected)
-                            lintErrors.add(lintError)
-                        }
-                    },
-                    debug = debug
-                )
+            KtLint.ExperimentalParams(
+                fileName = file.relativeTo(mavenProject.basedir).path,
+                text = text,
+                ruleSets = ruleSets,
+                userData = mapOf("file_path" to file.path),
+                script = file.extension.equals("kts", ignoreCase = true),
+                cb = { lintError, isCorrected ->
+                    if (baselineErrors.none {
+                        // ktlint's BaselineReporter stores only these fields
+                        it.line == lintError.line && it.col == lintError.col &&
+                            it.ruleId == lintError.ruleId
+                    }) {
+                        reporterImpl.onLintError(file.path, lintError, isCorrected)
+                        lintErrors.add(lintError)
+                    }
+                },
+                debug = debug
+            )
         runAction(params)
     }
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/constants/Chapters.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/constants/Chapters.kt
@@ -56,7 +56,7 @@ fun Warnings.isRuleFromActiveChapter(configRules: List<RulesConfig>): Boolean {
 fun Warnings.getChapterByWarning() = Chapters.values().find { it.number == this.ruleId.first().toString() }!!
 
 private fun validate(chapter: String) =
-        require(chapter in Chapters.values().map { it.title }) {
-            val closestMatch = Chapters.values().minByOrNull { Levenshtein.distance(it.title, chapter) }
-            "Chapter name <$chapter> in configuration file is invalid, did you mean <$closestMatch>?"
-        }
+    require(chapter in Chapters.values().map { it.title }) {
+        val closestMatch = Chapters.values().minByOrNull { Levenshtein.distance(it.title, chapter) }
+        "Chapter name <$chapter> in configuration file is invalid, did you mean <$closestMatch>?"
+    }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/constants/Warnings.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/constants/Warnings.kt
@@ -105,7 +105,7 @@ enum class Warnings(
     NO_BRACES_IN_CONDITIONALS_AND_LOOPS(true, "3.2.1", "in if, else, when, for, do, and while statements braces should be used. Exception: single line if statement."),
     WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES(true, "3.1.4", "the declaration part of a class-like code structures (class/interface/etc.) should be in the proper order"),
     BLANK_LINE_BETWEEN_PROPERTIES(true, "3.1.4", "there should be no blank lines between properties without comments; comment, KDoc or annotation on property should have blank" +
-            " line before"),
+        " line before"),
     TOP_LEVEL_ORDER(true, "3.1.5", "the declaration part of a top level elements should be in the proper order"),
     BRACES_BLOCK_STRUCTURE_ERROR(true, "3.2.2", "braces should follow 1TBS style"),
     WRONG_INDENTATION(true, "3.3.1", "only spaces are allowed for indentation and each indentation should equal to 4 spaces (tabs are not allowed)"),

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/generation/Generation.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/generation/Generation.kt
@@ -26,10 +26,10 @@ import kotlin.io.path.writeLines
  * The comment that will be added to the generated sources file.
  */
 private val autoGenerationComment =
-        """
-            | This document was auto generated, please don't modify it.
-            | This document contains all enum properties from Warnings.kt as Strings.
-        """.trimMargin()
+    """
+        | This document was auto generated, please don't modify it.
+        | This document contains all enum properties from Warnings.kt as Strings.
+    """.trimMargin()
 
 fun main() {
     generateWarningNames()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
@@ -65,7 +65,7 @@ abstract class DiktatRule(
     }
 
     private fun areInspectionsDisabled(): Boolean =
-            inspections.none { configRules.isRuleEnabled(it) }
+        inspections.none { configRules.isRuleEnabled(it) }
 
     /**
      * Logic of the rule

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
@@ -118,7 +118,7 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
     )
     override fun get(): RuleSet {
         log.debug("Will run $DIKTAT_RULE_SET_ID with $diktatConfigFile" +
-                " (it can be placed to the run directory or the default file from resources will be used)")
+            " (it can be placed to the run directory or the default file from resources will be used)")
         val configPath = possibleConfigs
             .firstOrNull { it != null && File(it).exists() }
         diktatConfigFile = configPath
@@ -126,12 +126,12 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
                 val possibleConfigsList = possibleConfigs.toList()
                 log.warn(
                     "Configuration file not found in directory where diktat is run (${possibleConfigsList[0]}) " +
-                            "or in the directory where diktat.jar is stored (${possibleConfigsList[1]}) " +
-                            "or in system property <diktat.config.path> (${possibleConfigsList[2]}), " +
-                            "the default file included in jar will be used. " +
-                            "Some configuration options will be disabled or substituted with defaults. " +
-                            "Custom configuration file should be placed in diktat working directory if run from CLI " +
-                            "or provided as configuration options in plugins."
+                        "or in the directory where diktat.jar is stored (${possibleConfigsList[1]}) " +
+                        "or in system property <diktat.config.path> (${possibleConfigsList[2]}), " +
+                        "the default file included in jar will be used. " +
+                        "Some configuration options will be disabled or substituted with defaults. " +
+                        "Custom configuration file should be placed in diktat working directory if run from CLI " +
+                        "or provided as configuration options in plugins."
                 )
                 diktatConfigFile
             }
@@ -241,10 +241,10 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
     }
 
     private fun validate(config: RulesConfig) =
-            require(config.name == DIKTAT_COMMON || config.name in Warnings.names) {
-                val closestMatch = Warnings.names.minByOrNull { Levenshtein.distance(it, config.name) }
-                "Warning name <${config.name}> in configuration file is invalid, did you mean <$closestMatch>?"
-            }
+        require(config.name == DIKTAT_COMMON || config.name in Warnings.names) {
+            val closestMatch = Warnings.names.minByOrNull { Levenshtein.distance(it, config.name) }
+            "Warning name <${config.name}> in configuration file is invalid, did you mean <$closestMatch>?"
+        }
 
     private fun resolveDefaultConfig() = diktatConfigFile
 
@@ -252,12 +252,12 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
         // for some aggregators of static analyzers we need to provide configuration for cli
         // in this case diktat would take the configuration from the directory where jar file is stored
         val ruleSetProviderPath =
-                DiktatRuleSetProvider::class
-                    .java
-                    .protectionDomain
-                    .codeSource
-                    .location
-                    .toURI()
+            DiktatRuleSetProvider::class
+                .java
+                .protectionDomain
+                .codeSource
+                .location
+                .toURI()
 
         val configPathWithFileName = File(ruleSetProviderPath).absolutePath
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
@@ -169,7 +169,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
                 }
                 // check if identifier of a property has a confusing name
                 if (confusingIdentifierNames.contains(variableName.text) && !isValidCatchIdentifier(variableName) &&
-                        node.elementType == ElementType.PROPERTY
+                    node.elementType == ElementType.PROPERTY
                 ) {
                     warnConfusingName(variableName)
                 }
@@ -193,7 +193,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
                             ?.forEach { (it.node.firstChildNode as LeafPsiElement).rawReplaceWithText(correctVariableName) }
                         if (variableName.treeParent.psi.run {
                             (this is KtProperty && isMember) ||
-                                    (this is KtParameter && getParentOfType<KtPrimaryConstructor>(true)?.valueParameters?.contains(this) == true)
+                                (this is KtParameter && getParentOfType<KtPrimaryConstructor>(true)?.valueParameters?.contains(this) == true)
                         }) {
                             // For class members also check `@property` KDoc tag.
                             // If we are here, then `variableName` is definitely a node from a class or an object.
@@ -257,7 +257,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
             destructingDeclaration.getAllChildrenWithType(DESTRUCTURING_DECLARATION_ENTRY)
                 .map { it.getIdentifierName()!! }
         } else if (node.parents().count() > 1 && node.treeParent.elementType == VALUE_PARAMETER_LIST &&
-                node.treeParent.treeParent.elementType == FUNCTION_TYPE
+            node.treeParent.treeParent.elementType == FUNCTION_TYPE
         ) {
             listOfNotNull(node.getIdentifierName())
         } else {
@@ -434,7 +434,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
         nodes.forEach {
             val isValidOneCharVariable = oneCharIdentifiers.contains(it.text) && isVariable
             if (it.text != "_" && !it.isTextLengthInRange(MIN_IDENTIFIER_LENGTH..MAX_IDENTIFIER_LENGTH) &&
-                    !isValidOneCharVariable && !isValidCatchIdentifier(it)
+                !isValidOneCharVariable && !isValidCatchIdentifier(it)
             ) {
                 IDENTIFIER_LENGTH.warn(configRules, emitWarn, isFixMode, it.text, it.startOffset, it)
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
@@ -81,7 +81,7 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
             }
         } ?: if (visitorCounter.incrementAndGet() == 1) {
             log.error("Not able to find an external configuration for domain" +
-                    " name in the common configuration (is it missing in yml config?)")
+                " name in the common configuration (is it missing in yml config?)")
         }
     }
 
@@ -123,7 +123,7 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
 
         return if (!filePathParts.contains(PACKAGE_PATH_ANCHOR)) {
             log.error("Not able to determine a path to a scanned file or \"$PACKAGE_PATH_ANCHOR\" directory cannot be found in it's path." +
-                    " Will not be able to determine correct package name. It can happen due to missing <$PACKAGE_PATH_ANCHOR> directory in the path")
+                " Will not be able to determine correct package name. It can happen due to missing <$PACKAGE_PATH_ANCHOR> directory in the path")
             emptyList()
         } else {
             // creating a real package name:
@@ -198,8 +198,8 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
         val wordFromPackage = word.replace("_", "")
 
         return wordFromPackage[0].isDigit() ||
-                wordFromPackage.isKotlinKeyWord() ||
-                wordFromPackage.isJavaKeyWord()
+            wordFromPackage.isKotlinKeyWord() ||
+            wordFromPackage.isJavaKeyWord()
     }
 
     /**

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/CommentsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/CommentsRule.kt
@@ -94,11 +94,11 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
             .forEach { (offset, parsedNode) ->
                 val invalidNode = errorNodesWithText.find {
                     it.second.trim().contains(parsedNode.text, false) ||
-                            parsedNode.text.contains(it.second.trim(), false)
+                        parsedNode.text.contains(it.second.trim(), false)
                 }?.first
                 if (invalidNode == null) {
                     logger.warn("Text [${parsedNode.text}] is a piece of code, created from comment; " +
-                            "but no matching text in comments has been found in the file ${node.getFilePath()}")
+                        "but no matching text in comments has been found in the file ${node.getFilePath()}")
                 } else {
                     COMMENTED_OUT_CODE.warn(
                         configRules,
@@ -159,7 +159,7 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isContainingRequiredPartOfCode(text: String): Boolean =
-            text.contains("val ", true) || text.contains("var ", true) || text.contains("=", true) || (text.contains("{", true) && text.substringAfter("{").contains("}", true))
+        text.contains("val ", true) || text.contains("var ", true) || text.contains("=", true) || (text.contains("{", true) && text.substringAfter("{").contains("}", true))
 
     /**
      * Some weak checks to see if this string can be used as a part of import statement.
@@ -167,9 +167,9 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
      * are considered for this case.
      */
     private fun String.isPossibleImport(): Boolean = trimStart().startsWith(importKeywordWithSpace) &&
-            substringAfter(importKeywordWithSpace, "").run {
-                startsWith('`') && endsWith('`') || !contains(' ')
-            }
+        substringAfter(importKeywordWithSpace, "").run {
+            startsWith('`') && endsWith('`') || !contains(' ')
+        }
 
     @Suppress("MaxLineLength")
     companion object {
@@ -179,7 +179,7 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
         private val packageKeywordWithSpace = "${KtTokens.PACKAGE_KEYWORD.value} "
         private val importOrPackage = """($importKeywordWithSpace|$packageKeywordWithSpace)""".toRegex()
         private val classRegex =
-                """^\s*(public|private|protected)*\s*(internal)*\s*(open|data|sealed)*\s*(internal)*\s*(class|object)\s+(\w+)(\(.*\))*(\s*:\s*\w+(\(.*\))*)?\s*\{*$""".toRegex()
+            """^\s*(public|private|protected)*\s*(internal)*\s*(open|data|sealed)*\s*(internal)*\s*(class|object)\s+(\w+)(\(.*\))*(\s*:\s*\w+(\(.*\))*)?\s*\{*$""".toRegex()
         private val importOrPackageRegex = """^(import|package)?\s+([a-zA-Z.])+;*$""".toRegex()
         private val functionRegex = """^(public|private|protected)*\s*(override|abstract|actual|expect)*\s?fun\s+\w+(\(.*\))?(\s*:\s*\w+)?\s*[{=]${'$'}""".toRegex()
         private val rightBraceRegex = """^\s*}$""".toRegex()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
@@ -60,7 +60,7 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun checkHeaderKdoc(node: ASTNode) {
         node.findChildBefore(PACKAGE_DIRECTIVE, KDOC)?.let { headerKdoc ->
             if (headerKdoc.treeNext != null && headerKdoc.treeNext.elementType == WHITE_SPACE &&
-                    headerKdoc.treeNext.text.count { it == '\n' } != 2) {
+                headerKdoc.treeNext.text.count { it == '\n' } != 2) {
                 HEADER_WRONG_FORMAT.warnAndFix(configRules, emitWarn, isFixMode,
                     "header KDoc should have a new line after", headerKdoc.startOffset, headerKdoc) {
                     node.replaceChild(headerKdoc.treeNext, PsiWhiteSpaceImpl("\n\n"))
@@ -69,7 +69,7 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
         }
             ?: run {
                 val numDeclaredClassesAndObjects = node.getAllChildrenWithType(ElementType.CLASS).size +
-                        node.getAllChildrenWithType(ElementType.OBJECT_DECLARATION).size
+                    node.getAllChildrenWithType(ElementType.OBJECT_DECLARATION).size
                 if (numDeclaredClassesAndObjects != 1) {
                     HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warn(configRules, emitWarn, isFixMode,
                         "there are $numDeclaredClassesAndObjects declared classes and/or objects", node.startOffset, node)
@@ -147,12 +147,12 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
         val headerComment = node.findChildBefore(PACKAGE_DIRECTIVE, BLOCK_COMMENT)
         // Depends only on content and doesn't consider years
         val isCopyrightMatchesPatternExceptFirstYear = isCopyRightTextMatchesPattern(headerComment, copyrightText) ||
-                isCopyRightTextMatchesPattern(headerComment, copyrightWithCorrectYear)
+            isCopyRightTextMatchesPattern(headerComment, copyrightWithCorrectYear)
 
         val isWrongCopyright = headerComment != null &&
-                !isCopyrightMatchesPatternExceptFirstYear &&
-                !isHeaderCommentContainText(headerComment, copyrightText) &&
-                !isHeaderCommentContainText(headerComment, copyrightWithCorrectYear)
+            !isCopyrightMatchesPatternExceptFirstYear &&
+            !isHeaderCommentContainText(headerComment, copyrightText) &&
+            !isHeaderCommentContainText(headerComment, copyrightWithCorrectYear)
 
         val isMissingCopyright = headerComment == null && configuration.isCopyrightMandatory()
         val isCopyrightInsideKdoc = (node.getAllChildrenWithType(KDOC) + node.getAllChildrenWithType(ElementType.EOL_COMMENT))
@@ -223,8 +223,8 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
      * Used to compare copyrights in yaml and file
      */
     private fun String.flatten(): String =
-            replace("\n", "")
-                .replace(" ", "")
+        replace("\n", "")
+            .replace(" ", "")
 
     /**
      * If it is multiline copyright, this method deletes spaces in empty lines.

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/CommentsFormatting.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/CommentsFormatting.kt
@@ -113,7 +113,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
                 return
             }
         } else if (node.treeParent.lastChildNode != node && node.treeParent.elementType != IF &&
-                node.treeParent.firstChildNode == node && node.treeParent.elementType != VALUE_ARGUMENT_LIST) {
+            node.treeParent.firstChildNode == node && node.treeParent.elementType != VALUE_ARGUMENT_LIST) {
             // Else it's a class comment
             checkClassComment(node)
         }
@@ -224,40 +224,40 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
     @Suppress("ComplexMethod", "TOO_LONG_FUNCTION")
     private fun checkWhiteSpaceBeginInComment(node: ASTNode, configuration: CommentsFormattingConfiguration) {
         if (node.elementType == EOL_COMMENT &&
-                node
-                    .text
-                    .trimStart('/')
-                    .takeWhile { it == ' ' }
-                    .length == configuration.maxSpacesInComment) {
+            node
+                .text
+                .trimStart('/')
+                .takeWhile { it == ' ' }
+                .length == configuration.maxSpacesInComment) {
             return
         }
 
         if (node.elementType == BLOCK_COMMENT &&
-                (node
+            (node
+                .text
+                .trim('/', '*')
+                .takeWhile { it == ' ' }
+                .length == configuration.maxSpacesInComment ||
+                node
                     .text
                     .trim('/', '*')
-                    .takeWhile { it == ' ' }
-                    .length == configuration.maxSpacesInComment ||
-                        node
-                            .text
-                            .trim('/', '*')
-                            .takeWhile { it == '\n' }
-                            .isNotEmpty())) {
+                    .takeWhile { it == '\n' }
+                    .isNotEmpty())) {
             return
         }
 
         if (node.elementType == KDOC) {
             val section = node.getFirstChildWithType(KDOC_SECTION)
             if (section != null &&
-                    section.findChildrenMatching(KDOC_TEXT) { (it.treePrev != null && it.treePrev.elementType == KDOC_LEADING_ASTERISK) || it.treePrev == null }
-                        .all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
+                section.findChildrenMatching(KDOC_TEXT) { (it.treePrev != null && it.treePrev.elementType == KDOC_LEADING_ASTERISK) || it.treePrev == null }
+                    .all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
                 // it.treePrev == null if there is no \n at the beginning of KDoc
                 return
             }
 
             if (section != null &&
-                    section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).isNotEmpty() &&
-                    section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
+                section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).isNotEmpty() &&
+                section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
                 return
             }
         }
@@ -303,7 +303,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
                 node.treeParent.treeParent.addChild(PsiWhiteSpaceImpl("\n"), node.treeParent)
             }
         } else if (node.treeParent.elementType != FILE &&
-                (node.treeParent.treePrev.numNewLines() == 1 || node.treeParent.treePrev.numNewLines() > 2)) {
+            (node.treeParent.treePrev.numNewLines() == 1 || node.treeParent.treePrev.numNewLines() > 2)) {
             WRONG_NEWLINES_AROUND_KDOC.warnAndFix(configRules, emitWarn, isFixMode, node.text, node.startOffset, node) {
                 (node.treeParent.treePrev as LeafPsiElement).rawReplaceWithText("\n\n")
             }
@@ -312,7 +312,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun checkFirstCommentSpaces(node: ASTNode) {
         if (node.treePrev.isWhiteSpace() &&
-                (node.treePrev.numNewLines() > 1 || node.treePrev.numNewLines() == 0)) {
+            (node.treePrev.numNewLines() > 1 || node.treePrev.numNewLines() == 0)) {
             FIRST_COMMENT_NO_BLANK_LINE.warnAndFix(configRules, emitWarn, isFixMode, node.text, node.startOffset, node) {
                 (node.treePrev as LeafPsiElement).rawReplaceWithText("\n")
             }
@@ -331,7 +331,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
         // `treeParent` is the first not-empty node in a file
         true
     } else if (node.treeParent.elementType != FILE && node.treeParent.treePrev != null &&
-            node.treeParent.treePrev.treePrev != null) {
+        node.treeParent.treePrev.treePrev != null) {
         // When comment inside of a PROPERTY
         node.treeParent.treePrev.treePrev.elementType == LBRACE
     } else {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
@@ -92,8 +92,8 @@ class KdocComments(configRules: List<RulesConfig>) : DiktatRule(
     @Suppress("UnsafeCallOnNullableType", "ComplexMethod")
     private fun checkValueParameter(valueParameterNode: ASTNode) {
         if (valueParameterNode.parents().none { it.elementType == PRIMARY_CONSTRUCTOR } ||
-                !valueParameterNode.hasChildOfType(VAL_KEYWORD) &&
-                        !valueParameterNode.hasChildOfType(VAR_KEYWORD)
+            !valueParameterNode.hasChildOfType(VAL_KEYWORD) &&
+                !valueParameterNode.hasChildOfType(VAR_KEYWORD)
         ) {
             return
         }
@@ -300,9 +300,9 @@ class KdocComments(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun checkTopLevelDoc(node: ASTNode) =
-            // checking that all top level class declarations and functions have kDoc
-            (node.getAllChildrenWithType(CLASS) + node.getAllChildrenWithType(FUN))
-                .forEach { checkDoc(it, MISSING_KDOC_TOP_LEVEL) }
+        // checking that all top level class declarations and functions have kDoc
+        (node.getAllChildrenWithType(CLASS) + node.getAllChildrenWithType(FUN))
+            .forEach { checkDoc(it, MISSING_KDOC_TOP_LEVEL) }
 
     /**
      * raises warning if protected, public or internal code element does not have a Kdoc

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
@@ -162,11 +162,11 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun findBeforeAndAfterSpaces(tag: KDocTag) = Pair(tag.node.findChildBefore(KDOC_TEXT, WHITE_SPACE).let {
         it?.text != " " &&
-                !(it?.isWhiteSpaceWithNewline() ?: false)
+            !(it?.isWhiteSpaceWithNewline() ?: false)
     },
         tag.node.findChildAfter(KDOC_TAG_NAME, WHITE_SPACE).let {
             it?.text != " " &&
-                    !(it?.isWhiteSpaceWithNewline() ?: false)
+                !(it?.isWhiteSpaceWithNewline() ?: false)
         }
     )
 
@@ -290,11 +290,11 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
         val poorlyFormattedTagNodes = presentSpecialTagNodes?.filterNot { specialTagNode ->
             // empty line with just * followed by white space or end of block
             specialTagNode.lastChildNode.elementType == KDOC_LEADING_ASTERISK &&
-                    (specialTagNode.treeNext == null || specialTagNode.treeNext.elementType == WHITE_SPACE &&
-                            specialTagNode.treeNext.text.count { it == '\n' } == 1) &&
-                    // and with no empty line before
-                    specialTagNode.lastChildNode.treePrev.elementType == WHITE_SPACE &&
-                    specialTagNode.lastChildNode.treePrev.treePrev.elementType != KDOC_LEADING_ASTERISK
+                (specialTagNode.treeNext == null || specialTagNode.treeNext.elementType == WHITE_SPACE &&
+                    specialTagNode.treeNext.text.count { it == '\n' } == 1) &&
+                // and with no empty line before
+                specialTagNode.lastChildNode.treePrev.elementType == WHITE_SPACE &&
+                specialTagNode.lastChildNode.treePrev.treePrev.elementType != KDOC_LEADING_ASTERISK
         }
 
         if (poorlyFormattedTagNodes != null && poorlyFormattedTagNodes.isNotEmpty()) {
@@ -324,7 +324,7 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
         node.kDocTags()
             .filter {
                 it.knownTag == KDocKnownTag.AUTHOR ||
-                        it.knownTag == KDocKnownTag.SINCE && it.hasInvalidVersion()
+                    it.knownTag == KDocKnownTag.SINCE && it.hasInvalidVersion()
             }
             .forEach {
                 KDOC_CONTAINS_DATE_OR_AUTHOR.warn(configRules, emitWarn, isFixMode, it.text.trim(), it.startOffset, it.node)
@@ -335,7 +335,7 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
     private fun ASTNode.hasEmptyLineAfter(): Boolean {
         require(this.elementType == KDOC_TAG) { "This check is only for KDOC_TAG" }
         return lastChildNode.elementType == KDOC_LEADING_ASTERISK &&
-                (treeNext == null || treeNext.elementType == WHITE_SPACE && treeNext.text.count { it == '\n' } == 1)
+            (treeNext == null || treeNext.elementType == WHITE_SPACE && treeNext.text.count { it == '\n' } == 1)
     }
 
     private fun ASTNode.kDocBasicTags() = kDocTags().filter { basicTagsList.contains(it.knownTag) }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
@@ -277,11 +277,11 @@ class KdocMethods(configRules: List<RulesConfig>) : DiktatRule(
     ) {
         MISSING_KDOC_ON_FUNCTION.warnAndFix(configRules, emitWarn, isFixMode, name, node.startOffset, node) {
             val kdocTemplate = "/**\n" +
-                    (missingParameters.joinToString("") { " * @param $it\n" } +
-                            (if (returnCheckFailed) " * @return\n" else "") +
-                            explicitlyThrownExceptions.joinToString("") { " * @throws $it\n" } +
-                            " */\n"
-                    )
+                (missingParameters.joinToString("") { " * @param $it\n" } +
+                    (if (returnCheckFailed) " * @return\n" else "") +
+                    explicitlyThrownExceptions.joinToString("") { " * @throws $it\n" } +
+                    " */\n"
+                )
             val kdocNode = KotlinParser().createNode(kdocTemplate).findChildByType(KDOC)!!
             node.appendNewlineMergingWhiteSpace(node.firstChildNode, node.firstChildNode)
             node.addChild(kdocNode, node.firstChildNode)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BlockStructureBraces.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BlockStructureBraces.kt
@@ -255,7 +255,7 @@ class BlockStructureBraces(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun checkBraceNode(node: ASTNode, shouldContainNewline: Boolean = false) =
-            shouldContainNewline == node.isWhiteSpaceWithNewline()
+        shouldContainNewline == node.isWhiteSpaceWithNewline()
 
     /**
      * Configuration for style of braces in block

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BooleanExpressionsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BooleanExpressionsRule.kt
@@ -95,10 +95,10 @@ class BooleanExpressionsRule(configRules: List<RulesConfig>) : DiktatRule(
         val logicalExpressions = otherBinaryExpressions.filter { otherBinaryExpression ->
             // keeping only boolean expressions, keeping things like `a + b < 6` and excluding `a + b`
             (otherBinaryExpression.psi as KtBinaryExpression).operationReference.text in logicalInfixMethods &&
-                    // todo: support xor; for now skip all expressions that are nested in xor
-                    otherBinaryExpression.parents()
-                        .takeWhile { it != node }
-                        .none { (it.psi as? KtBinaryExpression)?.isXorExpression() ?: false }
+                // todo: support xor; for now skip all expressions that are nested in xor
+                otherBinaryExpression.parents()
+                    .takeWhile { it != node }
+                    .none { (it.psi as? KtBinaryExpression)?.isXorExpression() ?: false }
         }
         // Boolean expressions like `a > 5 && b < 7` or `x.isEmpty() || (y.isNotEmpty())` we convert to individual parts.
         val elementaryBooleanExpressions = booleanBinaryExpressions
@@ -111,13 +111,13 @@ class BooleanExpressionsRule(configRules: List<RulesConfig>) : DiktatRule(
             .filterNot {
                 // finally, if parts are binary expressions themselves, they should be present in our lists and we will process them later.
                 it.elementType == BINARY_EXPRESSION ||
-                        // !(a || b) should be skipped too, `a` and `b` should be present later
-                        (it.psi as? KtPrefixExpression)?.lastChild
-                            ?.node
-                            ?.removeAllParentheses()
-                            ?.elementType == BINARY_EXPRESSION ||
-                        // `true` and `false` are valid tokens for jBool, so we keep them.
-                        it.text == "true" || it.text == "false"
+                    // !(a || b) should be skipped too, `a` and `b` should be present later
+                    (it.psi as? KtPrefixExpression)?.lastChild
+                        ?.node
+                        ?.removeAllParentheses()
+                        ?.elementType == BINARY_EXPRESSION ||
+                    // `true` and `false` are valid tokens for jBool, so we keep them.
+                    it.text == "true" || it.text == "false"
             }
         (logicalExpressions + elementaryBooleanExpressions).forEach { expression ->
             expressionsReplacement.addExpression(expression)
@@ -137,9 +137,9 @@ class BooleanExpressionsRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun ASTNode.collectElementaryExpressions() = this
         .findAllNodesWithCondition { astNode ->
             astNode.elementType == BINARY_EXPRESSION &&
-                    // filter out boolean conditions in nested lambdas, e.g. `if (foo.filter { a && b })`
-                    (astNode == this || astNode.parents().takeWhile { it != this }
-                        .all { it.elementType in setOf(BINARY_EXPRESSION, PARENTHESIZED, PREFIX_EXPRESSION) })
+                // filter out boolean conditions in nested lambdas, e.g. `if (foo.filter { a && b })`
+                (astNode == this || astNode.parents().takeWhile { it != this }
+                    .all { it.elementType in setOf(BINARY_EXPRESSION, PARENTHESIZED, PREFIX_EXPRESSION) })
         }
         .partition {
             val operationReferenceText = (it.psi as KtBinaryExpression).operationReference.text
@@ -227,8 +227,8 @@ class BooleanExpressionsRule(configRules: List<RulesConfig>) : DiktatRule(
         // There should be three operands and three operation references in order to consider the expression
         // Moreover the operation references between operands should alternate.
         if (expressionsReplacement.size() < DISTRIBUTIVE_LAW_MIN_EXPRESSIONS ||
-                numberOfOperationReferences < DISTRIBUTIVE_LAW_MIN_OPERATIONS ||
-                !isSequenceAlternate(operationSequence)) {
+            numberOfOperationReferences < DISTRIBUTIVE_LAW_MIN_OPERATIONS ||
+            !isSequenceAlternate(operationSequence)) {
             return null
         }
         return if (operationSequence.first() == '&') {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BracesInConditionalsAndLoopsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BracesInConditionalsAndLoopsRule.kt
@@ -161,7 +161,7 @@ class BracesInConditionalsAndLoopsRule(configRules: List<RulesConfig>) : DiktatR
             .map { it.expression as KtBlockExpression }
             .filter { block ->
                 block.statements.size == 1 &&
-                        block.findChildrenMatching { it.isPartOfComment() }.isEmpty()
+                    block.findChildrenMatching { it.isPartOfComment() }.isEmpty()
             }
             .forEach {
                 NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnAndFix(configRules, emitWarn, isFixMode, "WHEN", it.node.startOffset, it.node) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ClassLikeStructuresOrderRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ClassLikeStructuresOrderRule.kt
@@ -72,9 +72,9 @@ class ClassLikeStructuresOrderRule(configRules: List<RulesConfig>) : DiktatRule(
             .allBlockFlattened()
             .map { astNode ->
                 listOf(astNode) +
-                        astNode.siblings(false)
-                            .takeWhile { it.elementType == WHITE_SPACE || it.isPartOfComment() }
-                            .toList()
+                    astNode.siblings(false)
+                        .takeWhile { it.elementType == WHITE_SPACE || it.isPartOfComment() }
+                        .toList()
             }
 
         node.checkAndReorderBlocks(blocks)
@@ -97,7 +97,7 @@ class ClassLikeStructuresOrderRule(configRules: List<RulesConfig>) : DiktatRule(
             .annotationEntries
             .any { it.node.isFollowedByNewline() }
         val hasCustomAccessors = (node.psi as KtProperty).accessors.isNotEmpty() ||
-                (previousProperty.psi as KtProperty).accessors.isNotEmpty()
+            (previousProperty.psi as KtProperty).accessors.isNotEmpty()
 
         val whiteSpaceBefore = previousProperty.nextSibling { it.elementType == WHITE_SPACE } ?: return
         val isBlankLineRequired = hasCommentBefore || hasAnnotationsBefore || hasCustomAccessors
@@ -105,7 +105,7 @@ class ClassLikeStructuresOrderRule(configRules: List<RulesConfig>) : DiktatRule(
         val actualNewLines = whiteSpaceBefore.text.count { it == '\n' }
         // for some cases (now - if this or previous property has custom accessors), blank line is allowed before it
         if (!hasCustomAccessors && actualNewLines != numRequiredNewLines ||
-                hasCustomAccessors && actualNewLines > numRequiredNewLines) {
+            hasCustomAccessors && actualNewLines > numRequiredNewLines) {
             BLANK_LINE_BETWEEN_PROPERTIES.warnAndFix(configRules, emitWarn, isFixMode, node.getIdentifierName()?.text ?: node.text, node.startOffset, node) {
                 whiteSpaceBefore.leaveExactlyNumNewLines(numRequiredNewLines)
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
@@ -88,7 +88,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val nestedIfNode = parentThenNode.findChildByType(IF) ?: return null
         // We won't collapse if-statements, if some of them have `else` node
         if ((parentNode.psi as KtIfExpression).`else` != null ||
-                (nestedIfNode.psi as KtIfExpression).`else` != null) {
+            (nestedIfNode.psi as KtIfExpression).`else` != null) {
             return null
         }
         // We monitor which types of nodes are followed before and after nested `if`
@@ -101,7 +101,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val listOfNodesAfterNestedIf = parentThenNode.getChildren(null).takeLastWhile { it != parentThenNode.findChildByType(IF) }
         val allowedTypes = listOf(LBRACE, WHITE_SPACE, RBRACE, BLOCK_COMMENT, EOL_COMMENT)
         if (listOfNodesBeforeNestedIf.any { it.elementType !in allowedTypes } ||
-                listOfNodesAfterNestedIf.any { it.elementType !in allowedTypes }) {
+            listOfNodesAfterNestedIf.any { it.elementType !in allowedTypes }) {
             return null
         }
         return nestedIfNode
@@ -111,7 +111,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val thenNode = (node.psi as KtIfExpression).then?.node
         return thenNode?.children()?.takeWhile { it.elementType != IF }?.filter {
             it.elementType == EOL_COMMENT ||
-                    it.elementType == BLOCK_COMMENT
+                it.elementType == BLOCK_COMMENT
         }
             ?.toList() ?: emptyList()
     }
@@ -136,13 +136,13 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         // If the nested condition is compound,
         // we need to put it to the brackets, according algebra of logic
         val mergeCondition =
-                if (nestedCondition?.node?.elementType == BINARY_EXPRESSION &&
-                        nestedCondition.node?.findChildByType(OPERATION_REFERENCE)?.text == "||"
-                ) {
-                    "if ($parentConditionText &&$commentsText($nestedConditionText)) {}"
-                } else {
-                    "if ($parentConditionText &&$commentsText$nestedConditionText) {}"
-                }
+            if (nestedCondition?.node?.elementType == BINARY_EXPRESSION &&
+                nestedCondition.node?.findChildByType(OPERATION_REFERENCE)?.text == "||"
+            ) {
+                "if ($parentConditionText &&$commentsText($nestedConditionText)) {}"
+            } else {
+                "if ($parentConditionText &&$commentsText$nestedConditionText) {}"
+            }
         val newParentIfNode = KotlinParser().createNode(mergeCondition)
         // Remove THEN block
         newParentIfNode.removeChild(newParentIfNode.lastChildNode)
@@ -170,7 +170,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val comments = takeCommentsBeforeNestedIf(parentNode)
         comments.forEach {
             if (it.treeNext.elementType == WHITE_SPACE &&
-                    it.treePrev.elementType == WHITE_SPACE) {
+                it.treePrev.elementType == WHITE_SPACE) {
                 parentNode.removeChild(it.treePrev)
             }
             parentNode.removeChild(it)
@@ -182,12 +182,12 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         repeat(2) {
             val firstElType = nestedContent.first().elementType
             if (firstElType == WHITE_SPACE ||
-                    firstElType == LBRACE) {
+                firstElType == LBRACE) {
                 nestedContent.removeFirst()
             }
             val lastElType = nestedContent.last().elementType
             if (lastElType == WHITE_SPACE ||
-                    lastElType == RBRACE) {
+                lastElType == RBRACE) {
                 nestedContent.removeLast()
             }
         }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ConsecutiveSpacesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ConsecutiveSpacesRule.kt
@@ -55,7 +55,7 @@ class ConsecutiveSpacesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun squeezeSpacesToOne(node: ASTNode, configuration: TooManySpacesRuleConfiguration) {
         val spaces = node.textLength
         if (spaces > configuration.numberOfSpaces && !node.isWhiteSpaceWithNewline() &&
-                !node.hasEolComment()) {
+            !node.hasEolComment()) {
             TOO_MANY_CONSECUTIVE_SPACES.warnAndFix(configRules, emitWarn, isFixMode,
                 "found: $spaces. need to be: ${configuration.numberOfSpaces}", node.startOffset, node) {
                 node.squeezeSpaces()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/DebugPrintRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/DebugPrintRule.kt
@@ -29,9 +29,9 @@ class DebugPrintRule(configRules: List<RulesConfig>) : DiktatRule(
             val referenceExpression = node.findChildByType(ElementType.REFERENCE_EXPRESSION)?.text
             val valueArgumentList = node.findChildByType(ElementType.VALUE_ARGUMENT_LIST)
             if (referenceExpression in setOf("print", "println") &&
-                    node.treePrev?.elementType != ElementType.DOT &&
-                    valueArgumentList?.getChildren(TokenSet.create(ElementType.VALUE_ARGUMENT))?.size?.let { it <= 1 } == true &&
-                    node.findChildByType(ElementType.LAMBDA_ARGUMENT) == null) {
+                node.treePrev?.elementType != ElementType.DOT &&
+                valueArgumentList?.getChildren(TokenSet.create(ElementType.VALUE_ARGUMENT))?.size?.let { it <= 1 } == true &&
+                node.findChildByType(ElementType.LAMBDA_ARGUMENT) == null) {
                 Warnings.DEBUG_PRINT.warn(
                     configRules, emitWarn, isFixMode,
                     "found $referenceExpression()", node.startOffset, node,
@@ -45,7 +45,7 @@ class DebugPrintRule(configRules: List<RulesConfig>) : DiktatRule(
         if (node.elementType == ElementType.DOT_QUALIFIED_EXPRESSION) {
             val isConsole = node.firstChildNode.let { referenceExpression ->
                 referenceExpression.elementType == ElementType.REFERENCE_EXPRESSION &&
-                        referenceExpression.firstChildNode.let { it.elementType == ElementType.IDENTIFIER && it.text == "console" }
+                    referenceExpression.firstChildNode.let { it.elementType == ElementType.IDENTIFIER && it.text == "console" }
             }
             if (isConsole) {
                 val logMethod = node.lastChildNode

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/EmptyBlock.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/EmptyBlock.kt
@@ -42,7 +42,7 @@ class EmptyBlock(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isNewLine(node: ASTNode) =
-            node.findChildByType(WHITE_SPACE)?.text?.contains("\n") ?: false
+        node.findChildByType(WHITE_SPACE)?.text?.contains("\n") ?: false
 
     @Suppress("UnsafeCallOnNullableType", "TOO_LONG_FUNCTION")
     private fun checkEmptyBlock(node: ASTNode, configuration: EmptyBlockStyleConfiguration) {
@@ -89,15 +89,15 @@ class EmptyBlock(configRules: List<RulesConfig>) : DiktatRule(
 
     @Suppress("UnsafeCallOnNullableType")
     private fun isAnonymousSamClass(node: ASTNode): Boolean =
-            if (node.elementType == FUNCTION_LITERAL && node.hasParent(CALL_EXPRESSION)) {
-                // We are checking identifier because it is not class in AST,
-                // SAM conversions are indistinguishable from lambdas.
-                // So we just verify that identifier is in PascalCase
-                val valueArgument = node.findParentNodeWithSpecificType(CALL_EXPRESSION)!!
-                valueArgument.findLeafWithSpecificType(IDENTIFIER)?.text?.isPascalCase() ?: false
-            } else {
-                false
-            }
+        if (node.elementType == FUNCTION_LITERAL && node.hasParent(CALL_EXPRESSION)) {
+            // We are checking identifier because it is not class in AST,
+            // SAM conversions are indistinguishable from lambdas.
+            // So we just verify that identifier is in PascalCase
+            val valueArgument = node.findParentNodeWithSpecificType(CALL_EXPRESSION)!!
+            valueArgument.findLeafWithSpecificType(IDENTIFIER)?.text?.isPascalCase() ?: false
+        } else {
+            false
+        }
 
     @Suppress("UnsafeCallOnNullableType")
     private fun isLambdaUsedAsFunction(node: ASTNode): Boolean {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/EnumsSeparated.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/EnumsSeparated.kt
@@ -67,7 +67,7 @@ class EnumsSeparated(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isEnumOneLine(nodes: List<ASTNode>) =
-            nodes.dropLast(1).none { it.treeNext.isWhiteSpaceWithNewline() }
+        nodes.dropLast(1).none { it.treeNext.isWhiteSpaceWithNewline() }
 
     private fun isEnumSimple(enumEntries: List<ASTNode>): Boolean {
         enumEntries.forEach { node ->

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
@@ -94,7 +94,7 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
             if (line.length > configuration.lineLength) {
                 val newNode = node.psi.findElementAt(offset + configuration.lineLength.toInt() - 1)!!.node
                 if ((newNode.elementType != KDOC_TEXT && newNode.elementType != KDOC_MARKDOWN_INLINE_LINK) ||
-                        !isKdocValid(newNode)
+                    !isKdocValid(newNode)
                 ) {
                     positionByOffset = node.treeParent.calculateLineColByOffset()
                     val fixableType = isFixable(newNode, configuration)
@@ -237,7 +237,7 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun checkFunAndProperty(wrongNode: ASTNode) =
-            if (wrongNode.hasChildOfType(EQ)) FunAndProperty(wrongNode) else None()
+        if (wrongNode.hasChildOfType(EQ)) FunAndProperty(wrongNode) else None()
 
     private fun checkComment(wrongNode: ASTNode, configuration: LineLengthConfiguration): LongLineFixableCases {
         val leftOffset = positionByOffset(wrongNode.startOffset).second
@@ -352,11 +352,11 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
         val firstPart = incorrectText.substring(0, wrongStringTemplate.delimiterIndex)
         val secondPart = incorrectText.substring(wrongStringTemplate.delimiterIndex, incorrectText.length)
         val textBetwenParts =
-                if (wrongStringTemplate.isOneLineString) {
-                    "\" +\n\""
-                } else {
-                    "\n"
-                }
+            if (wrongStringTemplate.isOneLineString) {
+                "\" +\n\""
+            } else {
+                "\n"
+            }
         val correctNode = KotlinParser().createNode("$firstPart$textBetwenParts$secondPart")
         wrongStringTemplate.node.treeParent.replaceChild(wrongStringTemplate.node, correctNode)
     }
@@ -394,11 +394,11 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
      */
     private fun searchBinaryExpression(node: ASTNode, binList: MutableList<ASTNode>) {
         if (node.hasChildOfType(BINARY_EXPRESSION) || node.hasChildOfType(PARENTHESIZED) ||
-                node.hasChildOfType(POSTFIX_EXPRESSION)) {
+            node.hasChildOfType(POSTFIX_EXPRESSION)) {
             node.getChildren(null)
                 .filter {
                     it.elementType == BINARY_EXPRESSION || it.elementType == PARENTHESIZED ||
-                            it.elementType == POSTFIX_EXPRESSION
+                        it.elementType == POSTFIX_EXPRESSION
                 }
                 .forEach {
                     searchBinaryExpression(it, binList)
@@ -434,7 +434,7 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
         val expression = rightBinList.firstOrNull { (it, offset) ->
             val binOperationReference = it.getFirstChildWithType(OPERATION_REFERENCE)!!.firstChildNode.elementType
             offset + (it.getFirstChildWithType(OPERATION_REFERENCE)?.text!!.length ?: 0) <= configuration.lineLength + 1 &&
-                    binOperationReference !in logicListOperationReference && binOperationReference !in compressionListOperationReference && binOperationReference != EXCL
+                binOperationReference !in logicListOperationReference && binOperationReference !in compressionListOperationReference && binOperationReference != EXCL
         }
         returnList.add(expression)
         return returnList
@@ -453,7 +453,7 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
         val expression = rightBinList.firstOrNull { (it, offset) ->
             val binOperationReference = it.getFirstChildWithType(OPERATION_REFERENCE)
             offset + (it.getFirstChildWithType(OPERATION_REFERENCE)?.text!!.length ?: 0) <= configuration.lineLength + 1 &&
-                    binOperationReference!!.firstChildNode.elementType in typesList
+                binOperationReference!!.firstChildNode.elementType in typesList
         }
         returnList.add(expression)
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
@@ -62,10 +62,10 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
         val isEnums = node.parent({ it.elementType == ENUM_ENTRY }) != null
         val isRanges = node.treeParent.run {
             this.elementType == BINARY_EXPRESSION &&
-                    this.findChildByType(OPERATION_REFERENCE)?.hasChildOfType(RANGE) ?: false
+                this.findChildByType(OPERATION_REFERENCE)?.hasChildOfType(RANGE) ?: false
         }
         val isExtensionFunctions = node.parent({ it.elementType == FUN && (it.psi as KtFunction).isExtensionDeclaration() }) != null &&
-                node.parents().find { it.elementType == PROPERTY } == null
+            node.parents().find { it.elementType == PROPERTY } == null
         val result = listOf(isHashFunction, isPropertyDeclaration, isLocalVariable, isValueParameter, isConstant,
             isCompanionObjectProperty, isEnums, isRanges, isExtensionFunctions).zip(mapConfiguration.map { configuration.getParameter(it.key) })
         if (result.any { it.first && it.first != it.second } && !isIgnoreNumber) {
@@ -74,9 +74,9 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun ASTNode.isHashFun() =
-            (this.psi as KtFunction).run {
-                this.nameIdentifier?.text == "hashCode" && this.annotationEntries.map { it.text }.contains("@Override")
-            }
+        (this.psi as KtFunction).run {
+            this.nameIdentifier?.text == "hashCode" && this.annotationEntries.map { it.text }.contains("@Override")
+        }
 
     /**
      * [RuleConfiguration] for configuration
@@ -109,7 +109,7 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
          * Check if string include a char of number type
          */
         private fun String.isOtherNumberType(): Boolean = ((this.last().uppercase() == "L" || this.last().uppercase() == "U") && this.substring(0, this.lastIndex).isNumber()) ||
-                (this.substring(this.lastIndex - 1).uppercase() == "UL" && this.substring(0, this.lastIndex - 1).isNumber())
+            (this.substring(this.lastIndex - 1).uppercase() == "UL" && this.substring(0, this.lastIndex - 1).isNumber())
     }
 
     companion object {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/NullableTypeRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/NullableTypeRule.kt
@@ -54,11 +54,11 @@ class NullableTypeRule(configRules: List<RulesConfig>) : DiktatRule(
             val typeReferenceNode = node.findChildByType(TYPE_REFERENCE)!!
             // check that property has nullable type, right value one of allow expression
             if (!node.hasChildOfType(NULL) &&
-                    node.findAllDescendantsWithSpecificType(DOT_QUALIFIED_EXPRESSION).isEmpty() &&
-                    typeReferenceNode.hasChildOfType(NULLABLE_TYPE) &&
-                    typeReferenceNode.findChildByType(NULLABLE_TYPE)!!.hasChildOfType(QUEST) &&
-                    (node.findChildByType(CALL_EXPRESSION)?.findChildByType(REFERENCE_EXPRESSION) == null ||
-                            node.findChildByType(CALL_EXPRESSION)!!.findChildByType(REFERENCE_EXPRESSION)!!.text in allowExpression)) {
+                node.findAllDescendantsWithSpecificType(DOT_QUALIFIED_EXPRESSION).isEmpty() &&
+                typeReferenceNode.hasChildOfType(NULLABLE_TYPE) &&
+                typeReferenceNode.findChildByType(NULLABLE_TYPE)!!.hasChildOfType(QUEST) &&
+                (node.findChildByType(CALL_EXPRESSION)?.findChildByType(REFERENCE_EXPRESSION) == null ||
+                    node.findChildByType(CALL_EXPRESSION)!!.findChildByType(REFERENCE_EXPRESSION)!!.text in allowExpression)) {
                 NULLABLE_PROPERTY_TYPE.warn(configRules, emitWarn, isFixMode, "don't use nullable type",
                     node.findChildByType(TYPE_REFERENCE)!!.startOffset, node)
             } else if (node.hasChildOfType(NULL)) {
@@ -93,21 +93,21 @@ class NullableTypeRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun findFixableForCollectionParam(referenceText: String): FixedParam? =
-            when (referenceText) {
-                "List", "Iterable" -> FixedParam(null, null, "emptyList()")
-                "Map" -> FixedParam(null, null, "emptyMap()")
-                "Array" -> FixedParam(null, null, "emptyArray()")
-                "Set" -> FixedParam(null, null, "emptySet()")
-                "Sequence" -> FixedParam(null, null, "emptySequence()")
-                "Queue" -> FixedParam(null, null, "LinkedList()")
-                "MutableList" -> FixedParam(null, null, "mutableListOf()")
-                "MutableMap" -> FixedParam(null, null, "mutableMapOf()")
-                "MutableSet" -> FixedParam(null, null, "mutableSetOf()")
-                "LinkedList" -> FixedParam(null, null, "LinkedList()")
-                "LinkedHashMap" -> FixedParam(null, null, "LinkedHashMap()")
-                "LinkedHashSet" -> FixedParam(null, null, "LinkedHashSet()")
-                else -> null
-            }
+        when (referenceText) {
+            "List", "Iterable" -> FixedParam(null, null, "emptyList()")
+            "Map" -> FixedParam(null, null, "emptyMap()")
+            "Array" -> FixedParam(null, null, "emptyArray()")
+            "Set" -> FixedParam(null, null, "emptySet()")
+            "Sequence" -> FixedParam(null, null, "emptySequence()")
+            "Queue" -> FixedParam(null, null, "LinkedList()")
+            "MutableList" -> FixedParam(null, null, "mutableListOf()")
+            "MutableMap" -> FixedParam(null, null, "mutableMapOf()")
+            "MutableSet" -> FixedParam(null, null, "mutableSetOf()")
+            "LinkedList" -> FixedParam(null, null, "LinkedList()")
+            "LinkedHashMap" -> FixedParam(null, null, "LinkedHashMap()")
+            "LinkedHashSet" -> FixedParam(null, null, "LinkedHashSet()")
+            else -> null
+        }
 
     @Suppress("UnsafeCallOnNullableType")
     private fun findSubstitution(node: ASTNode, fixedParam: FixedParam) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/SortRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/SortRule.kt
@@ -46,7 +46,7 @@ class SortRule(configRules: List<RulesConfig>) : DiktatRule(
             sortEnum(classBody)
         }
         if ((node.psi as? KtObjectDeclaration)?.isCompanion() == true && classBody != null &&
-                configuration.sortProperty) {
+            configuration.sortProperty) {
             sortProperty(classBody)
         }
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringConcatenationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringConcatenationRule.kt
@@ -47,7 +47,7 @@ class StringConcatenationRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isSingleLineStatement(node: ASTNode): Boolean =
-            !node.text.contains("\n")
+        !node.text.contains("\n")
 
     /**
      * This method works only with top-level binary expressions. It should be checked before the call.
@@ -94,7 +94,7 @@ class StringConcatenationRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isStringVar(firstChild: ASTNode, lastChild: ASTNode) = firstChild.elementType == STRING_TEMPLATE ||
-            ((firstChild.text.endsWith("toString()")) && firstChild.elementType == DOT_QUALIFIED_EXPRESSION && lastChild.elementType == STRING_TEMPLATE)
+        ((firstChild.text.endsWith("toString()")) && firstChild.elementType == DOT_QUALIFIED_EXPRESSION && lastChild.elementType == STRING_TEMPLATE)
 
     @Suppress("COMMENT_WHITE_SPACE")
     private fun isPlusBinaryExpression(node: ASTNode): Boolean {
@@ -117,7 +117,7 @@ class StringConcatenationRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isPlusBinaryExpressionAndFirstElementString(binaryExpressionNode: KtBinaryExpression) =
-            (binaryExpressionNode.left is KtStringTemplateExpression) && PLUS == binaryExpressionNode.operationToken
+        (binaryExpressionNode.left is KtStringTemplateExpression) && PLUS == binaryExpressionNode.operationToken
 
     @Suppress(
         "TOO_LONG_FUNCTION",
@@ -187,34 +187,34 @@ class StringConcatenationRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun KtBinaryExpression.isRvalueConstantExpression() =
-            this.right is KtConstantExpression
+        this.right is KtConstantExpression
 
     private fun KtBinaryExpression.isRvalueStringTemplateExpression() =
-            this.right is KtStringTemplateExpression
+        this.right is KtStringTemplateExpression
 
     private fun KtBinaryExpression.isRvalueCallExpression() =
-            this.right is KtCallExpression
+        this.right is KtCallExpression
 
     private fun KtBinaryExpression.isRvalueReferenceExpression() =
-            this.right is KtReferenceExpression
+        this.right is KtReferenceExpression
 
     private fun KtBinaryExpression.isRvalueParenthesized() =
-            this.right is KtParenthesizedExpression
+        this.right is KtParenthesizedExpression
 
     private fun KtBinaryExpression.isLvalueDotQualifiedExpression() =
-            this.left is KtDotQualifiedExpression
+        this.left is KtDotQualifiedExpression
 
     private fun KtBinaryExpression.isLvalueBinaryExpression() =
-            this.left is KtBinaryExpression
+        this.left is KtBinaryExpression
 
     private fun KtBinaryExpression.isLvalueReferenceExpression() =
-            this.left is KtReferenceExpression
+        this.left is KtReferenceExpression
 
     private fun KtBinaryExpression.isLvalueConstantExpression() =
-            this.left is KtConstantExpression
+        this.left is KtConstantExpression
 
     private fun KtBinaryExpression.isRvalueExpression() =
-            this.right is KtExpression
+        this.right is KtExpression
 
     companion object {
         const val NAME_ID = "abr-string-concatenation"

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
@@ -62,7 +62,7 @@ class TrailingCommaRule(configRules: List<RulesConfig>) : DiktatRule(
     private val configuration by lazy {
         if (trailingConfig.isEmpty()) {
             log.warn("You have enabled TRAILING_COMMA, but rule will remain inactive until you explicitly set" +
-                    " configuration options. See [available-rules.md] for possible configuration options.")
+                " configuration options. See [available-rules.md] for possible configuration options.")
         }
         TrailingCommaConfiguration(trailingConfig)
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/WhenMustHaveElseRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/WhenMustHaveElseRule.kt
@@ -120,7 +120,7 @@ class WhenMustHaveElseRule(configRules: List<RulesConfig>) : DiktatRule(
 
         // Checks if `when` is the last statement in lambda body
         if (node.treeParent.elementType == BLOCK && node.treeParent.treeParent.elementType == FUNCTION_LITERAL &&
-                node.treeParent.lastChildNode == node) {
+            node.treeParent.lastChildNode == node) {
             return false
         }
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/BlankLinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/BlankLinesRule.kt
@@ -41,7 +41,7 @@ class BlankLinesRule(configRules: List<RulesConfig>) : DiktatRule(
         if (node.treeParent.let {
             // kts files are parsed as a SCRIPT node containing BLOCK, therefore WHITE_SPACEs from these BLOCKS shouldn't be checked
             it.elementType == BLOCK && it.treeParent?.elementType != SCRIPT ||
-                    it.elementType == CLASS_BODY || it.elementType == FUNCTION_LITERAL
+                it.elementType == CLASS_BODY || it.elementType == FUNCTION_LITERAL
         }) {
             node.findParentNodeWithSpecificType(LAMBDA_ARGUMENT)?.let {
                 // Lambda body is always has a BLOCK -> run { } - (LBRACE, WHITE_SPACE, BLOCK "", RBRACE)
@@ -64,7 +64,7 @@ class BlankLinesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun handleTooManyBlankLines(node: ASTNode) {
         TOO_MANY_BLANK_LINES.warnAndFix(configRules, emitWarn, isFixMode, "do not use more than two consecutive blank lines", node.startOffset, node) {
             if (node.treeParent.elementType != FILE && (node.treeParent.getFirstChildWithType(WHITE_SPACE) == node ||
-                    node.treeParent.getAllChildrenWithType(WHITE_SPACE).last() == node)) {
+                node.treeParent.getAllChildrenWithType(WHITE_SPACE).last() == node)) {
                 node.leaveExactlyNumNewLines(1)
             } else {
                 node.leaveExactlyNumNewLines(2)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
@@ -140,12 +140,12 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
             ?: node.children().firstOrNull {
                 // taking nodes with actual code
                 !it.isWhiteSpace() && !it.isPartOfComment() &&
-                        // but not the ones we are going to move
-                        it.elementType != FILE_ANNOTATION_LIST &&
-                        // if we are here, then IMPORT_LIST either is not present in the AST, or is empty. Either way, we don't need to select it.
-                        it.elementType != IMPORT_LIST &&
-                        // if we are here, then package is default and we don't need to select the empty PACKAGE_DIRECTIVE node.
-                        it.elementType != PACKAGE_DIRECTIVE
+                    // but not the ones we are going to move
+                    it.elementType != FILE_ANNOTATION_LIST &&
+                    // if we are here, then IMPORT_LIST either is not present in the AST, or is empty. Either way, we don't need to select it.
+                    it.elementType != IMPORT_LIST &&
+                    // if we are here, then package is default and we don't need to select the empty PACKAGE_DIRECTIVE node.
+                    it.elementType != PACKAGE_DIRECTIVE
             }
             ?: return  // at this point it means the file contains only comments
         // We consider the first block comment of the file to be the one that possibly contains copyright information.
@@ -166,7 +166,7 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
         val otherNodesBeforeCode = firstCodeNode.siblings(forward = false)
             .filterNot {
                 it.isWhiteSpace() ||
-                        it == copyrightComment || it == headerKdoc || it == fileAnnotations
+                    it == copyrightComment || it == headerKdoc || it == fileAnnotations
             }
             .toList()
             .reversed()
@@ -234,8 +234,8 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
                 val importName = ktImportDirective.importPath?.importedName?.asString()
                 val importPath = ktImportDirective.importPath?.pathStr!!  // importPath - ifNOtParsed & Nullable
                 if (ktImportDirective.aliasName == null &&
-                        packageName.isNotEmpty() && importPath.startsWith("$packageName.") &&
-                        importPath.substring(packageName.length + 1).indexOf('.') == -1
+                    packageName.isNotEmpty() && importPath.startsWith("$packageName.") &&
+                    importPath.substring(packageName.length + 1).indexOf('.') == -1
                 ) {
                     // this branch corresponds to imports from the same package
                     deleteImport(importPath, node, ktImportDirective)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
@@ -218,13 +218,13 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
     ) {
         val nextNode = whiteSpace.node.treeNext
         if (nextNode != null &&
-                nextNode.elementType == DOT_QUALIFIED_EXPRESSION &&
-                nextNode.firstChildNode.elementType == STRING_TEMPLATE &&
-                nextNode.firstChildNode.text.startsWith("\"\"\"") &&
-                nextNode.findChildByType(CALL_EXPRESSION)?.text?.let {
-                    it == "trimIndent()" ||
-                            it == "trimMargin()"
-                } == true) {
+            nextNode.elementType == DOT_QUALIFIED_EXPRESSION &&
+            nextNode.firstChildNode.elementType == STRING_TEMPLATE &&
+            nextNode.firstChildNode.text.startsWith("\"\"\"") &&
+            nextNode.findChildByType(CALL_EXPRESSION)?.text?.let {
+                it == "trimIndent()" ||
+                    it == "trimMargin()"
+            } == true) {
             fixStringLiteral(whiteSpace, expectedIndent, actualIndent)
         }
     }
@@ -380,7 +380,7 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
              * @return boolean result
              */
             fun isActive(currentNode: ASTNode): Boolean = currentNode.psi.parentsWithSelf.any { it.node == initiator } &&
-                    (includeLastChild || currentNode.treeNext != initiator.lastChildNode)
+                (includeLastChild || currentNode.treeNext != initiator.lastChildNode)
         }
     }
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -186,7 +186,7 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
                 val isSingleLineIfElse = parent({ it.elementType == IF }, true)?.isSingleLineIfElse() ?: false
                 // to follow functional style these operators should be started by newline
                 (isFollowedByNewline() || !isBeginByNewline()) && !isSingleLineIfElse &&
-                        (!isFirstCall() || !isMultilineLambda(treeParent))
+                    (!isFirstCall() || !isMultilineLambda(treeParent))
             } else {
                 if (isInvalidCallsChain(dropLeadingProperties = false) && node.isInParentheses()) {
                     checkForComplexExpression(node)
@@ -400,9 +400,9 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
         if (numEntries > configuration.maxParametersInOneLine) {
             when (node.elementType) {
                 VALUE_PARAMETER_LIST -> handleFirstValue(node, VALUE_PARAMETER, "first parameter should be placed on a separate line " +
-                        "or all other parameters should be aligned with it in declaration of <${node.getParentIdentifier()}>")
+                    "or all other parameters should be aligned with it in declaration of <${node.getParentIdentifier()}>")
                 VALUE_ARGUMENT_LIST -> handleFirstValue(node, VALUE_ARGUMENT, "first value argument (%s) should be placed on the new line " +
-                        "or all other parameters should be aligned with it")
+                    "or all other parameters should be aligned with it")
                 else -> {
                 }
             }
@@ -443,8 +443,8 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
         .children()
         .filter {
             (it.elementType == COMMA && !it.treeNext.isNewLineNode()) ||
-                    // Move RPAR to the new line
-                    (it.elementType == RPAR && it.treePrev.elementType != COMMA && !it.treePrev.isNewLineNode())
+                // Move RPAR to the new line
+                (it.elementType == RPAR && it.treePrev.elementType != COMMA && !it.treePrev.isNewLineNode())
         }
         .toList()
         .takeIf { it.isNotEmpty() }
@@ -483,10 +483,10 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
         // if statements here have the only right order - don't change it
 
         if (psi.children.isNotEmpty() && !psi.isFirstChildElementType(DOT_QUALIFIED_EXPRESSION) &&
-                !psi.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
+            !psi.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
             val firstChild = psi.firstChild
             if (firstChild.isFirstChildElementType(DOT_QUALIFIED_EXPRESSION) ||
-                    firstChild.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
+                firstChild.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
                 getOrderedCallExpressions(firstChild.firstChild, result)
             }
             result.add(firstChild.node
@@ -536,10 +536,10 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
 
     // fixme: there could be other cases when dot means something else
     private fun ASTNode.isDotFromPackageOrImport() = elementType == DOT &&
-            parent({ it.elementType == IMPORT_DIRECTIVE || it.elementType == PACKAGE_DIRECTIVE }, true) != null
+        parent({ it.elementType == IMPORT_DIRECTIVE || it.elementType == PACKAGE_DIRECTIVE }, true) != null
 
     private fun PsiElement.isFirstChildElementType(elementType: IElementType) =
-            this.firstChild.node.elementType == elementType
+        this.firstChild.node.elementType == elementType
 
     /**
      * This method collects chain calls and checks it
@@ -591,13 +591,13 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
      *  taking all expressions inside complex expression until we reach lambda arguments
      */
     private fun ASTNode.getParentExpressions() =
-            parents().takeWhile { it.elementType in chainExpressionTypes && it.elementType != LAMBDA_ARGUMENT }
+        parents().takeWhile { it.elementType in chainExpressionTypes && it.elementType != LAMBDA_ARGUMENT }
 
     private fun isMultilineLambda(node: ASTNode): Boolean =
-            (node.findAllDescendantsWithSpecificType(LAMBDA_ARGUMENT)
-                .firstOrNull()
-                ?.text
-                ?.count { it == '\n' } ?: -1) > 0
+        (node.findAllDescendantsWithSpecificType(LAMBDA_ARGUMENT)
+            .firstOrNull()
+            ?.text
+            ?.count { it == '\n' } ?: -1) > 0
 
     /**
      * Getting the first call expression in call chain
@@ -615,8 +615,8 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
      * This method should be called on OPERATION_REFERENCE in the middle of BINARY_EXPRESSION
      */
     private fun ASTNode.isInfixCall() = elementType == OPERATION_REFERENCE &&
-            firstChildNode.elementType == IDENTIFIER &&
-            treeParent.elementType == BINARY_EXPRESSION
+        firstChildNode.elementType == IDENTIFIER &&
+        treeParent.elementType == BINARY_EXPRESSION
 
     /**
      * This method checks that complex expression should be replace with new variable

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/WhiteSpaceRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/WhiteSpaceRule.kt
@@ -128,17 +128,17 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun handleLbracket(node: ASTNode) =
-            if (node.treeParent.elementType == COLLECTION_LITERAL_EXPRESSION) {
-                handleToken(node, 1, 0)
-            } else {
-                handleToken(node, 0, 0)
-            }
+        if (node.treeParent.elementType == COLLECTION_LITERAL_EXPRESSION) {
+            handleToken(node, 1, 0)
+        } else {
+            handleToken(node, 0, 0)
+        }
 
     private fun handleConstructor(node: ASTNode) {
         if (node.treeNext.numWhiteSpaces()?.let { it > 0 } == true) {
             // there is either whitespace or newline after constructor keyword
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "keyword '${node.text}' should not be separated from " +
-                    "'(' with a whitespace", node.startOffset, node) {
+                "'(' with a whitespace", node.startOffset, node) {
                 node.treeParent.removeChild(node.treeNext)
             }
         }
@@ -154,7 +154,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
                 return
             }
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "keyword '${node.text}' should be separated from " +
-                    "'${nextCodeLeaf.text}' with a whitespace", nextCodeLeaf.startOffset, nextCodeLeaf) {
+                "'${nextCodeLeaf.text}' with a whitespace", nextCodeLeaf.startOffset, nextCodeLeaf) {
                 node.leaveSingleWhiteSpace()
             }
         }
@@ -162,9 +162,9 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun handleRbrace(node: ASTNode) {
         if (node.treeParent.elementType == FUNCTION_LITERAL &&
-                !node.treePrev.isWhiteSpace() &&
-                node.treePrev.elementType == BLOCK &&
-                node.treePrev.text.isNotEmpty()) {
+            !node.treePrev.isWhiteSpace() &&
+            node.treePrev.elementType == BLOCK &&
+            node.treePrev.text.isNotEmpty()) {
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "there should be a whitespace before }", node.startOffset, node) {
                 node.treeParent.addChild(PsiWhiteSpaceImpl(" "), node)
             }
@@ -185,10 +185,10 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
             .takeIf { it.size == NUM_PARENTS_FOR_LAMBDA }
             ?.let {
                 it[0].elementType == FUNCTION_LITERAL &&
-                        it[1].elementType == LAMBDA_EXPRESSION &&
-                        it[2].elementType == VALUE_ARGUMENT &&
-                        // lambda is not passed as a named argument
-                        !it[2].hasChildOfType(EQ)
+                    it[1].elementType == LAMBDA_EXPRESSION &&
+                    it[2].elementType == VALUE_ARGUMENT &&
+                    // lambda is not passed as a named argument
+                    !it[2].hasChildOfType(EQ)
             }
             ?: false
 
@@ -213,7 +213,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
             // If it is lambda, then we don't force it to be on newline or same line
             if (numWhiteSpace != 0 && isFirstArgument) {
                 WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "there should be no whitespace before '{' of lambda" +
-                        " inside argument list", node.startOffset, node) {
+                    " inside argument list", node.startOffset, node) {
                     whitespaceOrPrevNode.treeParent.removeChild(whitespaceOrPrevNode)
                 }
             }
@@ -226,7 +226,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun handleWhiteSpaceAfterLeftBrace(node: ASTNode) {
         if (node.treeParent.elementType == FUNCTION_LITERAL && !node.treeNext.isWhiteSpace() &&
-                node.treeNext.elementType == BLOCK && node.treeNext.text.isNotEmpty()) {
+            node.treeNext.elementType == BLOCK && node.treeNext.text.isNotEmpty()) {
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "there should be a whitespace after {", node.startOffset, node) {
                 node.treeParent.addChild(PsiWhiteSpaceImpl(" "), node.treeNext)
             }
@@ -272,7 +272,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
             return
         }
         if (node.elementType == OPERATION_REFERENCE && node.treeParent.elementType.let { it == BINARY_EXPRESSION || it == POSTFIX_EXPRESSION || it == PROPERTY } ||
-                node.elementType != OPERATION_REFERENCE) {
+            node.elementType != OPERATION_REFERENCE) {
             val requiredNumSpaces = if (operatorNode.elementType in operatorsWithNoWhitespace) 0 else 1
 
             handleToken(node, requiredNumSpaces, requiredNumSpaces)
@@ -301,9 +301,9 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
         val isErrorAfter = requiredSpacesAfter != null && spacesAfter != null && spacesAfter != requiredSpacesAfter
         if (isErrorBefore || isErrorAfter) {
             val freeText = "${node.text} should have" +
-                    getDescription(requiredSpacesBefore != null, requiredSpacesAfter != null, requiredSpacesBefore, requiredSpacesAfter) +
-                    ", but has" +
-                    getDescription(isErrorBefore, isErrorAfter, spacesBefore, spacesAfter)
+                getDescription(requiredSpacesBefore != null, requiredSpacesAfter != null, requiredSpacesBefore, requiredSpacesAfter) +
+                ", but has" +
+                getDescription(isErrorBefore, isErrorAfter, spacesBefore, spacesAfter)
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, freeText, node.startOffset, node) {
                 node.fixSpaceAround(requiredSpacesBefore, requiredSpacesAfter)
             }
@@ -412,15 +412,15 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
                                before: Int?,
                                after: Int?
     ): String =
-            if (shouldBefore && shouldAfter) {
-                " $before space(s) before and $after space(s) after"
-            } else if (shouldBefore && !shouldAfter) {
-                " $before space(s) before"
-            } else if (shouldAfter) {
-                " $after space(s) after"
-            } else {
-                ""
-            }
+        if (shouldBefore && shouldAfter) {
+            " $before space(s) before and $after space(s) after"
+        } else if (shouldBefore && !shouldAfter) {
+            " $before space(s) before"
+        } else if (shouldAfter) {
+            " $after space(s) after"
+        } else {
+            ""
+        }
 
     companion object {
         private val log = LoggerFactory.getLogger(CompactInitialization::class.java)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/identifiers/LocalVariablesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/identifiers/LocalVariablesRule.kt
@@ -64,9 +64,9 @@ class LocalVariablesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun collectLocalPropertiesWithUsages(node: ASTNode) = node
         .findAllVariablesWithUsages { propertyNode ->
             propertyNode.isLocal && propertyNode.name != null && propertyNode.parent is KtBlockExpression &&
-                    (propertyNode.isVar && propertyNode.initializer == null ||
-                            (propertyNode.initializer?.containsOnlyConstants() ?: false) ||
-                            (propertyNode.initializer as? KtCallExpression).isWhitelistedMethod())
+                (propertyNode.isVar && propertyNode.initializer == null ||
+                    (propertyNode.initializer?.containsOnlyConstants() ?: false) ||
+                    (propertyNode.initializer as? KtCallExpression).isWhitelistedMethod())
         }
 
         .filterNot { it.value.isEmpty() }
@@ -105,16 +105,16 @@ class LocalVariablesRule(configRules: List<RulesConfig>) : DiktatRule(
     @Suppress("TOO_LONG_FUNCTION")
     private fun handleConsecutiveDeclarations(statement: PsiElement, properties: List<KtProperty>) {
         val numLinesAfterLastProp =
-                properties
-                    .last()
-                    .node
-                    .treeNext
-                    .takeIf { it.elementType == WHITE_SPACE }
-                    ?.let {
-                        // minus one is needed to except \n after property
-                        it.numNewLines() - 1
-                    }
-                    ?: 0
+            properties
+                .last()
+                .node
+                .treeNext
+                .takeIf { it.elementType == WHITE_SPACE }
+                ?.let {
+                    // minus one is needed to except \n after property
+                    it.numNewLines() - 1
+                }
+                ?: 0
 
         val sortedProperties = properties.sortedBy { it.node.getLineNumber() }
         // need to check that properties are declared consecutively with only maybe empty lines
@@ -204,12 +204,12 @@ class LocalVariablesRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun KtCallExpression?.isWhitelistedMethod() =
-            this?.run {
-                // `referenceExpression()` can return something different than just a name, e.g. when function returns a function:
-                // `foo()()` `referenceExpression()` will be a `KtCallExpression` as well
-                (referenceExpression() as? KtNameReferenceExpression)?.getReferencedName() in functionInitializers &&
-                        valueArguments.isEmpty()
-            } ?: false
+        this?.run {
+            // `referenceExpression()` can return something different than just a name, e.g. when function returns a function:
+            // `foo()()` `referenceExpression()` will be a `KtCallExpression` as well
+            (referenceExpression() as? KtNameReferenceExpression)?.getReferencedName() in functionInitializers &&
+                valueArguments.isEmpty()
+        } ?: false
 
     private fun warnMessage(
         name: String,

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/ImmutableValNoVarRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/ImmutableValNoVarRule.kt
@@ -43,7 +43,7 @@ class ImmutableValNoVarRule(configRules: List<RulesConfig>) : DiktatRule(
             usages.forEach { (property, usages) ->
                 val usedInAccumulators = usages.any {
                     it.getParentOfType<KtLoopExpression>(true) != null ||
-                            it.getParentOfType<KtLambdaExpression>(true) != null
+                        it.getParentOfType<KtLambdaExpression>(true) != null
                 }
 
                 if (!usedInAccumulators) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
@@ -110,7 +110,7 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
             ?.let { it.findChildByType(BLOCK) ?: it }
             ?.let { astNode ->
                 astNode.hasChildOfType(BREAK) &&
-                        (astNode.psi as? KtBlockExpression)?.statements?.size != 1
+                    (astNode.psi as? KtBlockExpression)?.statements?.size != 1
             } ?: false
         return (!isBlockInIfWithBreak && !isOneLineBlockInIfWithBreak)
     }
@@ -167,8 +167,8 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
     ): String = when {
         // if (a != null) {  } -> a ?: editedElse
         (thenCodeLines.isNullOrEmpty() && elseEditedCodeLines.isNotEmpty()) ||
-                // if (a != null) { a } else { ... } -> a ?: editedElse
-                (thenCodeLines?.singleOrNull() == variableName && elseEditedCodeLines.isNotEmpty()) -> variableName
+            // if (a != null) { a } else { ... } -> a ?: editedElse
+            (thenCodeLines?.singleOrNull() == variableName && elseEditedCodeLines.isNotEmpty()) -> variableName
         // if (a != null) { a.foo() } -> a?.foo()
         thenCodeLines?.singleOrNull()?.startsWith("$variableName.") ?: false -> "$variableName?${thenCodeLines?.firstOrNull()!!.removePrefix(variableName)}"
         // if (a != null) { break } -> a?.let { ... }
@@ -177,7 +177,7 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun getDefaultCaseThenCodeLines(variableName: String, thenCodeLines: List<String>?): String =
-            "$variableName?.let {${thenCodeLines?.joinToString(prefix = "\n", postfix = "\n", separator = "\n")}}"
+        "$variableName?.let {${thenCodeLines?.joinToString(prefix = "\n", postfix = "\n", separator = "\n")}}"
 
     private fun getDefaultCaseElseCodeLines(elseCodeLines: List<String>): String = "?: run {${elseCodeLines.joinToString(prefix = "\n", postfix = "\n", separator = "\n")}}"
 
@@ -222,25 +222,25 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
         ?: false
 
     private fun ASTNode.extractLinesFromBlock(type: IElementType): List<String>? =
-            treeParent
-                .getFirstChildWithType(type)
-                ?.text
-                ?.trim('{', '}')
-                ?.split("\n")
-                ?.filter { it.isNotBlank() }
-                ?.map { it.trim() }
-                ?.toList()
+        treeParent
+            .getFirstChildWithType(type)
+            ?.text
+            ?.trim('{', '}')
+            ?.split("\n")
+            ?.filter { it.isNotBlank() }
+            ?.map { it.trim() }
+            ?.toList()
 
     @Suppress("UnsafeCallOnNullableType")
     private fun isNullCheckBinaryExpression(condition: KtBinaryExpression): Boolean =
-            // check that binary expression has `null` as right or left operand
-            setOf(condition.right, condition.left).map { it!!.node.elementType }.contains(NULL) &&
-                    // checks that it is the comparison condition
-                    setOf(ElementType.EQEQ, ElementType.EQEQEQ, ElementType.EXCLEQ, ElementType.EXCLEQEQEQ)
-                        .contains(condition.operationToken) &&
-                    // no need to raise warning or fix null checks in complex expressions
-                    !condition.isComplexCondition() &&
-                    !condition.isInLambda()
+        // check that binary expression has `null` as right or left operand
+        setOf(condition.right, condition.left).map { it!!.node.elementType }.contains(NULL) &&
+            // checks that it is the comparison condition
+            setOf(ElementType.EQEQ, ElementType.EQEQEQ, ElementType.EXCLEQ, ElementType.EXCLEQEQEQ)
+                .contains(condition.operationToken) &&
+            // no need to raise warning or fix null checks in complex expressions
+            !condition.isComplexCondition() &&
+            !condition.isInLambda()
 
     /**
      * checks if condition is a complex expression. For example:
@@ -280,7 +280,7 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isRequireFun(referenceExpression: ASTNode) =
-            referenceExpression.elementType == REFERENCE_EXPRESSION && referenceExpression.firstChildNode.text == "require"
+        referenceExpression.elementType == REFERENCE_EXPRESSION && referenceExpression.firstChildNode.text == "require"
 
     companion object {
         const val NAME_ID = "ach-null-checks"

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
@@ -195,7 +195,7 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
         val exprToChange = asExpr.filter {
             blocks.any { isExpr ->
                 isExpr.identifier == it.identifier &&
-                        isExpr.type == it.type
+                    isExpr.type == it.type
             }
         }
 
@@ -223,9 +223,9 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
                 .mapNotNull { it as? KtProperty }
                 .find {
                     it.isLocal &&
-                            it.hasInitializer() &&
-                            it.name?.equals(getReferencedName())
-                                ?: false
+                        it.hasInitializer() &&
+                        it.name?.equals(getReferencedName())
+                            ?: false
                 }
         }
 
@@ -241,11 +241,11 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
      */
     @Suppress("TYPE_ALIAS")
     private fun collectReferenceList(propertiesToUsages: Map<KtProperty, List<KtNameReferenceExpression>>): Map<KtProperty, List<KtNameReferenceExpression>> =
-            propertiesToUsages.mapValues { (_, value) ->
-                value.filter { entry ->
-                    entry.parent.node.elementType == IS_EXPRESSION || entry.parent.node.elementType == BINARY_WITH_TYPE
-                }
+        propertiesToUsages.mapValues { (_, value) ->
+            value.filter { entry ->
+                entry.parent.node.elementType == IS_EXPRESSION || entry.parent.node.elementType == BINARY_WITH_TYPE
             }
+        }
 
     /**
      * @property identifier a reference that is cast

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/VariableGenericTypeDeclarationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/VariableGenericTypeDeclarationRule.kt
@@ -61,8 +61,8 @@ class VariableGenericTypeDeclarationRule(configRules: List<RulesConfig>) : Dikta
         }
 
         if (rightSide != null && leftSide != null &&
-                rightSide.size == leftSide.size &&
-                rightSide.zip(leftSide).all { (first, second) -> first.text == second.text }) {
+            rightSide.size == leftSide.size &&
+            rightSide.zip(leftSide).all { (first, second) -> first.text == second.text }) {
             GENERIC_VARIABLE_WRONG_DECLARATION.warnAndFix(configRules, emitWarn, isFixMode,
                 "type arguments are unnecessary in ${callExpr.text}", node.startOffset, node) {
                 callExpr.removeChild(callExpr.findChildByType(TYPE_ARGUMENT_LIST)!!)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/calculations/AccurateCalculationsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/calculations/AccurateCalculationsRule.kt
@@ -44,36 +44,36 @@ class AccurateCalculationsRule(configRules: List<RulesConfig>) : DiktatRule(
         }
         ?: false
     private fun KtDotQualifiedExpression.isComparisonWithAbs() =
-            takeIf {
-                it.selectorExpression.run {
-                    this is KtCallExpression && getFunctionName() in comparisonFunctions
-                }
+        takeIf {
+            it.selectorExpression.run {
+                this is KtCallExpression && getFunctionName() in comparisonFunctions
             }
-                ?.run {
-                    (selectorExpression as KtCallExpression)
-                        .valueArguments
-                        .singleOrNull()
-                        ?.let { it.getArgumentExpression() as? KtCallExpression }
-                        ?.isAbsOfFloat()
-                        ?: false ||
-                            (receiverExpression as? KtCallExpression).isAbsOfFloat()
-                }
-                ?: false
+        }
+            ?.run {
+                (selectorExpression as KtCallExpression)
+                    .valueArguments
+                    .singleOrNull()
+                    ?.let { it.getArgumentExpression() as? KtCallExpression }
+                    ?.isAbsOfFloat()
+                    ?: false ||
+                    (receiverExpression as? KtCallExpression).isAbsOfFloat()
+            }
+            ?: false
 
     private fun KtBinaryExpression.isComparisonWithAbs() =
-            takeIf { it.operationToken in comparisonOperators }
-                ?.run { left as? KtCallExpression ?: right as? KtCallExpression }
-                ?.run { calleeExpression as? KtNameReferenceExpression }
-                ?.getReferencedName()
-                ?.equals("abs")
-                ?: false
+        takeIf { it.operationToken in comparisonOperators }
+            ?.run { left as? KtCallExpression ?: right as? KtCallExpression }
+            ?.run { calleeExpression as? KtNameReferenceExpression }
+            ?.getReferencedName()
+            ?.equals("abs")
+            ?: false
 
     private fun isComparisonWithAbs(psiElement: PsiElement) =
-            when (psiElement) {
-                is KtBinaryExpression -> psiElement.isComparisonWithAbs()
-                is KtDotQualifiedExpression -> psiElement.isComparisonWithAbs()
-                else -> false
-            }
+        when (psiElement) {
+            is KtBinaryExpression -> psiElement.isComparisonWithAbs()
+            is KtDotQualifiedExpression -> psiElement.isComparisonWithAbs()
+            else -> false
+        }
 
     private fun checkFloatValue(floatValue: PsiElement?, expression: KtExpression) {
         floatValue?.let {
@@ -136,14 +136,14 @@ class AccurateCalculationsRule(configRules: List<RulesConfig>) : DiktatRule(
 
 @Suppress("UnsafeCallOnNullableType")
 private fun PsiElement.isFloatingPoint(): Boolean =
-        node.elementType == ElementType.FLOAT_LITERAL ||
-                node.elementType == ElementType.FLOAT_CONSTANT ||
-                ((this as? KtNameReferenceExpression)
-                    ?.findLocalDeclaration()
-                    ?.initializer
-                    ?.node
-                    ?.run { elementType == ElementType.FLOAT_LITERAL || elementType == ElementType.FLOAT_CONSTANT }
-                    ?: false) ||
-                ((this as? KtBinaryExpression)
-                    ?.run { left!!.isFloatingPoint() && right!!.isFloatingPoint() }
-                    ?: false)
+    node.elementType == ElementType.FLOAT_LITERAL ||
+        node.elementType == ElementType.FLOAT_CONSTANT ||
+        ((this as? KtNameReferenceExpression)
+            ?.findLocalDeclaration()
+            ?.initializer
+            ?.node
+            ?.run { elementType == ElementType.FLOAT_LITERAL || elementType == ElementType.FLOAT_CONSTANT }
+            ?: false) ||
+        ((this as? KtBinaryExpression)
+            ?.run { left!!.isFloatingPoint() && right!!.isFloatingPoint() }
+            ?: false)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/AvoidNestedFunctionsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/AvoidNestedFunctionsRule.kt
@@ -66,14 +66,14 @@ class AvoidNestedFunctionsRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isNestedFunction(node: ASTNode): Boolean =
-            node.hasParent(FUN) && node.hasFunParentUntil(CLASS_BODY) && !node.hasChildOfType(MODIFIER_LIST) &&
-                    !node.isAnonymousFunction()
+        node.hasParent(FUN) && node.hasFunParentUntil(CLASS_BODY) && !node.hasChildOfType(MODIFIER_LIST) &&
+            !node.isAnonymousFunction()
 
     private fun ASTNode.hasFunParentUntil(stopNode: IElementType): Boolean =
-            parents()
-                .asSequence()
-                .takeWhile { it.elementType != stopNode }
-                .any { it.elementType == FUN }
+        parents()
+            .asSequence()
+            .takeWhile { it.elementType != stopNode }
+            .any { it.elementType == FUN }
 
     /**
      * Checks if local function has no usage of outside properties
@@ -98,7 +98,7 @@ class AvoidNestedFunctionsRule(configRules: List<RulesConfig>) : DiktatRule(
      */
     @Suppress("UnsafeCallOnNullableType")
     private fun getParameterNames(node: ASTNode): List<String> =
-            (node.psi as KtFunction).valueParameters.map { it.name!! }
+        (node.psi as KtFunction).valueParameters.map { it.name!! }
 
     companion object {
         const val NAME_ID = "acj-avoid-nested-functions"

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/CustomLabel.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/CustomLabel.kt
@@ -30,7 +30,7 @@ class CustomLabel(configRules: List<RulesConfig>) : DiktatRule(
         if (node.elementType == LABEL_QUALIFIER && node.text !in labels && node.treeParent.elementType in stopWords) {
             val nestedCount = node.parents().count {
                 it.elementType in loopType ||
-                        (it.elementType == CALL_EXPRESSION && it.findChildByType(REFERENCE_EXPRESSION)?.text in forEachReference)
+                    (it.elementType == CALL_EXPRESSION && it.findChildByType(REFERENCE_EXPRESSION)?.text in forEachReference)
             }
             if (nestedCount == 1) {
                 CUSTOM_LABEL.warn(configRules, emitWarn, isFixMode, node.text, node.startOffset, node)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/AvoidUtilityClass.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/AvoidUtilityClass.kt
@@ -45,7 +45,7 @@ class AvoidUtilityClass(configRules: List<RulesConfig>) : DiktatRule(
     private fun checkClass(node: ASTNode) {
         // checks that class/object doesn't contain primary constructor and its identifier doesn't has "utli"
         if (!node.hasChildOfType(IDENTIFIER) || node.hasChildOfType(PRIMARY_CONSTRUCTOR) ||
-                !node.findChildByType(IDENTIFIER)!!.text.lowercase(Locale.getDefault()).contains("util")) {
+            !node.findChildByType(IDENTIFIER)!!.text.lowercase(Locale.getDefault()).contains("util")) {
             return
         }
         node.findChildByType(CLASS_BODY)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/ExtensionFunctionsInFileRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/ExtensionFunctionsInFileRule.kt
@@ -47,11 +47,11 @@ class ExtensionFunctionsInFileRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun collectAllExtensionFunctionsWithSameClassName(node: ASTNode, classNames: List<String>): List<ASTNode> =
-            node.getAllChildrenWithType(FUN).filter { isExtensionFunctionWithClassName(it, classNames) }
+        node.getAllChildrenWithType(FUN).filter { isExtensionFunctionWithClassName(it, classNames) }
 
     @Suppress("UnsafeCallOnNullableType")
     private fun isExtensionFunctionWithClassName(node: ASTNode, classNames: List<String>): Boolean =
-            node.getFirstChildWithType(IDENTIFIER)!!.prevSibling { it.elementType == TYPE_REFERENCE }?.text in classNames
+        node.getFirstChildWithType(IDENTIFIER)!!.prevSibling { it.elementType == TYPE_REFERENCE }?.text in classNames
 
     companion object {
         const val NAME_ID = "aax-extension-functions-class-file"

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/PropertyAccessorFields.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/PropertyAccessorFields.kt
@@ -42,8 +42,8 @@ class PropertyAccessorFields(configRules: List<RulesConfig>) : DiktatRule(
             .mapNotNull { it.findChildByType(IDENTIFIER) }
             .firstOrNull {
                 it.text == leftValue.text &&
-                        (it.treeParent.treeParent.elementType != DOT_QUALIFIED_EXPRESSION ||
-                                it.treeParent.treeParent.firstChildNode.elementType == THIS_EXPRESSION)
+                    (it.treeParent.treeParent.elementType != DOT_QUALIFIED_EXPRESSION ||
+                        it.treeParent.treeParent.firstChildNode.elementType == THIS_EXPRESSION)
             }
         val isContainLocalVarSameName = node
             .findChildByType(BLOCK)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/TrivialPropertyAccessors.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/TrivialPropertyAccessors.kt
@@ -59,9 +59,9 @@ class TrivialPropertyAccessors(configRules: List<RulesConfig>) : DiktatRule(
             val blockChildren = block.getChildren(null).filter { it.elementType !in excessChildrenTypes }
 
             if (blockChildren.size == 1 &&
-                    blockChildren.first().elementType == BINARY_EXPRESSION &&
-                    (blockChildren.first().psi as KtBinaryExpression).left?.text == "field" &&
-                    (blockChildren.first().psi as KtBinaryExpression).right?.text == valueParamName
+                blockChildren.first().elementType == BINARY_EXPRESSION &&
+                (blockChildren.first().psi as KtBinaryExpression).left?.text == "field" &&
+                (blockChildren.first().psi as KtBinaryExpression).right?.text == valueParamName
             ) {
                 raiseWarning(node)
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UseLastIndex.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UseLastIndex.kt
@@ -32,7 +32,7 @@ class UseLastIndex(configRules: List<RulesConfig>) : DiktatRule(
             val operation = node.getFirstChildWithType(OPERATION_REFERENCE)
             val number = node.getFirstChildWithType(INTEGER_CONSTANT)
             it.elementType == DOT_QUALIFIED_EXPRESSION && it.lastChildNode.text == "length" && it.lastChildNode.elementType == REFERENCE_EXPRESSION &&
-                    operation?.text == "-" && number?.text == "1"
+                operation?.text == "-" && number?.text == "1"
         }
         if (listWithRightLength.toList().isNotEmpty()) {
             Warnings.USE_LAST_INDEX.warnAndFix(configRules, emitWarn, isFixMode, node.text, node.startOffset, node) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UselessSupertype.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UselessSupertype.kt
@@ -121,7 +121,7 @@ class UselessSupertype(configRules: List<RulesConfig>) : DiktatRule(
         }
         val superNodes = fileNode.findAllNodesWithCondition { superClass ->
             superClass.elementType == CLASS &&
-                    superClass.getIdentifierName()!!.text in superNodesIdentifier
+                superClass.getIdentifierName()!!.text in superNodesIdentifier
         }.mapNotNull { it.findChildByType(CLASS_BODY) }
         if (superNodes.size != superTypeList.size) {
             return null
@@ -131,7 +131,7 @@ class UselessSupertype(configRules: List<RulesConfig>) : DiktatRule(
             val overrideFunctions = classBody.findAllDescendantsWithSpecificType(FUN)
                 .filter {
                     (if (classBody.treeParent.hasChildOfType(CLASS_KEYWORD)) it.findChildByType(MODIFIER_LIST)!!.hasChildOfType(OPEN_KEYWORD) else true) &&
-                            it.getIdentifierName()!!.text in methodsName
+                        it.getIdentifierName()!!.text in methodsName
                 }
             overrideFunctions.forEach {
                 functionNameMap.compute(it.getIdentifierName()!!.text) { _, oldValue -> (oldValue ?: 0) + 1 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/AbstractClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/AbstractClassesRule.kt
@@ -44,7 +44,7 @@ class AbstractClassesRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun ASTNode.hasAbstractModifier(): Boolean =
-            getFirstChildWithType(MODIFIER_LIST)?.hasChildOfType(ABSTRACT_KEYWORD) ?: false
+        getFirstChildWithType(MODIFIER_LIST)?.hasChildOfType(ABSTRACT_KEYWORD) ?: false
 
     private fun ASTNode.isNotSubclass(): Boolean = findChildByType(SUPER_TYPE_LIST)?.children()?.filter {
         it.elementType == SUPER_TYPE_CALL_ENTRY || it.elementType == SUPER_TYPE_ENTRY

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
@@ -68,10 +68,10 @@ class CompactInitialization(configRules: List<RulesConfig>) : DiktatRule(
                 .takeWhile {
                     // statements like `name.field = value` where name == propertyName
                     it is KtBinaryExpression && it.node.findChildByType(OPERATION_REFERENCE)?.findChildByType(EQ) != null &&
-                            (it.left as? KtDotQualifiedExpression)?.run {
-                                (receiverExpression as? KtNameReferenceExpression)?.getReferencedName() == propertyName
-                            }
-                                ?: false
+                        (it.left as? KtDotQualifiedExpression)?.run {
+                            (receiverExpression as? KtNameReferenceExpression)?.getReferencedName() == propertyName
+                        }
+                            ?: false
                 }
                 .map {
                     // collect as an assignment associated with assigned field name

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/DataClassesRule.kt
@@ -99,16 +99,16 @@ class DataClassesRule(configRules: List<RulesConfig>) : DiktatRule(
             val list = getFirstChildWithType(MODIFIER_LIST)!!
             return list.getChildren(null)
                 .none { it.elementType in badModifiers } &&
-                    classBody?.getAllChildrenWithType(FUN)
-                        ?.isEmpty()
-                        ?: false &&
-                    getFirstChildWithType(SUPER_TYPE_LIST) == null
+                classBody?.getAllChildrenWithType(FUN)
+                    ?.isEmpty()
+                    ?: false &&
+                getFirstChildWithType(SUPER_TYPE_LIST) == null
         }
         return classBody?.getAllChildrenWithType(FUN)?.isEmpty() ?: false &&
-                getFirstChildWithType(SUPER_TYPE_LIST) == null &&
-                // if there is any prop with logic in accessor then don't recommend to convert class to data class
-                classBody?.let(::areGoodProps)
-                    ?: true
+            getFirstChildWithType(SUPER_TYPE_LIST) == null &&
+            // if there is any prop with logic in accessor then don't recommend to convert class to data class
+            classBody?.let(::areGoodProps)
+                ?: true
     }
 
     /**

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/InlineClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/InlineClassesRule.kt
@@ -33,9 +33,9 @@ class InlineClassesRule(configRules: List<RulesConfig>) : DiktatRule(
     override fun logic(node: ASTNode) {
         val configuration = configRules.getCommonConfiguration()
         if (node.elementType == CLASS &&
-                !(node.psi as KtClass).isInterface() &&
-                configuration.kotlinVersion >= minKtVersion &&
-                configuration.kotlinVersion < maxKtVersion
+            !(node.psi as KtClass).isInterface() &&
+            configuration.kotlinVersion >= minKtVersion &&
+            configuration.kotlinVersion < maxKtVersion
         ) {
             handleClasses(node.psi as KtClass)
         }
@@ -44,8 +44,8 @@ class InlineClassesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun handleClasses(classPsi: KtClass) {
         // Fixme: In Kotlin 1.4.30 inline classes may be used with internal constructors. When it will be released need to check it
         if (hasValidProperties(classPsi) &&
-                !isExtendingClass(classPsi.node) &&
-                classPsi.node.getFirstChildWithType(MODIFIER_LIST)?.getChildren(null)?.all { it.elementType in goodModifiers } != false) {
+            !isExtendingClass(classPsi.node) &&
+            classPsi.node.getFirstChildWithType(MODIFIER_LIST)?.getChildren(null)?.all { it.elementType in goodModifiers } != false) {
             // Fixme: since it's an experimental feature we shouldn't do fixer
             INLINE_CLASS_CAN_BE_USED.warn(configRules, emitWarn, isFixMode, "class ${classPsi.name}", classPsi.node.startOffset, classPsi.node)
         }
@@ -56,18 +56,18 @@ class InlineClassesRule(configRules: List<RulesConfig>) : DiktatRule(
             return !classPsi.getProperties().single().isVar
         } else if (classPsi.getProperties().isEmpty() && classPsi.hasExplicitPrimaryConstructor()) {
             return classPsi.primaryConstructorParameters.size == 1 &&
-                    !classPsi.primaryConstructorParameters.first().node.hasChildOfType(VAR_KEYWORD) &&
-                    classPsi.primaryConstructor?.visibilityModifierType()?.value?.let { it == "public" } ?: true
+                !classPsi.primaryConstructorParameters.first().node.hasChildOfType(VAR_KEYWORD) &&
+                classPsi.primaryConstructor?.visibilityModifierType()?.value?.let { it == "public" } ?: true
         }
         return false
     }
 
     private fun isExtendingClass(node: ASTNode): Boolean =
-            node
-                .getFirstChildWithType(SUPER_TYPE_LIST)
-                ?.children()
-                ?.any { it.hasChildOfType(CONSTRUCTOR_CALLEE) }
-                ?: false
+        node
+            .getFirstChildWithType(SUPER_TYPE_LIST)
+            ?.children()
+            ?.any { it.hasChildOfType(CONSTRUCTOR_CALLEE) }
+            ?: false
 
     companion object {
         const val NAME_ID = "aaw-inline-classes"

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/SingleConstructorRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/SingleConstructorRule.kt
@@ -138,27 +138,27 @@ class SingleConstructorRule(configRules: List<RulesConfig>) : DiktatRule(
 
     @Suppress("UnsafeCallOnNullableType")
     private fun List<KtBinaryExpression>.associateWithAssignedReference(localProperties: List<KtProperty>, classProperties: List<KtProperty>) =
-            associateWith {
-                // non-null assert is safe because of predicate in partitioning
-                it.asAssignment()!!.left!!
-            }
-                .filterValues { left ->
-                    // we keep only statements where property is referenced via this (like `this.foo = ...`)
-                    left is KtDotQualifiedExpression && left.receiverExpression is KtThisExpression && left.selectorExpression is KtNameReferenceExpression ||
-                            // or directly (like `foo = ...`)
-                            left is KtNameReferenceExpression && localProperties.none {
-                                // check for shadowing
-                                left.node.isGoingAfter(it.node) && it.name == left.name
-                            }
-                }
-                .mapValues { (_, left) ->
-                    when (left) {
-                        is KtDotQualifiedExpression -> left.selectorExpression as KtNameReferenceExpression
-                        is KtNameReferenceExpression -> left
-                        else -> error("Unexpected psi class ${left::class} with text ${left.text}")
+        associateWith {
+            // non-null assert is safe because of predicate in partitioning
+            it.asAssignment()!!.left!!
+        }
+            .filterValues { left ->
+                // we keep only statements where property is referenced via this (like `this.foo = ...`)
+                left is KtDotQualifiedExpression && left.receiverExpression is KtThisExpression && left.selectorExpression is KtNameReferenceExpression ||
+                    // or directly (like `foo = ...`)
+                    left is KtNameReferenceExpression && localProperties.none {
+                        // check for shadowing
+                        left.node.isGoingAfter(it.node) && it.name == left.name
                     }
+            }
+            .mapValues { (_, left) ->
+                when (left) {
+                    is KtDotQualifiedExpression -> left.selectorExpression as KtNameReferenceExpression
+                    is KtNameReferenceExpression -> left
+                    else -> error("Unexpected psi class ${left::class} with text ${left.text}")
                 }
-                .filterValues { left -> left.getReferencedName() in classProperties.mapNotNull { it.name } }
+            }
+            .filterValues { left -> left.getReferencedName() in classProperties.mapNotNull { it.name } }
 
     @Suppress(
         "NestedBlockDepth",
@@ -254,15 +254,15 @@ class SingleConstructorRule(configRules: List<RulesConfig>) : DiktatRule(
             ?.text
             ?.plus(" constructor ")
             ?: "") +
-                "(" +
-                declarationsAssignedInCtor.run {
-                    joinToString(
-                        ", ",
-                        postfix = if (isNotEmpty() && valueParameters.isNotEmpty()) ", " else ""
-                    ) { it.text }
-                } +
-                valueParameters.joinToString(", ") { it.text } +
-                ")"
+            "(" +
+            declarationsAssignedInCtor.run {
+                joinToString(
+                    ", ",
+                    postfix = if (isNotEmpty() && valueParameters.isNotEmpty()) ", " else ""
+                ) { it.text }
+            } +
+            valueParameters.joinToString(", ") { it.text } +
+            ")"
     )
         .node
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/StatelessClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/StatelessClassesRule.kt
@@ -67,16 +67,16 @@ class StatelessClassesRule(configRules: List<RulesConfig>) : DiktatRule(
         val properties = (node.psi as KtClass).getProperties()
         val functions = node.findAllDescendantsWithSpecificType(FUN)
         return properties.isEmpty() &&
-                functions.isNotEmpty() &&
-                !(node.psi as KtClass).hasExplicitPrimaryConstructor()
+            functions.isNotEmpty() &&
+            !(node.psi as KtClass).hasExplicitPrimaryConstructor()
     }
 
     private fun isClassExtendsValidInterface(node: ASTNode, interfaces: List<ASTNode>): Boolean =
-            node.findChildByType(SUPER_TYPE_LIST)
-                ?.getAllChildrenWithType(SUPER_TYPE_ENTRY)
-                ?.isNotEmpty()
-                ?.and(isClassInheritsStatelessInterface(node, interfaces))
-                ?: false
+        node.findChildByType(SUPER_TYPE_LIST)
+            ?.getAllChildrenWithType(SUPER_TYPE_ENTRY)
+            ?.isNotEmpty()
+            ?.and(isClassInheritsStatelessInterface(node, interfaces))
+            ?: false
 
     @Suppress("UnsafeCallOnNullableType")
     private fun isClassInheritsStatelessInterface(node: ASTNode, interfaces: List<ASTNode>): Boolean {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -102,7 +102,7 @@ fun ASTNode.isTextLengthInRange(range: IntRange): Boolean = this.textLength in r
  * @return node with type [ElementType.IDENTIFIER] or null if it is not present
  */
 fun ASTNode.getIdentifierName(): ASTNode? =
-        this.getFirstChildWithType(ElementType.IDENTIFIER)
+    this.getFirstChildWithType(ElementType.IDENTIFIER)
 
 /**
  * getting first child name with TYPE_PARAMETER_LIST type
@@ -110,7 +110,7 @@ fun ASTNode.getIdentifierName(): ASTNode? =
  * @return a node with type TYPE_PARAMETER_LIST or null if it is not present
  */
 fun ASTNode.getTypeParameterList(): ASTNode? =
-        this.getFirstChildWithType(ElementType.TYPE_PARAMETER_LIST)
+    this.getFirstChildWithType(ElementType.TYPE_PARAMETER_LIST)
 
 /**
  * @return true if this node contains no error elements, false otherwise
@@ -124,7 +124,7 @@ fun ASTNode.isCorrect() = this.findAllDescendantsWithSpecificType(TokenType.ERRO
  * @return list of nodes
  */
 fun ASTNode.getAllChildrenWithType(elementType: IElementType): List<ASTNode> =
-        this.getChildren(null).filter { it.elementType == elementType }
+    this.getChildren(null).filter { it.elementType == elementType }
 
 /**
  * Generates a sequence of this ASTNode's children in reversed order
@@ -158,7 +158,7 @@ fun ASTNode.replaceWhiteSpaceText(beforeNode: ASTNode, text: String) {
  * @return a node or null if it was not found
  */
 fun ASTNode.getFirstChildWithType(elementType: IElementType): ASTNode? =
-        this.findChildByType(elementType)
+    this.findChildByType(elementType)
 
 /**
  * Checks if a function is anonymous
@@ -181,49 +181,49 @@ fun ASTNode.isEol() = parent({ it.treeNext != null }, false)?.isFollowedByNewlin
  * Therefore, to check if they are followed by newline we need to check their parents.
  */
 fun ASTNode.isFollowedByNewline() =
-        parent({ it.treeNext != null }, strict = false)?.let {
-            it.treeNext.elementType == WHITE_SPACE && it.treeNext.text.contains("\n")
-        } ?: false
+    parent({ it.treeNext != null }, strict = false)?.let {
+        it.treeNext.elementType == WHITE_SPACE && it.treeNext.text.contains("\n")
+    } ?: false
 
 /**
  * This function is similar to isFollowedByNewline(), but there may be a comment after the node
  */
 fun ASTNode.isFollowedByNewlineWithComment() =
-        parent({ it.treeNext != null }, strict = false)
-            ?.treeNext?.run {
-            when (elementType) {
-                WHITE_SPACE -> text.contains("\n")
-                EOL_COMMENT, BLOCK_COMMENT, KDOC -> isFollowedByNewline()
-                else -> false
-            } ||
-                    parent({ it.treeNext != null }, strict = false)?.let {
-                        it.treeNext.elementType == EOL_COMMENT && it.treeNext.isFollowedByNewline()
-                    } ?: false
-        } ?: false
+    parent({ it.treeNext != null }, strict = false)
+        ?.treeNext?.run {
+        when (elementType) {
+            WHITE_SPACE -> text.contains("\n")
+            EOL_COMMENT, BLOCK_COMMENT, KDOC -> isFollowedByNewline()
+            else -> false
+        } ||
+            parent({ it.treeNext != null }, strict = false)?.let {
+                it.treeNext.elementType == EOL_COMMENT && it.treeNext.isFollowedByNewline()
+            } ?: false
+    } ?: false
 
 /**
  * Checks if there is a newline before this element. See [isFollowedByNewline] for motivation on parents check.
  * Or if there is nothing before, it cheks, that there are empty imports and package before (Every FILE node has children of type IMPORT_LIST and PACKAGE)
  */
 fun ASTNode.isBeginByNewline() =
-        parent({ it.treePrev != null }, strict = false)?.let {
-            it.treePrev.elementType == WHITE_SPACE && it.treePrev.text.contains("\n") ||
-                    (it.treePrev.elementType == IMPORT_LIST && it.treePrev.isLeaf() && it.treePrev.treePrev.isLeaf())
-        } ?: false
+    parent({ it.treePrev != null }, strict = false)?.let {
+        it.treePrev.elementType == WHITE_SPACE && it.treePrev.text.contains("\n") ||
+            (it.treePrev.elementType == IMPORT_LIST && it.treePrev.isLeaf() && it.treePrev.treePrev.isLeaf())
+    } ?: false
 
 /**
  * Checks if there is a newline before this element or before comment before. See [isBeginByNewline] for motivation on parents check.
  */
 fun ASTNode.isBeginNewLineWithComment() =
-        isBeginByNewline() || siblings(forward = false).takeWhile { !it.textContains('\n') }.toList().run {
-            all { it.isWhiteSpace() || it.isPartOfComment() } && isNotEmpty()
-        }
+    isBeginByNewline() || siblings(forward = false).takeWhile { !it.textContains('\n') }.toList().run {
+        all { it.isWhiteSpace() || it.isPartOfComment() } && isNotEmpty()
+    }
 
 /**
  * checks if the node has corresponding child with elementTyp
  */
 fun ASTNode.hasChildOfType(elementType: IElementType) =
-        this.getFirstChildWithType(elementType) != null
+    this.getFirstChildWithType(elementType) != null
 
 /**
  * Checks whether the node has at least one child of at least one of [elementType]
@@ -231,7 +231,7 @@ fun ASTNode.hasChildOfType(elementType: IElementType) =
  * @param elementType vararg of [IElementType]
  */
 fun ASTNode.hasAnyChildOfTypes(vararg elementType: IElementType) =
-        elementType.any { this.hasChildOfType(it) }
+    elementType.any { this.hasChildOfType(it) }
 
 /**
  * checks if node has parent of type
@@ -299,7 +299,7 @@ fun ASTNode.findChildAfter(afterThisNodeType: IElementType, childNodeType: IElem
  * @return ASTNode?
  */
 fun ASTNode.prevNodeUntilNode(stopNodeType: IElementType, checkNodeType: IElementType): ASTNode? =
-        siblings(false).takeWhile { it.elementType != stopNodeType }.find { it.elementType == checkNodeType }
+    siblings(false).takeWhile { it.elementType != stopNodeType }.find { it.elementType == checkNodeType }
 
 /**
  * Returns all siblings of [this] node
@@ -308,7 +308,7 @@ fun ASTNode.prevNodeUntilNode(stopNodeType: IElementType, checkNodeType: IElemen
  * @return list of siblings
  */
 fun ASTNode.allSiblings(withSelf: Boolean = false): List<ASTNode> =
-        siblings(false).toList() + (if (withSelf) listOf(this) else emptyList()) + siblings(true)
+    siblings(false).toList() + (if (withSelf) listOf(this) else emptyList()) + siblings(true)
 
 /**
  * Checks whether [this] node belongs to a companion object
@@ -363,8 +363,8 @@ fun ASTNode.isNodeFromFileLevel(): Boolean = this.treeParent.elementType == FILE
  * Checks whether [this] node of type PROPERTY is `val`
  */
 fun ASTNode.isValProperty() =
-        this.getChildren(null)
-            .any { it.elementType == ElementType.VAL_KEYWORD }
+    this.getChildren(null)
+        .any { it.elementType == ElementType.VAL_KEYWORD }
 
 /**
  * Checks whether this node of type PROPERTY has `const` modifier
@@ -385,8 +385,8 @@ fun ASTNode.hasModifier(modifier: IElementType) = this.findChildByType(MODIFIER_
  * Checks whether [this] node of type PROPERTY is `var`
  */
 fun ASTNode.isVarProperty() =
-        this.getChildren(null)
-            .any { it.elementType == ElementType.VAR_KEYWORD }
+    this.getChildren(null)
+        .any { it.elementType == ElementType.VAR_KEYWORD }
 
 /**
  * Replaces text of [this] node with lowercase text
@@ -440,7 +440,7 @@ fun ASTNode.numNewLines() = text.count { it == '\n' }
  * This method performs tree traversal and returns all nodes with specific element type
  */
 fun ASTNode.findAllDescendantsWithSpecificType(elementType: IElementType, withSelf: Boolean = true) =
-        findAllNodesWithCondition(withSelf) { it.elementType == elementType }
+    findAllNodesWithCondition(withSelf) { it.elementType == elementType }
 
 /**
  * This method performs tree traversal and returns all nodes which satisfy the condition
@@ -464,22 +464,22 @@ fun ASTNode.isClassEnum(): Boolean = (psi as? KtClass)?.isEnum() ?: false
  * This method finds first parent node from the sequence of parents that has specified elementType
  */
 fun ASTNode.findParentNodeWithSpecificType(elementType: IElementType) =
-        this.parents().find { it.elementType == elementType }
+    this.parents().find { it.elementType == elementType }
 
 /**
  * Finds all children of optional type which match the predicate
  */
 fun ASTNode.findChildrenMatching(elementType: IElementType? = null,
                                  predicate: (ASTNode) -> Boolean): List<ASTNode> =
-        getChildren(elementType?.let { TokenSet.create(it) })
-            .filter(predicate)
+    getChildren(elementType?.let { TokenSet.create(it) })
+        .filter(predicate)
 
 /**
  * Check if this node has any children of optional type matching the predicate
  */
 fun ASTNode.hasChildMatching(elementType: IElementType? = null,
                              predicate: (ASTNode) -> Boolean): Boolean =
-        findChildrenMatching(elementType, predicate).isNotEmpty()
+    findChildrenMatching(elementType, predicate).isNotEmpty()
 
 /**
  * Converts this AST node and all its children to pretty string representation
@@ -495,7 +495,7 @@ fun ASTNode.prettyPrint(level: Int = 0, maxLevel: Int = -1): String {
             this.getChildren(null).forEach { child ->
                 result.append(
                     "${"-".repeat(level + 1)} " +
-                            child.doPrettyPrint(level + 1, maxLevel - 1)
+                        child.doPrettyPrint(level + 1, maxLevel - 1)
                 )
             }
         }
@@ -509,12 +509,12 @@ fun ASTNode.prettyPrint(level: Int = 0, maxLevel: Int = -1): String {
  * The receiver should be an ASTNode with ElementType.MODIFIER_LIST, can be null if entity has no modifier list
  */
 fun ASTNode?.isAccessibleOutside(): Boolean =
-        this?.run {
-            require(this.elementType == MODIFIER_LIST)
-            this.hasAnyChildOfTypes(PUBLIC_KEYWORD, PROTECTED_KEYWORD, INTERNAL_KEYWORD) ||
-                    !this.hasAnyChildOfTypes(PUBLIC_KEYWORD, INTERNAL_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD)
-        }
-            ?: true
+    this?.run {
+        require(this.elementType == MODIFIER_LIST)
+        this.hasAnyChildOfTypes(PUBLIC_KEYWORD, PROTECTED_KEYWORD, INTERNAL_KEYWORD) ||
+            !this.hasAnyChildOfTypes(PUBLIC_KEYWORD, INTERNAL_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD)
+    }
+        ?: true
 
 /**
  * Checks whether [this] node has a parent annotated with `@Suppress` with [warningName]
@@ -527,13 +527,13 @@ fun ASTNode.isSuppressed(
     rule: Rule,
     configs: List<RulesConfig>
 ) =
-        this.parent(hasAnySuppressorForInspection(warningName, rule, configs), strict = false) != null
+    this.parent(hasAnySuppressorForInspection(warningName, rule, configs), strict = false) != null
 
 /**
  * Checks node has `override` modifier
  */
 fun ASTNode.isOverridden(): Boolean =
-        findChildByType(MODIFIER_LIST)?.findChildByType(OVERRIDE_KEYWORD) != null
+    findChildByType(MODIFIER_LIST)?.findChildByType(OVERRIDE_KEYWORD) != null
 
 /**
  * removing all newlines in WHITE_SPACE node and replacing it to a one newline saving the initial indenting format
@@ -632,7 +632,7 @@ fun ASTNode.isSingleLineIfElse(): Boolean {
  * @return boolean result
  */
 fun ASTNode.isChildAfterAnother(child: ASTNode, afterChild: ASTNode): Boolean =
-        getChildren(null).indexOf(child) > getChildren(null).indexOf(afterChild)
+    getChildren(null).indexOf(child) > getChildren(null).indexOf(afterChild)
 
 /**
  * Checks whether [child] is after all nodes from [group] among the children of [this] node
@@ -640,7 +640,7 @@ fun ASTNode.isChildAfterAnother(child: ASTNode, afterChild: ASTNode): Boolean =
  * @return boolean result
  */
 fun ASTNode.isChildAfterGroup(child: ASTNode, group: List<ASTNode>): Boolean =
-        getChildren(null).indexOf(child) > (group.map { getChildren(null).indexOf(it) }.maxOrNull() ?: 0)
+    getChildren(null).indexOf(child) > (group.map { getChildren(null).indexOf(it) }.maxOrNull() ?: 0)
 
 /**
  * Checks whether [child] is before [beforeChild] among the children of [this] node
@@ -648,7 +648,7 @@ fun ASTNode.isChildAfterGroup(child: ASTNode, group: List<ASTNode>): Boolean =
  * @return boolean result
  */
 fun ASTNode.isChildBeforeAnother(child: ASTNode, beforeChild: ASTNode): Boolean =
-        areChildrenBeforeGroup(listOf(child), listOf(beforeChild))
+    areChildrenBeforeGroup(listOf(child), listOf(beforeChild))
 
 /**
  * Checks whether [child] is before all nodes is [group] among the children of [this] node
@@ -656,7 +656,7 @@ fun ASTNode.isChildBeforeAnother(child: ASTNode, beforeChild: ASTNode): Boolean 
  * @return boolean result
  */
 fun ASTNode.isChildBeforeGroup(child: ASTNode, group: List<ASTNode>): Boolean =
-        areChildrenBeforeGroup(listOf(child), group)
+    areChildrenBeforeGroup(listOf(child), group)
 
 /**
  * Checks whether all nodes in [children] is before [beforeChild] among the children of [this] node
@@ -664,7 +664,7 @@ fun ASTNode.isChildBeforeGroup(child: ASTNode, group: List<ASTNode>): Boolean =
  * @return boolean result
  */
 fun ASTNode.areChildrenBeforeChild(children: List<ASTNode>, beforeChild: ASTNode): Boolean =
-        areChildrenBeforeGroup(children, listOf(beforeChild))
+    areChildrenBeforeGroup(children, listOf(beforeChild))
 
 /**
  * Checks whether all nodes in [children] is before all nodes in [group] among the children of [this] node
@@ -691,8 +691,8 @@ fun List<ASTNode>.handleIncorrectOrder(
     forEach { astNode ->
         val (afterThisNode, beforeThisNode) = astNode.getSiblingBlocks()
         val isPositionIncorrect =
-                (afterThisNode != null && !astNode.treeParent.isChildAfterAnother(astNode, afterThisNode)) ||
-                        !astNode.treeParent.isChildBeforeAnother(astNode, beforeThisNode)
+            (afterThisNode != null && !astNode.treeParent.isChildAfterAnother(astNode, afterThisNode)) ||
+                !astNode.treeParent.isChildBeforeAnother(astNode, beforeThisNode)
 
         if (isPositionIncorrect) {
             incorrectPositionHandler(astNode, beforeThisNode)
@@ -800,10 +800,10 @@ fun ASTNode.isGoingAfter(otherNode: ASTNode): Boolean {
  * check that node has binary expression with `EQ`
  */
 fun ASTNode.hasEqBinaryExpression(): Boolean =
-        findChildByType(BINARY_EXPRESSION)
-            ?.findChildByType(OPERATION_REFERENCE)
-            ?.hasChildOfType(EQ)
-            ?: false
+    findChildByType(BINARY_EXPRESSION)
+        ?.findChildByType(OPERATION_REFERENCE)
+        ?.hasChildOfType(EQ)
+        ?: false
 
 /**
  * Get line number, where this node's content starts.
@@ -811,7 +811,7 @@ fun ASTNode.hasEqBinaryExpression(): Boolean =
  * @return line number
  */
 fun ASTNode.getLineNumber(): Int =
-        calculateLineNumber()
+    calculateLineNumber()
 
 /**
  * Get node by taking children by types and ignore `PARENTHESIZED`
@@ -832,13 +832,13 @@ fun ASTNode.takeByChainOfTypes(vararg types: IElementType): ASTNode? {
 }
 
 private fun Collection<KtAnnotationEntry>.containSuppressWithName(name: String) =
-        this.any {
-            it.shortName.toString() == (Suppress::class.simpleName) &&
-                    (it.valueArgumentList
-                        ?.arguments
-                        ?.any { annotation -> annotation.text.trim('"') == name }
-                        ?: false)
-        }
+    this.any {
+        it.shortName.toString() == (Suppress::class.simpleName) &&
+            (it.valueArgumentList
+                ?.arguments
+                ?.any { annotation -> annotation.text.trim('"') == name }
+                ?: false)
+    }
 
 private fun ASTNode.findOffsetByLine(line: Int, positionByOffset: (Int) -> Pair<Int, Int>): Int {
     val currentLine = this.getLineNumber()
@@ -998,7 +998,7 @@ private fun hasAnySuppressorForInspection(
     val foundSuppress = annotationsForNode.containSuppressWithName(warningName)
 
     val foundIgnoredAnnotation =
-            configs.isAnnotatedWithIgnoredAnnotation(rule, annotationsForNode.map { it.shortName.toString() }.toSet())
+        configs.isAnnotatedWithIgnoredAnnotation(rule, annotationsForNode.map { it.shortName.toString() }.toSet())
 
     val isCompletelyIgnoredBlock = annotationsForNode.containSuppressWithName(DIKTAT)
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FileUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FileUtils.kt
@@ -12,9 +12,9 @@ internal const val SRC_DIRECTORY_NAME = "src"
  * @return list of path parts
  */
 fun String.splitPathToDirs(): List<String> =
-        this.replace("\\", "/")
-            .replace("//", "/")
-            .split("/")
+    this.replace("\\", "/")
+        .replace("//", "/")
+        .split("/")
 
 /**
  * Checks if [this] String is a name of a kotlin script file by checking whether file extension equals 'kts'

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FunctionAstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FunctionAstNodeUtils.kt
@@ -69,6 +69,6 @@ private fun ASTNode.argList(): ASTNode? {
 }
 
 private fun checkNodeIsFun(node: ASTNode) =
-        require(node.elementType == ElementType.FUN) {
-            "This utility method operates on nodes of type ElementType.FUN only"
-        }
+    require(node.elementType == ElementType.FUN) {
+        "This utility method operates on nodes of type ElementType.FUN only"
+    }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/KdocUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/KdocUtils.kt
@@ -32,7 +32,7 @@ fun ASTNode.kDocTags(): List<KDocTag> {
  * @return whether this tag is present
  */
 fun Iterable<KDocTag>.hasKnownKdocTag(knownTag: KDocKnownTag): Boolean =
-        this.find { it.knownTag == knownTag } != null
+    this.find { it.knownTag == knownTag } != null
 
 /**
  * Checks for trailing newlines in tag's body. Handles cases, when there is no leading asterisk on an empty line:
@@ -46,10 +46,10 @@ fun Iterable<KDocTag>.hasKnownKdocTag(knownTag: KDocKnownTag): Boolean =
  * @return true if there is a trailing newline
  */
 fun KDocTag.hasTrailingNewlineInTagBody() = node.lastChildNode.isWhiteSpaceWithNewline() ||
-        node.reversedChildren()
-            .takeWhile { it.elementType == WHITE_SPACE || it.elementType == ElementType.KDOC_LEADING_ASTERISK }
-            .firstOrNull { it.elementType == ElementType.KDOC_LEADING_ASTERISK }
-            ?.takeIf { it.treeNext == null || it.treeNext.elementType == WHITE_SPACE } != null
+    node.reversedChildren()
+        .takeWhile { it.elementType == WHITE_SPACE || it.elementType == ElementType.KDOC_LEADING_ASTERISK }
+        .firstOrNull { it.elementType == ElementType.KDOC_LEADING_ASTERISK }
+        ?.takeIf { it.treeNext == null || it.treeNext.elementType == WHITE_SPACE } != null
 
 /**
  * This method inserts a new tag into KDoc before specified another tag, aligning it with the rest of this KDoc

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/KotlinParser.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/KotlinParser.kt
@@ -172,5 +172,5 @@ class KotlinParser {
     }
 
     private fun isContainKdoc(text: String) =
-            text.lines().any { it.trim().startsWith("/**") }
+        text.lines().any { it.trim().startsWith("/**") }
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/PsiUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/PsiUtils.kt
@@ -28,21 +28,21 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  */
 @Suppress("UnsafeCallOnNullableType", "FUNCTION_BOOLEAN_PREFIX")
 fun KtExpression.containsOnlyConstants(): Boolean =
-        when (this) {
-            is KtConstantExpression -> true
-            is KtStringTemplateExpression -> entries.all { it.expression?.containsOnlyConstants() ?: true }
-            // left and right are marked @Nullable @IfNotParsed, so it should be safe to `!!`
-            is KtBinaryExpression -> left!!.containsOnlyConstants() && right!!.containsOnlyConstants()
-            is KtDotQualifiedExpression -> receiverExpression.containsOnlyConstants() &&
-                    (selectorExpression is KtReferenceExpression ||
-                            ((selectorExpression as? KtCallExpression)
-                                ?.valueArgumentList
-                                ?.arguments
-                                ?.all { it.getArgumentExpression()!!.containsOnlyConstants() }
-                                ?: false)
-                    )
-            else -> false
-        }
+    when (this) {
+        is KtConstantExpression -> true
+        is KtStringTemplateExpression -> entries.all { it.expression?.containsOnlyConstants() ?: true }
+        // left and right are marked @Nullable @IfNotParsed, so it should be safe to `!!`
+        is KtBinaryExpression -> left!!.containsOnlyConstants() && right!!.containsOnlyConstants()
+        is KtDotQualifiedExpression -> receiverExpression.containsOnlyConstants() &&
+            (selectorExpression is KtReferenceExpression ||
+                ((selectorExpression as? KtCallExpression)
+                    ?.valueArgumentList
+                    ?.arguments
+                    ?.all { it.getArgumentExpression()!!.containsOnlyConstants() }
+                    ?: false)
+            )
+        else -> false
+    }
 
 /**
  * Get block inside which the property is declared.
@@ -51,11 +51,11 @@ fun KtExpression.containsOnlyConstants(): Boolean =
  */
 @Suppress("UnsafeCallOnNullableType")
 fun KtProperty.getDeclarationScope() =
-        // FixMe: class body is missing here
-        getParentOfType<KtBlockExpression>(true)
-            .let { if (it is KtIfExpression) it.then!! else it }
-            .let { if (it is KtTryExpression) it.tryBlock else it }
-            as KtBlockExpression?
+    // FixMe: class body is missing here
+    getParentOfType<KtBlockExpression>(true)
+        .let { if (it is KtIfExpression) it.then!! else it }
+        .let { if (it is KtTryExpression) it.tryBlock else it }
+        as KtBlockExpression?
 
 /**
  * Method that tries to find a local property declaration with the same name as current [KtNameReferenceExpression] element
@@ -71,9 +71,9 @@ fun KtNameReferenceExpression.findLocalDeclaration(): KtProperty? = parents
             .mapNotNull { it as? KtProperty }
             .find {
                 it.isLocal &&
-                        it.hasInitializer() &&
-                        it.name?.equals(getReferencedName())
-                            ?: false
+                    it.hasInitializer() &&
+                    it.name?.equals(getReferencedName())
+                        ?: false
             }
     }
     .firstOrNull()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringCaseUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringCaseUtils.kt
@@ -159,7 +159,7 @@ fun String.toPascalCase(): String = when {
  * @return index of first character which is a letter or a digit
  */
 private fun String.getFirstLetterOrDigit() =
-        indexOfFirst { it.isLetterOrDigit() }
+    indexOfFirst { it.isLetterOrDigit() }
 
 private fun convertUnknownCaseToCamel(str: String, isFirstLetterCapital: Boolean): String {
     // [p]a[SC]a[_]l -> [P]a[Sc]a[L]

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/Checkers.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/Checkers.kt
@@ -83,12 +83,12 @@ internal class ValueParameterListChecker(configuration: IndentationConfig) : Cus
      * 3. there are no more arguments after this node
      */
     private fun isCheckNeeded(whiteSpace: PsiWhiteSpace) =
-            whiteSpace.parent.node.elementType.let { it == VALUE_PARAMETER_LIST || it == VALUE_ARGUMENT_LIST } &&
-                    whiteSpace.siblings(forward = false, withItself = false).none { it is PsiWhiteSpace && it.textContains('\n') } &&
-                    // no need to trigger when there are no more parameters in the list
-                    whiteSpace.siblings(forward = true, withItself = false).any {
-                        it.node.elementType.run { this == VALUE_ARGUMENT || this == VALUE_PARAMETER }
-                    }
+        whiteSpace.parent.node.elementType.let { it == VALUE_PARAMETER_LIST || it == VALUE_ARGUMENT_LIST } &&
+            whiteSpace.siblings(forward = false, withItself = false).none { it is PsiWhiteSpace && it.textContains('\n') } &&
+            // no need to trigger when there are no more parameters in the list
+            whiteSpace.siblings(forward = true, withItself = false).any {
+                it.node.elementType.run { this == VALUE_ARGUMENT || this == VALUE_PARAMETER }
+            }
 
     override fun checkNode(whiteSpace: PsiWhiteSpace, indentError: IndentationError): CheckResult? {
         if (isCheckNeeded(whiteSpace)) {
@@ -99,8 +99,8 @@ internal class ValueParameterListChecker(configuration: IndentationConfig) : Cus
                 ?.treeNext
                 ?.takeIf {
                     it.elementType != WHITE_SPACE &&
-                            // there can be multiline arguments and in this case we don't align parameters with them
-                            !it.textContains('\n')
+                        // there can be multiline arguments and in this case we don't align parameters with them
+                        !it.textContains('\n')
                 }
 
             val expectedIndent = if (parameterAfterLpar != null && configuration.alignedParameters && parameterList.elementType == VALUE_PARAMETER_LIST) {
@@ -134,7 +134,7 @@ internal class ExpressionIndentationChecker(configuration: IndentationConfig) : 
     override fun checkNode(whiteSpace: PsiWhiteSpace, indentError: IndentationError): CheckResult? {
         if (whiteSpace.parent.node.elementType == BINARY_EXPRESSION && whiteSpace.prevSibling.node.elementType == OPERATION_REFERENCE) {
             val expectedIndent = (whiteSpace.parentIndent() ?: indentError.expected) +
-                    (if (configuration.extendedIndentAfterOperators) 2 else 1) * configuration.indentationSize
+                (if (configuration.extendedIndentAfterOperators) 2 else 1) * configuration.indentationSize
             return CheckResult.from(indentError.actual, expectedIndent, true)
         }
         return null
@@ -182,7 +182,7 @@ internal class SuperTypeListChecker(config: IndentationConfig) : CustomIndentati
  */
 internal class DotCallChecker(config: IndentationConfig) : CustomIndentationChecker(config) {
     private fun ASTNode.isDotBeforeCallOrReference() = elementType.let { it == DOT || it == SAFE_ACCESS } &&
-            treeNext.elementType.let { it == CALL_EXPRESSION || it == REFERENCE_EXPRESSION }
+        treeNext.elementType.let { it == CALL_EXPRESSION || it == REFERENCE_EXPRESSION }
 
     private fun ASTNode.isCommentBeforeDot(): Boolean {
         if (elementType == EOL_COMMENT || elementType == BLOCK_COMMENT) {
@@ -196,21 +196,21 @@ internal class DotCallChecker(config: IndentationConfig) : CustomIndentationChec
     }
 
     private fun ASTNode.isFromStringTemplate(): Boolean =
-            hasParent(LONG_STRING_TEMPLATE_ENTRY)
+        hasParent(LONG_STRING_TEMPLATE_ENTRY)
 
     @Suppress("ComplexMethod")
     override fun checkNode(whiteSpace: PsiWhiteSpace, indentError: IndentationError): CheckResult? {
         whiteSpace.nextSibling.node
             .takeIf { nextNode ->
                 (nextNode.isDotBeforeCallOrReference() ||
-                        nextNode.elementType == OPERATION_REFERENCE && nextNode.firstChildNode.elementType.let { type ->
-                            type == ELVIS || type == IS_EXPRESSION || type == AS_KEYWORD || type == AS_SAFE
-                        } || nextNode.isCommentBeforeDot()) && whiteSpace.parents.none { it.node.elementType == LONG_STRING_TEMPLATE_ENTRY }
+                    nextNode.elementType == OPERATION_REFERENCE && nextNode.firstChildNode.elementType.let { type ->
+                        type == ELVIS || type == IS_EXPRESSION || type == AS_KEYWORD || type == AS_SAFE
+                    } || nextNode.isCommentBeforeDot()) && whiteSpace.parents.none { it.node.elementType == LONG_STRING_TEMPLATE_ENTRY }
             }
             ?.let { node ->
                 if (node.isFromStringTemplate()) {
                     return CheckResult.from(indentError.actual, indentError.expected +
-                            (if (configuration.extendedIndentBeforeDot) 2 else 1) * configuration.indentationSize, true)
+                        (if (configuration.extendedIndentBeforeDot) 2 else 1) * configuration.indentationSize, true)
                 }
 
                 // we need to get indent before the first expression in calls chain
@@ -219,7 +219,7 @@ internal class DotCallChecker(config: IndentationConfig) : CustomIndentationChec
                 }
                     .parentIndent()
                     ?: indentError.expected) +
-                        (if (configuration.extendedIndentBeforeDot) 2 else 1) * configuration.indentationSize, true)
+                    (if (configuration.extendedIndentBeforeDot) 2 else 1) * configuration.indentationSize, true)
             }
         return null
     }
@@ -235,7 +235,7 @@ internal class ConditionalsAndLoopsWithoutBracesChecker(config: IndentationConfi
         return when (parent) {
             is KtLoopExpression -> nextNode?.elementType == BODY && parent.body !is KtBlockExpression
             is KtIfExpression -> nextNode?.elementType == THEN && parent.then !is KtBlockExpression ||
-                    nextNode?.elementType == ELSE && parent.`else`.let { it !is KtBlockExpression && it !is KtIfExpression }
+                nextNode?.elementType == ELSE && parent.`else`.let { it !is KtBlockExpression && it !is KtIfExpression }
             else -> false
         }
             .takeIf { it }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
@@ -26,13 +26,13 @@ internal class IndentationConfig(config: Map<String, String>) : RuleConfiguratio
     /**
      * If true, if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
      */
-    val extendedIndentAfterOperators = config["extendedIndentAfterOperators"]?.toBoolean() ?: true
+    val extendedIndentAfterOperators = config["extendedIndentAfterOperators"]?.toBoolean() ?: false
 
     /**
      * If true, when dot qualified expression starts on a new line, this line will be indented with
      * two indentations instead of one
      */
-    val extendedIndentBeforeDot = config["extendedIndentBeforeDot"]?.toBoolean() ?: true
+    val extendedIndentBeforeDot = config["extendedIndentBeforeDot"]?.toBoolean() ?: false
 
     /**
      * The indentation size for each file

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesSearch.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesSearch.kt
@@ -103,11 +103,11 @@ abstract class VariablesSearch(val node: ASTNode,
             // FixMe: in class or a file the declaration can easily go after the usage (by lines of code)
             block.getChildrenOfType<KtProperty>()
                 .any { it.nameAsName == property.nameAsName && expression.node.isGoingAfter(it.node) } ||
-                    block.parent
-                        .let { it as? KtFunctionLiteral }
-                        ?.valueParameters
-                        ?.any { it.nameAsName == property.nameAsName }
-                        ?: false
+                block.parent
+                    .let { it as? KtFunctionLiteral }
+                    ?.valueParameters
+                    ?.any { it.nameAsName == property.nameAsName }
+                    ?: false
             // FixMe: also see very strange behavior of Kotlin in tests (disabled)
         }
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithAssignmentSearch.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithAssignmentSearch.kt
@@ -37,11 +37,11 @@ class VariablesWithAssignmentSearch(fileNode: ASTNode,
             // FixMe: Currently we check only val a = 5, ++a is not checked here
             // FixMe: also there can be some tricky cases with setters, but I am not able to imagine them now
             it.isGoingAfter(property.node) &&
-                    (it.psi as KtBinaryExpression).operationToken == ElementType.EQ &&
-                    (it.psi as KtBinaryExpression)
-                        .left
-                        ?.node
-                        ?.elementType == ElementType.REFERENCE_EXPRESSION
+                (it.psi as KtBinaryExpression).operationToken == ElementType.EQ &&
+                (it.psi as KtBinaryExpression)
+                    .left
+                    ?.node
+                    ?.elementType == ElementType.REFERENCE_EXPRESSION
         }
         .map { (it.psi as KtBinaryExpression).left as KtNameReferenceExpression }
         // checking that name of the property in usage matches with the name in the declaration
@@ -49,8 +49,8 @@ class VariablesWithAssignmentSearch(fileNode: ASTNode,
         .filterNot { expression ->
             // to avoid false triggering on objects' fields with same name as property
             expression.isReferenceToFieldOfObject() ||
-                    // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
-                    isReferenceToOtherVariableWithSameName(expression, this, property)
+                // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
+                isReferenceToOtherVariableWithSameName(expression, this, property)
         }
         .toList()
 }
@@ -59,4 +59,4 @@ class VariablesWithAssignmentSearch(fileNode: ASTNode,
  * the default value for filtering condition is always true
  */
 fun ASTNode.findAllVariablesWithAssignments(filterForVariables: (KtProperty) -> Boolean = ::default) =
-        VariablesWithAssignmentSearch(this, filterForVariables).collectVariables()
+    VariablesWithAssignmentSearch(this, filterForVariables).collectVariables()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithUsagesSearch.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithUsagesSearch.kt
@@ -30,8 +30,8 @@ class VariablesWithUsagesSearch(fileNode: ASTNode,
         .filterNot { expression ->
             // to avoid false triggering on objects' fields with same name as property
             expression.isReferenceToFieldOfObject() ||
-                    // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
-                    isReferenceToOtherVariableWithSameName(expression, this, property)
+                // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
+                isReferenceToOtherVariableWithSameName(expression, this, property)
         }
 }
 
@@ -39,4 +39,4 @@ class VariablesWithUsagesSearch(fileNode: ASTNode,
  * the default value for filtering condition is always true
  */
 fun ASTNode.findAllVariablesWithUsages(filterForVariables: (KtProperty) -> Boolean = ::default) =
-        VariablesWithUsagesSearch(this, filterForVariables).collectVariables()
+    VariablesWithUsagesSearch(this, filterForVariables).collectVariables()

--- a/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
@@ -208,7 +208,7 @@
     # If true: if first parameter in parameter list is on the same line as opening parenthesis, then other parameters can be aligned with it
     alignedParameters: true
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     # If true: when dot qualified expression starts on a new line, this line will be indented with two indentations instead of one
     extendedIndentBeforeDot: false
     # The indentation size for each file

--- a/diktat-rules/src/main/resources/diktat-analysis.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis.yml
@@ -208,7 +208,7 @@
     # If true: if first parameter in parameter list is on the same line as opening parenthesis, then other parameters can be aligned with it
     alignedParameters: true
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     # The indentation size for each file
     indentationSize: 4
 # Checks that there is no empty blocks in a file.

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -36,12 +36,12 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.GENERIC_NAME)
     fun `generic class - single capital letter, can be followed by a number  (check - positive1)`() {
         val code =
-                """
-                    package org.cqfn.diktat.test
+            """
+                package org.cqfn.diktat.test
 
-                    class TreeNode<T>(val value: T?, val next: TreeNode<T>? = null)
+                class TreeNode<T>(val value: T?, val next: TreeNode<T>? = null)
 
-                """.trimIndent()
+            """.trimIndent()
         lintMethod(code)
     }
 
@@ -49,12 +49,12 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.GENERIC_NAME)
     fun `generic class - single capital letter, can be followed by a number  (check - positive2)`() {
         val code =
-                """
-                    package org.cqfn.diktat.test
+            """
+                package org.cqfn.diktat.test
 
-                    class TreeNode<T123>(val value: T?, val next: TreeNode<T>? = null)
+                class TreeNode<T123>(val value: T?, val next: TreeNode<T>? = null)
 
-                """.trimIndent()
+            """.trimIndent()
         lintMethod(code)
     }
 
@@ -76,12 +76,12 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.GENERIC_NAME)
     fun `generic class - single capital letter, can be followed by a number  (check - negative1)`() {
         val code =
-                """
-                    package org.cqfn.diktat.test
+            """
+                package org.cqfn.diktat.test
 
-                    class TreeNode<a>(val value: T?, val next: TreeNode<T>? = null)
+                class TreeNode<a>(val value: T?, val next: TreeNode<T>? = null)
 
-                """.trimIndent()
+            """.trimIndent()
         lintMethod(code, LintError(
             3, 15, ruleId, "${GENERIC_NAME.warnText()} <a>", true)
         )
@@ -91,12 +91,12 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.GENERIC_NAME)
     fun `generic class - single capital letter, can be followed by a number  (check - negative2)`() {
         val code =
-                """
-                    package org.cqfn.diktat.test
+            """
+                package org.cqfn.diktat.test
 
-                    class TreeNode<TBBB>(val value: T?, val next: TreeNode<T>? = null)
+                class TreeNode<TBBB>(val value: T?, val next: TreeNode<T>? = null)
 
-                """.trimIndent()
+            """.trimIndent()
         lintMethod(code, LintError(
             3, 15, ruleId, "${GENERIC_NAME.warnText()} <TBBB>", true)
         )
@@ -106,17 +106,17 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.GENERIC_NAME)
     fun `generic method - single capital letter, can be followed by a number  (check)`() {
         val code =
-                """
-                   package org.cqfn.diktat.test
+            """
+                package org.cqfn.diktat.test
 
-                   fun <T> makeLinkedList(vararg elements: T): TreeNode<T>? {
-                        var node: TreeNode<T>? = null
-                        for (element in elements.reversed()) {
-                             node = TreeNode(element, node)
-                        }
-                        return node
+                fun <T> makeLinkedList(vararg elements: T): TreeNode<T>? {
+                    var node: TreeNode<T>? = null
+                    for (element in elements.reversed()) {
+                         node = TreeNode(element, node)
                     }
-                """.trimIndent()
+                    return node
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
@@ -125,10 +125,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.CLASS_NAME_INCORRECT)
     fun `check class name (check)`() {
         val code =
-                """
-                    class incorrectNAME {}
-                    class IncorrectNAME {}
-                """
+            """
+                class incorrectNAME {}
+                class IncorrectNAME {}
+            """
         lintMethod(code,
             LintError(2, 27, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrectNAME", true),
             LintError(3, 27, ruleId, "${CLASS_NAME_INCORRECT.warnText()} IncorrectNAME", true)
@@ -143,22 +143,22 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     )
     fun `check identifiers case format (check - negative)`() {
         val code =
-                """
-                  var SOMEtest = "TEST"
-                  const val thisConstantShouldBeUpper = "CONST"
-                  class className {
-                      data class badClassName(val FIRST: String, var SECOND: String)
+            """
+              var SOMEtest = "TEST"
+              const val thisConstantShouldBeUpper = "CONST"
+              class className {
+                  data class badClassName(val FIRST: String, var SECOND: String)
 
-                      companion object {
-                          const val incorrect_case = ""
-                          val correctCase = ""
-                          var INCORRECT = ""
-                      }
-
-                      var check_me = ""
-                      val CHECK_ME = ""
+                  companion object {
+                      const val incorrect_case = ""
+                      val correctCase = ""
+                      var INCORRECT = ""
                   }
-                """.trimIndent()
+
+                  var check_me = ""
+                  val CHECK_ME = ""
+              }
+            """.trimIndent()
 
         lintMethod(code,
             LintError(1, 5, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SOMEtest", true),
@@ -178,14 +178,14 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tags(Tag(WarningNames.IDENTIFIER_LENGTH), Tag(WarningNames.VARIABLE_NAME_INCORRECT))
     fun `check variable length (check - negative)`() {
         val code =
-                """
-                  val r = 0
-                  val x256 = 256
-                  val i = 1
-                  class LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName {
-                      val veryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongName = ""
-                  }
-                """.trimIndent()
+            """
+                val r = 0
+                val x256 = 256
+                val i = 1
+                class LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName {
+                    val veryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongName =                "                "
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 5, ruleId, "${IDENTIFIER_LENGTH.warnText()} r"),
             LintError(2, 5, ruleId, "${VARIABLE_NAME_INCORRECT.warnText()} x256"),
@@ -198,9 +198,9 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.VARIABLE_NAME_INCORRECT_FORMAT)
     fun `check value parameters in dataclasses (check - negative)`() {
         val code =
-                """
-                    data class ClassName(val FIRST: String, var SECOND: String)
-                """.trimIndent()
+            """
+                data class ClassName(val FIRST: String, var SECOND: String)
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 26, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} FIRST", true),
             LintError(1, 45, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SECOND", true)
@@ -211,10 +211,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.VARIABLE_NAME_INCORRECT_FORMAT)
     fun `check value parameters in functions (check - negative)`() {
         val code =
-                """
-                    fun foo(SOMENAME: String) {
-                    }
-                """.trimIndent()
+            """
+                fun foo(SOMENAME: String) {
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SOMENAME", true)
         )
@@ -224,11 +224,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tags(Tag(WarningNames.ENUM_VALUE), Tag(WarningNames.CLASS_NAME_INCORRECT))
     fun `check case for enum values (check - negative)`() {
         val code =
-                """
-                  enum class TEST_ONE {
+            """
+                enum class TEST_ONE {
                     first_value, secondValue, thirdVALUE, FourthValue
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
             LintError(2, 3, ruleId, "${ENUM_VALUE.warnText()} first_value", true),
@@ -246,11 +246,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 mapOf("enumStyle" to "pascalCase"))
         )
         val code =
-                """
-                  enum class TEST_ONE {
+            """
+                enum class TEST_ONE {
                     first_value, secondValue, thirdVALUE, FOURTH_VALUE
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
             LintError(2, 3, ruleId, "${ENUM_VALUE.warnText()} first_value", true),
@@ -265,10 +265,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.OBJECT_NAME_INCORRECT)
     fun `check case for object (check - negative)`() {
         val code =
-                """
-                  object TEST_ONE {
-                  }
-                """.trimIndent()
+            """
+                object TEST_ONE {
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 8, ruleId, "${OBJECT_NAME_INCORRECT.warnText()} TEST_ONE", true)
         )
@@ -279,9 +279,9 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.CLASS_NAME_INCORRECT)
     fun `check exception case format`() {
         val code =
-                """
-                    class incorrect_case_Exception(message: String) : Exception(message)
-                """.trimIndent()
+            """
+                class incorrect_case_Exception(message: String) : Exception(message)
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 7, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrect_case_Exception", true)
         )
@@ -291,9 +291,9 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.EXCEPTION_SUFFIX)
     fun `check exception case and suffix (with type call entry) - negative`() {
         val code =
-                """
-                    class Custom(message: String) : Exception(message)
-                """.trimIndent()
+            """
+                class Custom(message: String) : Exception(message)
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 7, ruleId, "${EXCEPTION_SUFFIX.warnText()} Custom", true)
         )
@@ -303,11 +303,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.EXCEPTION_SUFFIX)
     fun `check exception case and suffix (only parent name inheritance) - negative`() {
         val code =
-                """
-                    class Custom: Exception {
-                        constructor(msg: String) : super(msg)
-                    }
-                """.trimIndent()
+            """
+                class Custom: Exception {
+                    constructor(msg: String) : super(msg)
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 7, ruleId, "${EXCEPTION_SUFFIX.warnText()} Custom", true)
         )
@@ -317,10 +317,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.VARIABLE_HAS_PREFIX)
     fun `checking that there should be no prefixes in variable name`() {
         val code =
-                """
-                    const val M_GLOB = ""
-                    val aPrefix = ""
-                """.trimIndent()
+            """
+                const val M_GLOB = ""
+                val aPrefix = ""
+            """.trimIndent()
 
         lintMethod(code,
             LintError(1, 11, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} M_GLOB", true),
@@ -332,10 +332,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tags(Tag(WarningNames.VARIABLE_NAME_INCORRECT_FORMAT), Tag(WarningNames.VARIABLE_HAS_PREFIX))
     fun `regression - checking that digit in the end will not raise a warning`() {
         val code =
-                """
-                    val I_AM_CONSTANT1  = ""
-                    const val I_AM_CONSTANT2  = ""
-                """.trimIndent()
+            """
+                val I_AM_CONSTANT1  = ""
+                const val I_AM_CONSTANT2  = ""
+            """.trimIndent()
 
         lintMethod(code,
             LintError(1, 5, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} I_AM_CONSTANT1", true),
@@ -348,7 +348,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.VARIABLE_NAME_INCORRECT_FORMAT)
     fun `regression - destructing declaration in lambdas - incorrect case `() {
         val code =
-                """
+            """
                 private fun checkCommentedCode(node: ASTNode) {
                     val eolCommentsOffsetToText = ""
                     val blockCommentsOffsetToText = ""
@@ -357,7 +357,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                         ""
                     }
                 }
-                """.trimIndent()
+            """.trimIndent()
 
         lintMethod(code,
             LintError(5, 13, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} STRANGECASE", true)
@@ -368,14 +368,14 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.VARIABLE_NAME_INCORRECT_FORMAT)
     fun `regression - lambda argument - incorrect case`() {
         val code =
-                """
+            """
                 private fun checkCommentedCode(node: ASTNode) {
                     val eolCommentsOffsetToText = ""
                     eolCommentsOffsetToText.map { STRANGECASE ->
                         ""
                     }
                 }
-                """.trimIndent()
+            """.trimIndent()
 
         lintMethod(code,
             LintError(3, 35, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} STRANGECASE", true)
@@ -464,11 +464,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.IDENTIFIER_LENGTH)
     fun `regression - object parsing should not fail with anonymous objects`() {
         val code =
-                """
-                    val fakeVal = RuleSet("test", object : Rule("astnode-utils-test") {
-                                    override fun visit(node: ASTNode) {}
-                                   })
-                """.trimIndent()
+            """
+                val fakeVal = RuleSet("test", object : Rule("astnode-utils-test") {
+                                override fun visit(node: ASTNode) {}
+                                })
+            """.trimIndent()
 
         lintMethod(code)
     }
@@ -477,13 +477,13 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.IDENTIFIER_LENGTH)
     fun `exception case for identifier naming in catch statements`() {
         val code =
-                """
-                    fun foo() {
-                        try {
-                        } catch (e: IOException) {
-                        }
+            """
+                fun foo() {
+                    try {
+                    } catch (e: IOException) {
                     }
-                """.trimIndent()
+                }
+            """.trimIndent()
 
         lintMethod(code)
     }
@@ -492,15 +492,15 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.IDENTIFIER_LENGTH)
     fun `exception case for identifier naming in catch statements with catch body`() {
         val code =
-                """
-                    fun foo() {
-                        try {
-                        } catch (e: IOException) {
-                            fun foo(e: Int) {
-                            }
+            """
+                fun foo() {
+                    try {
+                    } catch (e: IOException) {
+                        fun foo(e: Int) {
                         }
                     }
-                """.trimIndent()
+                }
+            """.trimIndent()
 
         lintMethod(code, LintError(4, 17, ruleId, "${IDENTIFIER_LENGTH.warnText()} e", false))
     }
@@ -509,13 +509,13 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.IDENTIFIER_LENGTH)
     fun `exception case for identifier naming - catching exception with type e`() {
         val code =
-                """
-                    fun foo() {
-                        try {
-                        } catch (e: e) {
-                        }
+            """
+                fun foo() {
+                    try {
+                    } catch (e: e) {
                     }
-                """.trimIndent()
+                }
+            """.trimIndent()
 
         lintMethod(code)
     }
@@ -524,11 +524,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.BACKTICKS_PROHIBITED)
     fun `backticks should be used only with functions from tests (function)`() {
         val code =
-                """
-                    fun `foo function`(`argument with backstick`: String) {
-                        val `foo variable` = ""
-                    }
-                """.trimIndent()
+            """
+                fun `foo function`(`argument with backstick`: String) {
+                    val `foo variable` = ""
+                }
+            """.trimIndent()
 
         lintMethod(code,
             LintError(1, 5, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `foo function`"),
@@ -541,11 +541,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.BACKTICKS_PROHIBITED)
     fun `backticks should be used only with functions from tests (test method)`() {
         val code =
-                """                    
-                    @Test
-                    fun `test function with backstick`() {                        
-                    }
-                """.trimIndent()
+            """
+                @Test
+                fun `test function with backstick`() {
+                }
+            """.trimIndent()
 
         lintMethod(code)
     }
@@ -554,13 +554,13 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.BACKTICKS_PROHIBITED)
     fun `backticks should be used only with functions from tests (test method with variables)`() {
         val code =
-                """                    
-                    @Test
-                    fun `test function with backstick`() {
-                        val `should not be used` = ""
-                        
-                    }
-                """.trimIndent()
+            """
+                @Test
+                fun `test function with backstick`() {
+                    val `should not be used` = ""
+
+                }
+            """.trimIndent()
 
         lintMethod(code, LintError(3, 9, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `should not be used`"))
     }
@@ -569,9 +569,9 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.BACKTICKS_PROHIBITED)
     fun `backticks should be used only with functions from tests (class)`() {
         val code =
-                """
-                    class `my class name` {}
-                """.trimIndent()
+            """
+                class `my class name` {}
+            """.trimIndent()
 
         lintMethod(code, LintError(1, 7, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `my class name`"))
     }
@@ -592,28 +592,28 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.VARIABLE_NAME_INCORRECT_FORMAT)
     fun `should not trigger on underscore`() {
         val code =
-                """
-                    class SomeClass {
-                        fun bar() {
-                            val ast = list.map {(first, _) -> foo(first)}
-                            
-                            var meanValue: Int = 0
-                                for ((
-                                    _,
-                                    _,
-                                    year
-                                ) in cars) {
-                                    meanValue += year
-                                }
-                            
-                            try {
-                                /* ... */
-                            } catch (_: IOException) {
-                                /* ... */
+            """
+                class SomeClass {
+                    fun bar() {
+                        val ast = list.map {(first, _) -> foo(first)}
+
+                        var meanValue: Int = 0
+                            for ((
+                                _,
+                                _,
+                                year
+                            ) in cars) {
+                                meanValue += year
                             }
+
+                        try {
+                            /* ... */
+                        } catch (_: IOException) {
+                            /* ... */
                         }
                     }
-                """.trimIndent()
+                }
+            """.trimIndent()
 
         lintMethod(code)
     }
@@ -622,16 +622,16 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.CONFUSING_IDENTIFIER_NAMING)
     fun `confusing identifier naming`() {
         val code =
-                """
-                    fun someFunc() {
-                        val D = 0
-                        val Z = 2
-                    }
-                    
-                    enum class Ident {
-                        B
-                    }
-                """.trimIndent()
+            """
+                fun someFunc() {
+                    val D = 0
+                    val Z = 2
+                }
+
+                enum class Ident {
+                    B
+                }
+            """.trimIndent()
 
         lintMethod(code,
             LintError(2, 9, ruleId, "${CONFUSING_IDENTIFIER_NAMING.warnText()} better name is: obj, dgt", false),
@@ -648,17 +648,17 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.GENERIC_NAME)
     fun `check generic types`() {
         val code =
-                """
-                    interface Test<String>
-                    interface Test1<T: String>
-                    interface Test2<T : Collection<T>>
-                    interface Test3<out T>
-                    interface Test3<in T>
-                    interface Test4<in T, A, B>
-                    interface Test5<in T, A, Br>
-                    interface Test6<in Tr>
-                    interface Test6<Tr: String>
-                """.trimIndent()
+            """
+                interface Test<String>
+                interface Test1<T: String>
+                interface Test2<T : Collection<T>>
+                interface Test3<out T>
+                interface Test3<in T>
+                interface Test4<in T, A, B>
+                interface Test5<in T, A, Br>
+                interface Test6<in Tr>
+                interface Test6<Tr: String>
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 15, ruleId, "${GENERIC_NAME.warnText()} <String>", true),
             LintError(7, 16, ruleId, "${GENERIC_NAME.warnText()} <in T, A, Br>", true),

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -130,8 +130,8 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 class IncorrectNAME {}
             """
         lintMethod(code,
-            LintError(2, 27, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrectNAME", true),
-            LintError(3, 27, ruleId, "${CLASS_NAME_INCORRECT.warnText()} IncorrectNAME", true)
+            LintError(2, 23, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrectNAME", true),
+            LintError(3, 23, ruleId, "${CLASS_NAME_INCORRECT.warnText()} IncorrectNAME", true)
         )
     }
 
@@ -231,10 +231,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
             """.trimIndent()
         lintMethod(code,
             LintError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
-            LintError(2, 3, ruleId, "${ENUM_VALUE.warnText()} first_value", true),
-            LintError(2, 16, ruleId, "${ENUM_VALUE.warnText()} secondValue", true),
-            LintError(2, 29, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE", true),
-            LintError(2, 41, ruleId, "${ENUM_VALUE.warnText()} FourthValue", true)
+            LintError(2, 5, ruleId, "${ENUM_VALUE.warnText()} first_value", true),
+            LintError(2, 18, ruleId, "${ENUM_VALUE.warnText()} secondValue", true),
+            LintError(2, 31, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE", true),
+            LintError(2, 43, ruleId, "${ENUM_VALUE.warnText()} FourthValue", true)
         )
     }
 
@@ -253,10 +253,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
             """.trimIndent()
         lintMethod(code,
             LintError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
-            LintError(2, 3, ruleId, "${ENUM_VALUE.warnText()} first_value", true),
-            LintError(2, 16, ruleId, "${ENUM_VALUE.warnText()} secondValue", true),
-            LintError(2, 29, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE", true),
-            LintError(2, 41, ruleId, "${ENUM_VALUE.warnText()} FOURTH_VALUE", true),
+            LintError(2, 5, ruleId, "${ENUM_VALUE.warnText()} first_value", true),
+            LintError(2, 18, ruleId, "${ENUM_VALUE.warnText()} secondValue", true),
+            LintError(2, 31, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE", true),
+            LintError(2, 43, ruleId, "${ENUM_VALUE.warnText()} FOURTH_VALUE", true),
             rulesConfigList = rulesConfigPascalCaseEnum
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/MethodNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/MethodNamingWarnTest.kt
@@ -19,13 +19,13 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.FUNCTION_NAME_INCORRECT_CASE)
     fun `method name incorrect, part 1`() {
         val code =
-                """
-                  class SomeClass {
+            """
+                class SomeClass {
                     fun /* */ methODTREE(): String {
 
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code, LintError(2, 13, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
@@ -33,13 +33,13 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.FUNCTION_NAME_INCORRECT_CASE)
     fun `method name incorrect, part 2`() {
         val code =
-                """
-                  class TestPackageName {
+            """
+                class TestPackageName {
                     fun method_two(): String {
                         return ""
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code, LintError(2, 7, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} method_two", true))
     }
 
@@ -47,13 +47,13 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.FUNCTION_NAME_INCORRECT_CASE)
     fun `method name incorrect, part 3`() {
         val code =
-                """
-                    fun String.methODTREE(): String {
-                        fun TEST(): Unit {
-                            return ""
-                        }
+            """
+                fun String.methODTREE(): String {
+                    fun TEST(): Unit {
+                        return ""
                     }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 12, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true),
             LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} TEST", true)
@@ -64,12 +64,12 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.FUNCTION_NAME_INCORRECT_CASE)
     fun `method name incorrect, part 4`() {
         val code =
-                """
-                  class TestPackageName {
+            """
+                class TestPackageName {
                     fun methODTREE(): String {
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code, LintError(2, 7, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
@@ -77,12 +77,12 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.FUNCTION_NAME_INCORRECT_CASE)
     fun `method name incorrect, part 5`() {
         val code =
-                """
-                  class TestPackageName {
+            """
+                class TestPackageName {
                     fun methODTREE() {
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code, LintError(2, 7, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
@@ -90,11 +90,11 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.TYPEALIAS_NAME_INCORRECT_CASE)
     fun `typeAlias name incorrect, part 1`() {
         val code =
-                """
-                      class TestPackageName {
-                        typealias relatedClasses = List<Pair<String, String>>
-                      }
-                """.trimIndent()
+            """
+                class TestPackageName {
+                    typealias relatedClasses = List<Pair<String, String>>
+                }
+            """.trimIndent()
         lintMethod(code, LintError(2, 13, ruleId, "${TYPEALIAS_NAME_INCORRECT_CASE.warnText()} relatedClasses", true))
     }
 
@@ -114,11 +114,11 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
     @Tag(WarningNames.FUNCTION_BOOLEAN_PREFIX)
     fun `boolean method name incorrect`() {
         val code =
-                """
-                 fun someBooleanCheck(): Boolean {
-                     return false
-                 }
-                """.trimIndent()
+            """
+                fun someBooleanCheck(): Boolean {
+                    return false
+                }
+            """.trimIndent()
         lintMethod(code, LintError(1, 5, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} someBooleanCheck", true))
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/MethodNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/MethodNamingWarnTest.kt
@@ -26,7 +26,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 13, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
+        lintMethod(code, LintError(2, 15, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
     @Test
@@ -40,7 +40,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 7, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} method_two", true))
+        lintMethod(code, LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} method_two", true))
     }
 
     @Test
@@ -70,7 +70,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 7, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
+        lintMethod(code, LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
     @Test
@@ -83,7 +83,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 7, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
+        lintMethod(code, LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
     @Test
@@ -95,7 +95,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     typealias relatedClasses = List<Pair<String, String>>
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 13, ruleId, "${TYPEALIAS_NAME_INCORRECT_CASE.warnText()} relatedClasses", true))
+        lintMethod(code, LintError(2, 15, ruleId, "${TYPEALIAS_NAME_INCORRECT_CASE.warnText()} relatedClasses", true))
     }
 
     @Test

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
@@ -18,14 +18,14 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check white space before comment good`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |    // First Comment
-                    |    private val log = LoggerFactory.getLogger(Example.javaClass)
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |    // First Comment
+                |    private val log = LoggerFactory.getLogger(Example.javaClass)
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -34,20 +34,20 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check white space before comment bad 2`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |    val s = RulesConfig(WRONG_INDENTATION.name, true,
-                    |            mapOf(
-                    |                    "newlineAtEnd" to "true",     // comment
-                    |                    "extendedIndentOfParameters" to "true",
-                    |                    "alignedParameters" to "true",
-                    |                    "extendedIndentAfterOperators" to "true"
-                    |            )
-                    |    )
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |    val s = RulesConfig(WRONG_INDENTATION.name, true,
+                |            mapOf(
+                |                    "newlineAtEnd" to "true",     // comment
+                |                    "extendedIndentOfParameters" to "true",
+                |                    "alignedParameters" to "true",
+                |                    "extendedIndentAfterOperators" to "true"
+                |            )
+                |    )
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(6, 51, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but there are too many in // comment", true))
@@ -57,14 +57,14 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check white space before comment bad 3`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |@Suppress("RULE")    // asdasd
-                    |class Example {
-                    |
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |@Suppress("RULE")    // asdasd
+                |class Example {
+                |
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(3, 22, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but there are too many in // asdasd", true))
@@ -74,28 +74,28 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check white space before comment good2`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |/* This is a comment */
-                    |class Example {
-                    |    /**
-                    |    *
-                    |    * Some Comment
-                    |    */
-                    |    private val log = LoggerFactory.getLogger(Example.javaClass)
-                    |    
-                    |    fun a() {
-                    |       // When comment
-                    |       when(1) {
-                    |           1 -> print(1)
-                    |       }
-                    |    }
-                    |    /*
-                    |       Some Comment
-                    |    */
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |/* This is a comment */
+                |class Example {
+                |    /**
+                |    *
+                |    * Some Comment
+                |    */
+                |    private val log = LoggerFactory.getLogger(Example.javaClass)
+                |
+                |    fun a() {
+                |       // When comment
+                |       when(1) {
+                |           1 -> print(1)
+                |       }
+                |    }
+                |    /*
+                |       Some Comment
+                |    */
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -104,15 +104,15 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check comment before package good`() {
         val code =
-                """
-                    |// This is a comment before package
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |// This is a comment
-                    |class Example {
-                    |
-                    |}
-                """.trimMargin()
+            """
+                |// This is a comment before package
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |// This is a comment
+                |class Example {
+                |
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -121,20 +121,20 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check white space before comment bad`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |    //First Comment
-                    |    private val log = LoggerFactory.getLogger(Example.javaClass)
-                    |    
-                    |    /**
-                    |    *      Some comment
-                    |    */
-                    |    
-                    |    /*     Comment */
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |    //First Comment
+                |    private val log = LoggerFactory.getLogger(Example.javaClass)
+                |
+                |    /**
+                |    *      Some comment
+                |    */
+                |
+                |    /*     Comment */
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(4, 5, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 1 space(s) before comment token in //First Comment", true),
@@ -145,37 +145,37 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.WRONG_NEWLINES_AROUND_KDOC)
     fun `check new line above comment good`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |    private val log = LoggerFactory.getLogger(Example.javaClass)
-                    |    
-                    |    // Another Comment
-                    |    private val some = 5
-                    |    
-                    |    fun someFunc() {
-                    |       /* First comment */
-                    |       val first = 5  // Some comment
-                    |       
-                    |       /**
-                    |       * kDoc comment
-                    |       * some text
-                    |       */
-                    |       val second = 6
-                    |       
-                    |       /**
-                    |       * asdasd
-                    |       */
-                    |       fun testFunc() {
-                    |           val a = 5  // Some Comment
-                    |           
-                    |           // Fun in fun Block
-                    |           val b = 6
-                    |       }
-                    |    }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |    private val log = LoggerFactory.getLogger(Example.javaClass)
+                |
+                |    // Another Comment
+                |    private val some = 5
+                |
+                |    fun someFunc() {
+                |       /* First comment */
+                |       val first = 5  // Some comment
+                |
+                |       /**
+                |       * kDoc comment
+                |       * some text
+                |       */
+                |       val second = 6
+                |
+                |       /**
+                |       * asdasd
+                |       */
+                |       fun testFunc() {
+                |           val a = 5  // Some Comment
+                |
+                |           // Fun in fun Block
+                |           val b = 6
+                |       }
+                |    }
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -184,19 +184,19 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.WRONG_NEWLINES_AROUND_KDOC)
     fun `check file new line above comment good`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |// Some comment
-                    |class Example {
-                    |
-                    |}
-                    |
-                    |// Some comment 2
-                    |class AnotherExample {
-                    |
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |// Some comment
+                |class Example {
+                |
+                |}
+                |
+                |// Some comment 2
+                |class AnotherExample {
+                |
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -205,18 +205,18 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.WRONG_NEWLINES_AROUND_KDOC)
     fun `check file new line above comment bad`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |// Some comment
-                    |class Example {
-                    |
-                    |}
-                    |
-                    |// Some comment 2
-                    |class AnotherExample {
-                    |
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |// Some comment
+                |class Example {
+                |
+                |}
+                |
+                |// Some comment 2
+                |class AnotherExample {
+                |
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(2, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} // Some comment", true))
@@ -226,20 +226,20 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.WRONG_NEWLINES_AROUND_KDOC)
     fun `check file new line above comment bad - block and kDOC comments`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |/* Some comment */
-                    |class Example {
-                    |
-                    |}
-                    |/**
-                    |* Some comment 2
-                    |*/
-                    |
-                    |class AnotherExample {
-                    |
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |/* Some comment */
+                |class Example {
+                |
+                |}
+                |/**
+                |* Some comment 2
+                |*/
+                |
+                |class AnotherExample {
+                |
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(2, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} /* Some comment */", true),
@@ -251,14 +251,14 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check right side comments - good`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |/* Some comment */
-                    |class Example {
-                    |   val a = 5  // This is a comment
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |/* Some comment */
+                |class Example {
+                |   val a = 5  // This is a comment
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -267,14 +267,14 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check right side comments - bad`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |/* Some comment */
-                    |class Example {
-                    |   val a = 5// This is a comment
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |/* Some comment */
+                |class Example {
+                |   val a = 5// This is a comment
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(5, 13, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but are none in // This is a comment", true))
@@ -284,22 +284,22 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.IF_ELSE_COMMENTS)
     fun `if - else comments good`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |   fun someFunc() {
-                    |       // general if comment
-                    |       if(a = 5) {
-                    |       
-                    |       }
-                    |       else {
-                    |           // Good Comment
-                    |           print(5)
-                    |       }
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |   fun someFunc() {
+                |       // general if comment
+                |       if(a = 5) {
+                |
+                |       }
+                |       else {
+                |           // Good Comment
+                |           print(5)
+                |       }
+                |   }
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -308,20 +308,20 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.IF_ELSE_COMMENTS)
     fun `if - else comments good 2`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |   fun someFunc() {
-                    |       // general if comment
-                    |       if(a = 5) {
-                    |       
-                    |       } else
-                    |           // Good Comment
-                    |           print(5)
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |   fun someFunc() {
+                |       // general if comment
+                |       if(a = 5) {
+                |
+                |       } else
+                |           // Good Comment
+                |           print(5)
+                |   }
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -330,22 +330,22 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.IF_ELSE_COMMENTS)
     fun `if - else comments bad`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |   fun someFunc() {
-                    |       // general if comment
-                    |       if(a = 5) {
-                    |       
-                    |       }
-                    |       // Bad Comment
-                    |       else {
-                    |           print(5)
-                    |       }
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |   fun someFunc() {
+                |       // general if comment
+                |       if(a = 5) {
+                |
+                |       }
+                |       // Bad Comment
+                |       else {
+                |           print(5)
+                |       }
+                |   }
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} // Bad Comment", true))
@@ -355,20 +355,20 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.IF_ELSE_COMMENTS)
     fun `if - else comments bad 3`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |   fun someFunc() {
-                    |       // general if comment
-                    |       if(a = 5) {
-                    |       
-                    |       }  /* Some comment */ else {
-                    |           print(5)
-                    |       }
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |   fun someFunc() {
+                |       // general if comment
+                |       if(a = 5) {
+                |
+                |       }  /* Some comment */ else {
+                |           print(5)
+                |       }
+                |   }
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} /* Some comment */", true))
@@ -378,19 +378,19 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.IF_ELSE_COMMENTS)
     fun `if - else comments bad 4`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |   fun someFunc() {
-                    |       // general if comment
-                    |       if(a = 5) {
-                    |       
-                    |       }  /* Some comment */ else
-                    |           print(5)
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |   fun someFunc() {
+                |       // general if comment
+                |       if(a = 5) {
+                |
+                |       }  /* Some comment */ else
+                |           print(5)
+                |   }
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} /* Some comment */", true))
@@ -400,20 +400,20 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.IF_ELSE_COMMENTS)
     fun `should not trigger on comment`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |   fun someFunc() {
-                    |       // general if comment
-                    |       if(a = 5) {
-                    |           /* Some comment */
-                    |       } else {
-                    |           print(5)
-                    |       }
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |   fun someFunc() {
+                |       // general if comment
+                |       if(a = 5) {
+                |           /* Some comment */
+                |       } else {
+                |           print(5)
+                |       }
+                |   }
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -422,20 +422,20 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.FIRST_COMMENT_NO_BLANK_LINE)
     fun `first comment no space in if - else bad`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {
-                    |   fun someFunc() {
-                    |       // general if comment
-                    |       if(a = 5) {
-                    |       
-                    |       } else {  // Bad Comment 
-                    |           print(5)
-                    |       }
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |   fun someFunc() {
+                |       // general if comment
+                |       if(a = 5) {
+                |
+                |       } else {  // Bad Comment
+                |           print(5)
+                |       }
+                |   }
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(8, 18, ruleId, "${Warnings.FIRST_COMMENT_NO_BLANK_LINE.warnText()} // Bad Comment ", true))
@@ -445,14 +445,14 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check comment in class bad`() {
         val code =
-                """
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example { 
-                    |    // First Comment
-                    |    private val log = LoggerFactory.getLogger(Example.javaClass)  // secondComment
-                    |}
-                """.trimMargin()
+            """
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |    // First Comment
+                |    private val log = LoggerFactory.getLogger(Example.javaClass)  // secondComment
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }
@@ -461,15 +461,15 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check comment on file level`() {
         val code =
-                """
-                    | /*
-                    |  * heh
-                    |  */
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {                   
-                    |}
-                """.trimMargin()
+            """
+                | /*
+                |  * heh
+                |  */
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |}
+            """.trimMargin()
 
         lintMethod(code,
             LintError(1, 2, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 0 space(s) before comment text, but are 1 in /*...", true))
@@ -479,15 +479,15 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
     @Tag(WarningNames.COMMENT_WHITE_SPACE)
     fun `check comment on file level without space`() {
         val code =
-                """
-                    |/*
-                    |  * heh
-                    |  */
-                    |package org.cqfn.diktat.ruleset.chapter3
-                    |
-                    |class Example {                   
-                    |}
-                """.trimMargin()
+            """
+                |/*
+                |  * heh
+                |  */
+                |package org.cqfn.diktat.ruleset.chapter3
+                |
+                |class Example {
+                |}
+            """.trimMargin()
 
         lintMethod(code)
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
@@ -438,7 +438,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(8, 18, ruleId, "${Warnings.FIRST_COMMENT_NO_BLANK_LINE.warnText()} // Bad Comment ", true))
+            LintError(8, 18, ruleId, "${Warnings.FIRST_COMMENT_NO_BLANK_LINE.warnText()} // Bad Comment", true))
     }
 
     @Test

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocCommentsWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocCommentsWarnTest.kt
@@ -23,22 +23,22 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_TOP_LEVEL)
     fun `all public classes should be documented with KDoc`() {
         val code =
-                """
-                    class SomeGoodName {
-                        private class InternalClass {
-                        }
+            """
+                class SomeGoodName {
+                    private class InternalClass {
                     }
+                }
 
-                    public open class SomeOtherGoodName {
-                    }
+                public open class SomeOtherGoodName {
+                }
 
-                    open class SomeNewGoodName {
-                    }
+                open class SomeNewGoodName {
+                }
 
-                    public class SomeOtherNewGoodName {
-                    }
+                public class SomeOtherNewGoodName {
+                }
 
-                """.trimIndent()
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeGoodName"),
             LintError(6, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeOtherGoodName"),
@@ -51,10 +51,10 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_TOP_LEVEL)
     fun `all internal classes should be documented with KDoc`() {
         val code =
-                """
-                    internal class SomeGoodName {
-                    }
-                """.trimIndent()
+            """
+                internal class SomeGoodName {
+                }
+            """.trimIndent()
         lintMethod(code, LintError(
             1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeGoodName")
         )
@@ -64,16 +64,16 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_TOP_LEVEL)
     fun `all internal and public functions on top-level should be documented with Kdoc`() {
         val code =
-                """
-                    fun someGoodName() {
-                    }
+            """
+                fun someGoodName() {
+                }
 
-                    internal fun someGoodNameNew(): String {
-                        return " ";
-                    }
-                    
-                    fun main() {}
-                """.trimIndent()
+                internal fun someGoodNameNew(): String {
+                    return " ";
+                }
+                
+                fun main() {}
+            """.trimIndent()
         lintMethod(code,
             LintError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} someGoodName"),
             LintError(4, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} someGoodNameNew")
@@ -84,10 +84,10 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_TOP_LEVEL)
     fun `all internal and public functions on top-level should be documented with Kdoc (positive case)`() {
         val code =
-                """
-                    private fun someGoodName() {
-                    }
-                """.trimIndent()
+            """
+                private fun someGoodName() {
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
@@ -95,10 +95,10 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_TOP_LEVEL)
     fun `positive Kdoc case with private class`() {
         val code =
-                """
-                    private class SomeGoodName {
-                    }
-                """.trimIndent()
+            """
+                private class SomeGoodName {
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
@@ -106,28 +106,28 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_CLASS_ELEMENTS)
     fun `Kdoc should present for each class element`() {
         val code =
-                """
-                    /**
-                    * class that contains fields, functions and public subclasses
-                    **/
-                    class SomeGoodName {
-                        val variable: String = ""
-                        private val privateVariable: String = ""
-                        fun perfectFunction() {
-                        }
-
-                        private fun privateFunction() {
-                        }
-
-                        class InternalClass {
-                        }
-
-                        private class InternalClass {
-                        }
-                        
-                        public fun main() {}
+            """
+                /**
+                * class that contains fields, functions and public subclasses
+                **/
+                class SomeGoodName {
+                    val variable: String = ""
+                    private val privateVariable: String = ""
+                    fun perfectFunction() {
                     }
-                """.trimIndent()
+
+                    private fun privateFunction() {
+                    }
+
+                    class InternalClass {
+                    }
+
+                    private class InternalClass {
+                    }
+                    
+                    public fun main() {}
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(5, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} variable"),
             LintError(7, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} perfectFunction"),
@@ -139,29 +139,29 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_CLASS_ELEMENTS)
     fun `Kdoc shouldn't not be mandatory for overridden functions and props`() {
         val code =
-                """
-                    /**
-                    * class that contains fields, functions and public subclasses
-                    **/
-                    class SomeGoodName : Another {
-                        val variable: String = ""
-                        private val privateVariable: String = ""
-                        override val someVal: String = ""
-                        fun perfectFunction() {
-                        }
-
-                        override fun overrideFunction() {
-                        }
-
-                        class InternalClass {
-                        }
-
-                        private class InternalClass {
-                        }
-                        
-                        public fun main() {}
+            """
+                /**
+                * class that contains fields, functions and public subclasses
+                **/
+                class SomeGoodName : Another {
+                    val variable: String = ""
+                    private val privateVariable: String = ""
+                    override val someVal: String = ""
+                    fun perfectFunction() {
                     }
-                """.trimIndent()
+
+                    override fun overrideFunction() {
+                    }
+
+                    class InternalClass {
+                    }
+
+                    private class InternalClass {
+                    }
+                    
+                    public fun main() {}
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(5, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} variable"),
             LintError(8, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} perfectFunction"),
@@ -200,37 +200,37 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
     @Tag(WarningNames.MISSING_KDOC_CLASS_ELEMENTS)
     fun `Kdoc should present for each class element (positive)`() {
         val code =
-                """
+            """
+                /**
+                * class that contains fields, functions and public subclasses
+                **/
+                class SomeGoodName {
                     /**
                     * class that contains fields, functions and public subclasses
                     **/
-                    class SomeGoodName {
-                        /**
-                        * class that contains fields, functions and public subclasses
-                        **/
-                        val variable: String = ""
+                    val variable: String = ""
 
-                        private val privateVariable: String = ""
+                    private val privateVariable: String = ""
 
-                        /**
-                        * class that contains fields, functions and public subclasses
-                        **/
-                        fun perfectFunction() {
-                        }
-
-                        private fun privateFunction() {
-                        }
-
-                        /**
-                        * class that contains fields, functions and public subclasses
-                        **/
-                        class InternalClass {
-                        }
-
-                        private class InternalClass {
-                        }
+                    /**
+                    * class that contains fields, functions and public subclasses
+                    **/
+                    fun perfectFunction() {
                     }
-                """.trimIndent()
+
+                    private fun privateFunction() {
+                    }
+
+                    /**
+                    * class that contains fields, functions and public subclasses
+                    **/
+                    class InternalClass {
+                    }
+
+                    private class InternalClass {
+                    }
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BlockStructureBracesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BlockStructureBracesWarnTest.kt
@@ -48,22 +48,22 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
     @Tag(WarningNames.BRACES_BLOCK_STRUCTURE_ERROR)
     fun `correct if expression without else`() {
         val withBrace =
-                """
-                    |fun foo() {
-                    |   if (x > 5) {
-                    |       x--
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |fun foo() {
+                |   if (x > 5) {
+                |       x--
+                |   }
+                |}
+            """.trimMargin()
         lintMethod(withBrace)
 
         val withoutBrace =
-                """
-                    |fun foo() {
-                    |   if (x > 5)
-                    |       x--
-                    |}
-                """.trimMargin()
+            """
+                |fun foo() {
+                |   if (x > 5)
+                |       x--
+                |}
+            """.trimMargin()
         lintMethod(withoutBrace)
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
@@ -24,11 +24,11 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
             mapOf("lineLength" to "40"))
     )
     private val wrongUrl = "dhttps://www.google.com/search?q=djfhvkdfhvkdh+gthtdj%" +
-            "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
-            "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
+        "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
+        "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
     private val correctUrl = "https://www.google.com/search?q=djfhvkdfhvkdh+gthtdj%" +
-            "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
-            "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
+        "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
+        "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
 
     @Test
     @Tag(WarningNames.LONG_LINE)

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringConcatenationWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringConcatenationWarnTest.kt
@@ -23,7 +23,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " \"my string\" + \"string\" + value + \"other value\"", canBeAutoCorrected)
+                " \"my string\" + \"string\" + value + \"other value\"", canBeAutoCorrected)
         )
     }
 
@@ -36,7 +36,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " \"my string\" + 1 + 2 + 3", canBeAutoCorrected)
+                " \"my string\" + 1 + 2 + 3", canBeAutoCorrected)
         )
     }
 
@@ -50,7 +50,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " (1 + 2).toString() + \"my string\" + 3", canBeAutoCorrected)
+                " (1 + 2).toString() + \"my string\" + 3", canBeAutoCorrected)
         )
     }
 
@@ -64,7 +64,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " (1 + 2).toString() + \"my string\" + 3 + \"string\" + myObject + myObject", canBeAutoCorrected)
+                " (1 + 2).toString() + \"my string\" + 3 + \"string\" + myObject + myObject", canBeAutoCorrected)
         )
     }
 
@@ -78,7 +78,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " (1 + 2).toString() + \"my string\" + (\"string\" + myObject) + myObject", canBeAutoCorrected)
+                " (1 + 2).toString() + \"my string\" + (\"string\" + myObject) + myObject", canBeAutoCorrected)
         )
     }
 
@@ -92,7 +92,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | }
                 """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
+                " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
 
@@ -106,7 +106,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
+                " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
 
@@ -120,7 +120,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + 2 + 3)", canBeAutoCorrected)
+                " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
 
@@ -133,8 +133,8 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + (2 + 3)) +" +
-                    " (\"third string\" + (\"str\" + 5))", canBeAutoCorrected)
+                " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + (2 + 3)) +" +
+                " (\"third string\" + (\"str\" + 5))", canBeAutoCorrected)
         )
     }
 
@@ -147,7 +147,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
                 """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                    " \"my string\" + (\"third string\" + (\"str\" + 5 * 12 / 100))", canBeAutoCorrected)
+                " \"my string\" + (\"third string\" + (\"str\" + 5 * 12 / 100))", canBeAutoCorrected)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/BlankLinesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/BlankLinesWarnTest.kt
@@ -14,7 +14,7 @@ class BlankLinesWarnTest : LintTestBase(::BlankLinesRule) {
     private val ruleId = "$DIKTAT_RULE_SET_ID:${BlankLinesRule.NAME_ID}"
     private val consecutiveLinesWarn = "${TOO_MANY_BLANK_LINES.warnText()} do not use more than two consecutive blank lines"
     private fun blankLinesInBlockWarn(isBeginning: Boolean) =
-            "${TOO_MANY_BLANK_LINES.warnText()} do not put newlines ${if (isBeginning) "in the beginning" else "at the end"} of code blocks"
+        "${TOO_MANY_BLANK_LINES.warnText()} do not put newlines ${if (isBeginning) "in the beginning" else "at the end"} of code blocks"
 
     @Test
     @Tag(WarningNames.TOO_MANY_BLANK_LINES)

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
@@ -341,7 +341,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |}
             """.trimMargin(),
             LintError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                    "should be aligned with it in declaration of <foo>", true),
+                "should be aligned with it in declaration of <foo>", true),
             LintError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <foo>", true)
         )
     }
@@ -688,13 +688,13 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |) { }
             """.trimMargin(),
             LintError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                    "should be aligned with it in declaration of <Foo>", true),
+                "should be aligned with it in declaration of <Foo>", true),
             LintError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
             LintError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                    "should be aligned with it in declaration of <Foo>", true),
+                "should be aligned with it in declaration of <Foo>", true),
             LintError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
             LintError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (arg1) should be placed on the new line or " +
-                    "all other parameters should be aligned with it", true),
+                "all other parameters should be aligned with it", true),
             LintError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true)
         )
     }
@@ -720,7 +720,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |) { }
             """.trimMargin(),
             LintError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                    "should be aligned with it in declaration of <bar>", true),
+                "should be aligned with it in declaration of <bar>", true),
             LintError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <bar>", true)
         )
     }
@@ -765,7 +765,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |}
             """.trimMargin(),
             LintError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (\"id\") should be placed on the new line or " +
-                    "all other parameters should be aligned with it", true),
+                "all other parameters should be aligned with it", true),
             LintError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true),
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
@@ -17,7 +17,8 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
                 "newlineAtEnd" to "true",  // expected file should have two newlines at end in order to be read by BufferedReader correctly
                 "extendedIndentOfParameters" to "true",
                 "alignedParameters" to "true",
-                "extendedIndentAfterOperators" to "true"
+                "extendedIndentAfterOperators" to "true",
+                "extendedIndentBeforeDot" to "true",
             )
         )
     )

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
@@ -114,8 +114,8 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |class Example {
                     |    private val foo = 0
                     |    private val fuu =
-                    |            0
-                    |    
+                    |        0
+                    |
                     |    fun bar() {
                     |        if (foo > 0) {
                     |            baz()
@@ -229,11 +229,11 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |    val a = list.filter {
                     |        predicate(it)
                     |    }
-                    |    
+                    |
                     |    val b =
-                    |            list.filter { 
-                    |                predicate(it)
-                    |            }
+                    |        list.filter { 
+                    |            predicate(it)
+                    |        }
                     |}
                     |
                 """.trimMargin()
@@ -249,11 +249,11 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |    val a = { x: Int ->
                     |        x * 2
                     |    }
-                    |    
+                    |
                     |    val b =
-                    |            { x: Int ->
-                    |                x * 2
-                    |            }
+                    |        { x: Int ->
+                    |            x * 2
+                    |        }
                     |}
                     |
                 """.trimMargin()
@@ -284,18 +284,18 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             """
                     |fun foo() {
                     |    Integer
-                    |            .valueOf(2).also {
-                    |                println(it)
-                    |            }
-                    |            ?.also {
-                    |                println("Also with safe access")
-                    |            }
-                    |            ?: Integer.valueOf(0)
+                    |        .valueOf(2).also {
+                    |            println(it)
+                    |        }
+                    |        ?.also {
+                    |            println("Also with safe access")
+                    |        }
+                    |        ?: Integer.valueOf(0)
                     |
                     |    bar
-                    |            .baz()
-                    |            as Baz
-                    |            as? Baz
+                    |        .baz()
+                    |        as Baz
+                    |        as? Baz
                     |}
                     |
                 """.trimMargin()
@@ -492,7 +492,7 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |            elem.qux()
                     |        },
                     |        param3 = x
-                    |                .y()
+                    |            .y()
                     |    )
                     |}
                     |
@@ -587,28 +587,28 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             """
                     |fun foo() {
                     |    list
-                    |            .map(::foo)
-                    |            // comment about the next call
-                    |            .filter { it.bar() }
-                    |            // another comment about the next call
-                    |            ?.filter { it.bar() }
-                    |            ?.count()
-                    |    
+                    |        .map(::foo)
+                    |        // comment about the next call
+                    |        .filter { it.bar() }
+                    |        // another comment about the next call
+                    |        ?.filter { it.bar() }
+                    |        ?.count()
+                    |
                     |    list.any { predicate(it) } &&
-                    |            list.any {
-                    |                predicate(it)
-                    |            }
-                    |    
+                    |        list.any {
+                    |            predicate(it)
+                    |        }
+                    |
                     |    list.any { predicate(it) } &&
-                    |            // comment
-                    |            list.any {
-                    |                predicate(it)
-                    |            }
-                    |    
+                    |        // comment
+                    |        list.any {
+                    |            predicate(it)
+                    |        }
+                    |
                     |    list.filter {
                     |        predicate(it) &&
-                    |                // comment
-                    |                predicate(it)
+                    |            // comment
+                    |            predicate(it)
                     |    }
                     |}
                     |
@@ -639,9 +639,9 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             """
                     |fun foo() {
                     |    return x +
-                    |            (y +
-                    |                    foo(x)
-                    |            )
+                    |        (y +
+                    |            foo(x)
+                    |        )
                     |}
                     |
                 """.trimMargin()

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/WhiteSpaceRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/WhiteSpaceRuleWarnTest.kt
@@ -16,7 +16,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
     private val eolSpaceWarn = "${WRONG_WHITESPACE.warnText()} there should be no spaces in the end of line"
     private val lbraceWarn = "${WRONG_WHITESPACE.warnText()} there should be a whitespace before '{'"
     private fun keywordWarn(keyword: String, sep: String) =
-            "${WRONG_WHITESPACE.warnText()} keyword '$keyword' should be separated from '$sep' with a whitespace"
+        "${WRONG_WHITESPACE.warnText()} keyword '$keyword' should be separated from '$sep' with a whitespace"
 
     private fun tokenWarn(token: String,
                           before: Int?,
@@ -24,13 +24,13 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                           reqBefore: Int?,
                           reqAfter: Int?
     ) = "${WRONG_WHITESPACE.warnText()} $token should have" +
-            (reqBefore?.let { " $it space(s) before" } ?: "") +
-            (if (reqBefore != null && reqAfter != null) " and" else "") +
-            (reqAfter?.let { " $it space(s) after" } ?: "") +
-            ", but has" +
-            (before?.let { " $it space(s) before" } ?: "") +
-            (if (before != null && after != null) " and" else "") +
-            (after?.let { " $it space(s) after" } ?: "")
+        (reqBefore?.let { " $it space(s) before" } ?: "") +
+        (if (reqBefore != null && reqAfter != null) " and" else "") +
+        (reqAfter?.let { " $it space(s) after" } ?: "") +
+        ", but has" +
+        (before?.let { " $it space(s) before" } ?: "") +
+        (if (before != null && after != null) " and" else "") +
+        (after?.let { " $it space(s) after" } ?: "")
 
     @Test
     @Tag(WarningNames.WRONG_WHITESPACE)

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NullChecksRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NullChecksRuleWarnTest.kt
@@ -47,7 +47,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
                 """.trimMargin(),
             LintError(3, 11, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                    " use '.let/.also/?:/e.t.c' instead of myVar == null", true),
+                " use '.let/.also/?:/e.t.c' instead of myVar == null", true),
         )
     }
 
@@ -64,7 +64,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
                 """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                    " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
+                " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
         )
     }
 
@@ -83,7 +83,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
                 """.trimMargin(),
             LintError(2, 27, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                    " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
+                " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
         )
     }
 
@@ -101,7 +101,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
                 """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                    " use '.let/.also/?:/e.t.c' instead of myVar !== null", true),
+                " use '.let/.also/?:/e.t.c' instead of myVar !== null", true),
         )
     }
 
@@ -172,7 +172,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
                 """.trimMargin(),
             LintError(2, 10, ruleId, "${Warnings.AVOID_NULL_CHECKS.warnText()} use '.let/.also/?:/e.t.c'" +
-                    " instead of myVar != null", true),
+                " instead of myVar != null", true),
         )
     }
 
@@ -186,7 +186,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
                 """.trimMargin(),
             LintError(2, 14, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                    " use 'requireNotNull' instead of require(myVar != null)", true),
+                " use 'requireNotNull' instead of require(myVar != null)", true),
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -203,7 +203,7 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
             LintError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
             LintError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
             LintError(9, 3, "$DIKTAT_RULE_SET_ID:${EmptyBlock.NAME_ID}", EMPTY_BLOCK_STRUCTURE_ERROR.warnText() +
-                    " empty blocks are forbidden unless it is function with override keyword", false),
+                " empty blocks are forbidden unless it is function with override keyword", false),
             LintError(12, 10, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
             LintError(14, 8, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
             LintError(19, 20, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false)
@@ -240,7 +240,7 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
         fixAndCompareSmokeTest("kotlin-library-expected.gradle.kts", "kotlin-library.gradle.kts")
         Assertions.assertEquals(
             LintError(2, 1, "$DIKTAT_RULE_SET_ID:${CommentsRule.NAME_ID}", "[COMMENTED_OUT_CODE] you should not comment out code, " +
-                    "use VCS to save it in history and delete this block: import org.jetbrains.kotlin.gradle.dsl.jvm", false),
+                "use VCS to save it in history and delete this block: import org.jetbrains.kotlin.gradle.dsl.jvm", false),
             unfixedLintErrors.single()
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -12,6 +12,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.KDOC_WITHOUT_PARAM_TAG
 import org.cqfn.diktat.ruleset.constants.Warnings.MISSING_KDOC_CLASS_ELEMENTS
 import org.cqfn.diktat.ruleset.constants.Warnings.MISSING_KDOC_ON_FUNCTION
 import org.cqfn.diktat.ruleset.constants.Warnings.MISSING_KDOC_TOP_LEVEL
+import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
 import org.cqfn.diktat.ruleset.rules.DIKTAT_RULE_SET_ID
 import org.cqfn.diktat.ruleset.rules.DiktatRuleSetProvider
 import org.cqfn.diktat.ruleset.rules.chapter1.FileNaming
@@ -37,10 +38,8 @@ import org.junit.jupiter.api.Test
 import java.io.File
 import java.time.LocalDate
 
-import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempFile
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.encodeToString
 
 typealias RuleToConfig = Map<String, Map<String, String>>
 
@@ -49,7 +48,6 @@ typealias RuleToConfig = Map<String, Map<String, String>>
  * Note: ktlint uses initial text from a file to calculate line and column from offset. Because of that line/col of unfixed errors
  * may change after some changes to text or other rules.
  */
-@OptIn(ExperimentalPathApi::class)
 class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
     { DiktatRuleSetProvider(configFilePath) },
     { lintError, _ -> unfixedLintErrors.add(lintError) },
@@ -123,6 +121,15 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
     @Test
     @Tag("DiktatRuleSetProvider")
     fun `smoke test #6`() {
+        overrideRulesConfig(
+            rulesToDisable = emptyList(),
+            rulesToOverride = mapOf(
+                WRONG_INDENTATION.name to mapOf(
+                    "extendedIndentAfterOperators" to "true",
+                    "extendedIndentBeforeDot" to "true",
+                )
+            )
+        )
         fixAndCompareSmokeTest("Example6Expected.kt", "Example6Test.kt")
     }
 
@@ -161,6 +168,15 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
     @Test
     @Tag("DiktatRuleSetProvider")
     fun `smoke test #4`() {
+        overrideRulesConfig(
+            rulesToDisable = emptyList(),
+            rulesToOverride = mapOf(
+                WRONG_INDENTATION.name to mapOf(
+                    "extendedIndentAfterOperators" to "true",
+                    "extendedIndentBeforeDot" to "false",
+                )
+            )
+        )
         fixAndCompareSmokeTest("Example4Expected.kt", "Example4Test.kt")
     }
 
@@ -179,6 +195,15 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
     @Test
     @Tag("DiktatRuleSetProvider")
     fun `smoke test #2`() {
+        overrideRulesConfig(
+            rulesToDisable = emptyList(),
+            rulesToOverride = mapOf(
+                WRONG_INDENTATION.name to mapOf(
+                    "extendedIndentAfterOperators" to "true",
+                    "extendedIndentBeforeDot" to "true",
+                )
+            )
+        )
         fixAndCompareSmokeTest("Example2Expected.kt", "Example2Test.kt")
         unfixedLintErrors.assertEquals(
             LintError(1, 1, "$DIKTAT_RULE_SET_ID:${HeaderCommentRule.NAME_ID}",
@@ -193,6 +218,15 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
     @Test
     @Tag("DiktatRuleSetProvider")
     fun `smoke test #1`() {
+        overrideRulesConfig(
+            rulesToDisable = emptyList(),
+            rulesToOverride = mapOf(
+                WRONG_INDENTATION.name to mapOf(
+                    "extendedIndentAfterOperators" to "true",
+                    "extendedIndentBeforeDot" to "false",
+                )
+            )
+        )
         fixAndCompareSmokeTest("Example1Expected.kt", "Example1Test.kt")
         unfixedLintErrors.assertEquals(
             LintError(1, 1, "$DIKTAT_RULE_SET_ID:${FileNaming.NAME_ID}", "${FILE_NAME_MATCH_CLASS.warnText()} Example1Test.kt vs Example", true),
@@ -216,7 +250,7 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
         overrideRulesConfig(
             emptyList(),
             mapOf(
-                Warnings.WRONG_INDENTATION.name to mapOf(
+                WRONG_INDENTATION.name to mapOf(
                     "newlineAtEnd" to "false",
                     "extendedIndentOfParameters" to "false",
                 )

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/AvailableRulesDocTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/AvailableRulesDocTest.kt
@@ -19,7 +19,7 @@ class AvailableRulesDocTest {
             val ruleName = splitMarkDown[SPLIT_MARK].trim()
 
             if (!ruleName.startsWith(TABLE_DELIMITER) &&
-                    !ruleName.startsWith(RULE_NAME_HEADER)) {
+                !ruleName.startsWith(RULE_NAME_HEADER)) {
                 listWithRulesFromDoc.add(ruleName)
             }
         }
@@ -36,7 +36,7 @@ class AvailableRulesDocTest {
             val ruleFound = allRulesFromDoc.find { it.trim() == ruleName } != null
             Assertions.assertTrue(ruleFound) {
                 val docs = "| | | $ruleName" +
-                        "|  |  |  | |"
+                    "|  |  |  | |"
                 """
                     Cannot find warning $ruleName in $AVAILABLE_RULES_FILE.
                     You can fix it by adding the following description below with more info to $AVAILABLE_RULES_FILE:

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/RulesConfigYamlTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/RulesConfigYamlTest.kt
@@ -23,9 +23,9 @@ import kotlinx.serialization.encodeToString
 class RulesConfigYamlTest {
     private val parentDiktatAnalysis = "${System.getProperty("user.dir")}${File.separator}..${File.separator}diktat-analysis.yml${File.separator}"
     private val pathMap: Map<String, String> =
-            mapOf("diktat-analysis.yml" to "diKTat/diktat-rules/src/main/resources/diktat-analysis.yml",
-                "diktat-analysis-huawei.yml" to "diKTat/diktat-rules/src/main/resources/diktat-analysis-huawei.yml",
-                parentDiktatAnalysis to "diKTat/diktat-analysis.yml")
+        mapOf("diktat-analysis.yml" to "diKTat/diktat-rules/src/main/resources/diktat-analysis.yml",
+            "diktat-analysis-huawei.yml" to "diKTat/diktat-rules/src/main/resources/diktat-analysis-huawei.yml",
+            parentDiktatAnalysis to "diKTat/diktat-analysis.yml")
 
     @Test
     fun `read rules config yml`() {
@@ -108,9 +108,9 @@ class RulesConfigYamlTest {
     }
 
     private fun readAllRulesFromConfig(nameConfig: String) =
-            RulesConfigReader(javaClass.classLoader)
-                .readResource(nameConfig) ?: emptyList()
+        RulesConfigReader(javaClass.classLoader)
+            .readResource(nameConfig) ?: emptyList()
 
     private fun readAllRulesFromCode() =
-            Warnings.values()
+        Warnings.values()
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressAnnotatedExpressionTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressAnnotatedExpressionTest.kt
@@ -14,17 +14,17 @@ class SuppressAnnotatedExpressionTest : LintTestBase(::CollapseIfStatementsRule)
     @Test
     fun `should lint errors without suppress`() {
         val code =
-                """
-                    |fun foo() {
-                    |   if (true) {
-                    |       if (true) {
-                    |           if (true) {
-                    |
-                    |           }
-                    |       }
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |fun foo() {
+                |   if (true) {
+                |       if (true) {
+                |           if (true) {
+                |
+                |           }
+                |       }
+                |   }
+                |}
+            """.trimMargin()
         lintMethod(code,
             LintError(3, 8, ruleId, "${Warnings.COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
             LintError(4, 12, ruleId, "${Warnings.COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
@@ -34,18 +34,18 @@ class SuppressAnnotatedExpressionTest : LintTestBase(::CollapseIfStatementsRule)
     @Test
     fun `should suppress annotated expressions`() {
         val code =
-                """
-                    |fun foo() {
-                    |   if (true) {
-                    |       @Suppress("COLLAPSE_IF_STATEMENTS")
-                    |       if (true) {
-                    |           if (true) {
-                    |
-                    |           }
-                    |       }
-                    |   }
-                    |}
-                """.trimMargin()
+            """
+                |fun foo() {
+                |   if (true) {
+                |       @Suppress("COLLAPSE_IF_STATEMENTS")
+                |       if (true) {
+                |           if (true) {
+                |
+                |           }
+                |       }
+                |   }
+                |}
+            """.trimMargin()
         lintMethod(code)
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressTest.kt
@@ -14,16 +14,16 @@ class SuppressTest : LintTestBase(::IdentifierNaming) {
     @Test
     fun `test suppress on class`() {
         val code =
-                """
-                  @Suppress("FUNCTION_NAME_INCORRECT_CASE", "BACKTICKS_PROHIBITED")
-                  class SomeClass {
+            """
+                @Suppress("FUNCTION_NAME_INCORRECT_CASE", "BACKTICKS_PROHIBITED")
+                class SomeClass {
                     fun /* */ methODTREE(): String {
 
                     }
-                    
+
                     fun `some`() {}
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
@@ -71,44 +71,44 @@ class SuppressTest : LintTestBase(::IdentifierNaming) {
     @Test
     fun `test suppress on file`() {
         val code =
-                """
-                  @file:Suppress("FUNCTION_NAME_INCORRECT_CASE")
+            """
+                @file:Suppress("FUNCTION_NAME_INCORRECT_CASE")
 
-                  class SomeClass {
+                class SomeClass {
                     fun /* */ methODTREE(): String {
 
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
     @Test
     fun `test suppress field`() {
         val code =
-                """
-                  class SomeClass(@field:Suppress("IDENTIFIER_LENGTH") val a:String) {
+            """
+                class SomeClass(@field:Suppress("IDENTIFIER_LENGTH") val a:String) {
                     fun /* */ method(): String {
 
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
     @Test
     fun `test suppress field with set`() {
         val code =
-                """
-                  class SomeClass() {
+            """
+                class SomeClass() {
                     @set:[Suppress("IDENTIFIER_LENGTH") Inject]
                     val a = 5
-                  
+                
                     fun /* */ method(): String {
 
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
@@ -131,14 +131,14 @@ class SuppressTest : LintTestBase(::IdentifierNaming) {
     @Test
     fun `test suppress on class bad`() {
         val code =
-                """
-                  @Suppress()
-                  class SomeClass {
+            """
+                @Suppress()
+                class SomeClass {
                     fun /* */ methODTREE(): String {
 
                     }
-                  }
-                """.trimIndent()
+                }
+            """.trimIndent()
         lintMethod(code,
             LintError(3, 13, "$DIKTAT_RULE_SET_ID:aai-identifier-naming",
                 "${Warnings.FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressTest.kt
@@ -140,7 +140,7 @@ class SuppressTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(3, 13, "$DIKTAT_RULE_SET_ID:aai-identifier-naming",
+            LintError(3, 15, "$DIKTAT_RULE_SET_ID:aai-identifier-naming",
                 "${Warnings.FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/SuppressingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/SuppressingTest.kt
@@ -32,55 +32,55 @@ class SuppressingTest : LintTestBase(::IdentifierNaming) {
     @Test
     fun `checking that suppression with ignoredAnnotation works`() {
         val code =
-                """
-                    @MySuperSuppress()
-                    fun foo() {
-                        val a = 1
-                    }
-                """.trimIndent()
+            """
+                @MySuperSuppress()
+                fun foo() {
+                    val a = 1
+                }
+            """.trimIndent()
         lintMethod(code, rulesConfigList = rulesConfigBooleanFunctions)
     }
 
     @Test
     fun `checking that suppression with ignore everything works`() {
         val code =
-                """
-                    @Suppress("diktat")
-                    fun foo() {
-                        val a = 1
-                    }
-                """.trimIndent()
+            """
+                @Suppress("diktat")
+                fun foo() {
+                    val a = 1
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
     @Test
     fun `checking that suppression with a targeted inspection name works`() {
         val code =
-                """
-                    @Suppress("IDENTIFIER_LENGTH")
-                    fun foo() {
-                        val a = 1
-                    }
-                """.trimIndent()
+            """
+                @Suppress("IDENTIFIER_LENGTH")
+                fun foo() {
+                    val a = 1
+                }
+            """.trimIndent()
         lintMethod(code)
     }
 
     @Test
     fun `negative scenario for other annotation`() {
         val code =
-                """
-                    @MySuperSuppress111()
-                    fun foo() {
-                        val a = 1
-                    }
-                """.trimIndent()
+            """
+                @MySuperSuppress111()
+                fun foo() {
+                    val a = 1
+                }
+            """.trimIndent()
         lintMethod(
             code,
             LintError(3,
                 9,
                 ruleId,
                 "[IDENTIFIER_LENGTH] identifier's length is incorrect, it" +
-                        " should be in range of [2, 64] symbols: a", false),
+                    " should be in range of [2, 64] symbols: a", false),
             rulesConfigList = rulesConfigBooleanFunctions,
         )
     }

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/config/TestConfig.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/config/TestConfig.kt
@@ -31,7 +31,7 @@ class TestConfig internal constructor(
 
     // FixMe: not used by for now, fix the description when the class will be ready
     override fun toString() =
-            """(executionCommand: $executionCommand, expectedResultFile: $expectedResultFile, inPlace: $inPlace,
+        """(executionCommand: $executionCommand, expectedResultFile: $expectedResultFile, inPlace: $inPlace,
                     executionType: $executionCommand)"""
 
     /**

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestProcessingFactory.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestProcessingFactory.kt
@@ -27,7 +27,7 @@ class TestProcessingFactory(private val argReader: TestArgumentsReader) {
             ?.let { File(it.file) }
             ?: run {
                 log.error("Not able to get directory with test configuration files: " +
-                        argReader.properties.testConfigsRelativePath)
+                    argReader.properties.testConfigsRelativePath)
                 exitProcess(STATUS_FIVE)
             }
         try {
@@ -57,7 +57,7 @@ class TestProcessingFactory(private val argReader: TestArgumentsReader) {
         }
 
         val testStream: Stream<String> =
-                if (argReader.properties.isParallelMode) testList.parallelStream() else testList.stream()
+            if (argReader.properties.isParallelMode) testList.parallelStream() else testList.stream()
 
         testStream
             .map { test: String -> findTestInResources(test) }
@@ -71,9 +71,9 @@ class TestProcessingFactory(private val argReader: TestArgumentsReader) {
     }
 
     private fun findTestInResources(test: String): TestConfig? =
-            TestConfigReader("${argReader.properties.testConfigsRelativePath}/$test.json", javaClass.classLoader)
-                .config
-                ?.setTestName(test)
+        TestConfigReader("${argReader.properties.testConfigsRelativePath}/$test.json", javaClass.classLoader)
+            .config
+            ?.setTestName(test)
 
     @Suppress("FUNCTION_BOOLEAN_PREFIX")
     private fun processTest(testConfig: TestConfig): Boolean {

--- a/examples/gradle-groovy-dsl/diktat-analysis.yml
+++ b/examples/gradle-groovy-dsl/diktat-analysis.yml
@@ -208,7 +208,7 @@
     # If true: if first parameter in parameter list is on the same line as opening parenthesis, then other parameters can be aligned with it
     alignedParameters: true
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     # The indentation size for each file
     indentationSize: 4
 # Checks that there is no empty blocks in a file.

--- a/examples/gradle-kotlin-dsl-multiproject/diktat-analysis.yml
+++ b/examples/gradle-kotlin-dsl-multiproject/diktat-analysis.yml
@@ -130,7 +130,7 @@
     newlineAtEnd: true
     extendedIndentOfParameters: false
     alignedParameters: true
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     indentationSize: 4
 - name: EMPTY_BLOCK_STRUCTURE_ERROR
   enabled: true

--- a/examples/gradle-kotlin-dsl/diktat-analysis.yml
+++ b/examples/gradle-kotlin-dsl/diktat-analysis.yml
@@ -208,7 +208,7 @@
     # If true: if first parameter in parameter list is on the same line as opening parenthesis, then other parameters can be aligned with it
     alignedParameters: true
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     # The indentation size for each file
     indentationSize: 4
 # Checks that there is no empty blocks in a file.

--- a/examples/maven/diktat-analysis.yml
+++ b/examples/maven/diktat-analysis.yml
@@ -208,7 +208,7 @@
     # If true: if first parameter in parameter list is on the same line as opening parenthesis, then other parameters can be aligned with it
     alignedParameters: true
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: true
+    extendedIndentAfterOperators: false
     # The indentation size for each file
     indentationSize: 4
 # Checks that there is no empty blocks in a file.


### PR DESCRIPTION
### What's done:

 * Since Kotlin style guide mentions no continuation indent,
   and IDEA defaults to no continuation indent as well,
   all `extendedIndent*` flags default to `false` from now on.
 * Closes: #1312

## Actions checklist
* [X] Updated diktat-analysis.yml
