### PR TITLE
Add unit tests for mis-indented expression body functions

### DIFF
--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
@@ -6,8 +6,14 @@ import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationRule
 import org.cqfn.diktat.util.FixTestBase
 
 import generated.WarningNames
+import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.nio.file.Path
 
 class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
     ::IndentationRule,
@@ -22,7 +28,7 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
             )
         )
     )
-) {
+), IndentationRuleTestMixin {
     @Test
     @Tag(WarningNames.WRONG_INDENTATION)
     fun `parameters should be properly aligned`() {
@@ -45,5 +51,127 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
     @Tag(WarningNames.WRONG_INDENTATION)
     fun `regression - incorrect fixing in constructor parameter list`() {
         fixAndCompare("ConstructorExpected.kt", "ConstructorTest.kt")
+    }
+
+    /**
+     * This test has a counterpart under [IndentationRuleWarnTest].
+     *
+     * See [#1330](https://github.com/saveourtool/diktat/issues/1330).
+     */
+    @Test
+    @Tag(WarningNames.WRONG_INDENTATION)
+    fun `expression body functions should remain unchanged if properly indented (extendedIndentAfterOperators = true)`(@TempDir tempDir: Path) {
+        val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+        val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to true)
+
+        lintMultipleMethods(
+            expressionBodyFunctionsContinuationIndent,
+            tempDir = tempDir,
+            rulesConfigList = customConfig.asRulesConfigList())
+    }
+
+    /**
+     * This test has a counterpart under [IndentationRuleWarnTest].
+     *
+     * See [#1330](https://github.com/saveourtool/diktat/issues/1330).
+     */
+    @Test
+    @Tag(WarningNames.WRONG_INDENTATION)
+    fun `expression body functions should remain unchanged if properly indented (extendedIndentAfterOperators = false)`(@TempDir tempDir: Path) {
+        val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+        val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to false)
+
+        lintMultipleMethods(
+            expressionBodyFunctionsSingleIndent,
+            tempDir = tempDir,
+            rulesConfigList = customConfig.asRulesConfigList())
+    }
+
+    /**
+     * This test has a counterpart under [IndentationRuleWarnTest].
+     *
+     * See [#1330](https://github.com/saveourtool/diktat/issues/1330).
+     */
+    @Test
+    @Tag(WarningNames.WRONG_INDENTATION)
+    fun `expression body functions should be reformatted if mis-indented (extendedIndentAfterOperators = true)`(@TempDir tempDir: Path) {
+        assumeTrue(testsCanBeMuted()) {
+            "Skipping a known-to-fail test"
+        }
+
+        val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+        val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to true)
+
+        lintMultipleMethods(
+            actualContent = expressionBodyFunctionsSingleIndent,
+            expectedContent = expressionBodyFunctionsContinuationIndent,
+            tempDir = tempDir,
+            rulesConfigList = customConfig.asRulesConfigList())
+    }
+
+    /**
+     * This test has a counterpart under [IndentationRuleWarnTest].
+     *
+     * See [#1330](https://github.com/saveourtool/diktat/issues/1330).
+     */
+    @Test
+    @Tag(WarningNames.WRONG_INDENTATION)
+    fun `expression body functions should be reformatted if mis-indented (extendedIndentAfterOperators = false)`(@TempDir tempDir: Path) {
+        assumeTrue(testsCanBeMuted()) {
+            "Skipping a known-to-fail test"
+        }
+
+        val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+        val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to false)
+
+        lintMultipleMethods(
+            actualContent = expressionBodyFunctionsContinuationIndent,
+            expectedContent = expressionBodyFunctionsSingleIndent,
+            tempDir = tempDir,
+            rulesConfigList = customConfig.asRulesConfigList())
+    }
+
+    /**
+     * @param actualContent the original file content (may well be modified as
+     *   fixes are applied).
+     * @param expectedContent the content the file is expected to have after the
+     *   fixes are applied.
+     */
+    private fun lintMultipleMethods(
+        @Language("kotlin") actualContent: Array<String>,
+        @Language("kotlin") expectedContent: Array<String> = actualContent,
+        tempDir: Path,
+        rulesConfigList: List<RulesConfig>? = null
+    ) {
+        require(actualContent.isNotEmpty()) {
+            "code fragments is an empty array"
+        }
+
+        require(actualContent.size == expectedContent.size) {
+            "The actual and expected code fragments are arrays of different size: ${actualContent.size} != ${expectedContent.size}"
+        }
+
+        assertSoftly { softly ->
+            sequence {
+                yieldAll(actualContent.asSequence() zip expectedContent.asSequence())
+
+                /*
+                 * All fragments concatenated.
+                 */
+                yield(actualContent.concatenated() to expectedContent.concatenated())
+            }.forEach { (actual, expected) ->
+                val lintResult = fixAndCompareContent(
+                    actual,
+                    expected,
+                    tempDir,
+                    rulesConfigList)
+
+                if (!lintResult.isSuccessful) {
+                    softly.assertThat(lintResult.actualContent)
+                        .describedAs("lint result for \"$actual\"")
+                        .isEqualTo(lintResult.expectedContent)
+                }
+            }
+        }
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestMixin.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestMixin.kt
@@ -1,0 +1,185 @@
+package org.cqfn.diktat.ruleset.chapter3.spaces
+
+import org.cqfn.diktat.common.config.rules.RulesConfig
+import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig
+import org.intellij.lang.annotations.Language
+
+import java.lang.Boolean.getBoolean as getBooleanProperty
+
+/**
+ * Code shared by [IndentationRuleWarnTest] and [IndentationRuleFixTest].
+ *
+ * @see IndentationRuleWarnTest
+ * @see IndentationRuleFixTest
+ */
+internal interface IndentationRuleTestMixin {
+    /**
+     * See [#1330](https://github.com/saveourtool/diktat/issues/1330).
+     *
+     * @see expressionBodyFunctionsContinuationIndent
+     */
+    @Suppress("CUSTOM_GETTERS_SETTERS")
+    val expressionBodyFunctionsSingleIndent: Array<String>
+        @Language("kotlin")
+        get() =
+            arrayOf(
+                """
+                |@Test
+                |fun `checking that suppression with ignore everything works`() {
+                |    val code =
+                |        ""${'"'}
+                |            @Suppress("diktat")
+                |            fun foo() {
+                |                val a = 1
+                |            }
+                |        ""${'"'}.trimIndent()
+                |    lintMethod(code)
+                |}
+                """.trimMargin(),
+
+                """
+                |val currentTime: Time
+                |    get() =
+                |        with(currentDateTime) {
+                |            Time(hour = hour, minute = minute, second = second)
+                |        }
+                """.trimMargin(),
+
+                """
+                |fun formatDateByPattern(date: String, pattern: String = "ddMMyy"): String =
+                |    DateTimeFormatter.ofPattern(pattern).format(LocalDate.parse(date))
+                """.trimMargin(),
+
+                """
+                |private fun createLayoutParams(): WindowManager.LayoutParams =
+                |    WindowManager.LayoutParams().apply { /* ... */ }
+                """.trimMargin(),
+
+                """
+                |val offsetDelta =
+                |    if (shimmerAnimationType != ShimmerAnimationType.FADE) translateAnim.dp
+                |    else 2000.dp
+                """.trimMargin(),
+
+                """
+                |private fun lerp(start: Float, stop: Float, fraction: Float): Float =
+                |    (1 - fraction) * start + fraction * stop
+                """.trimMargin()
+            )
+
+    /**
+     * See [#1330](https://github.com/saveourtool/diktat/issues/1330).
+     *
+     * @see expressionBodyFunctionsSingleIndent
+     */
+    @Suppress("CUSTOM_GETTERS_SETTERS")
+    val expressionBodyFunctionsContinuationIndent: Array<String>
+        @Language("kotlin")
+        get() =
+            arrayOf(
+                """
+                |@Test
+                |fun `checking that suppression with ignore everything works`() {
+                |    val code =
+                |            ""${'"'}
+                |                @Suppress("diktat")
+                |                fun foo() {
+                |                    val a = 1
+                |                }
+                |            ""${'"'}.trimIndent()
+                |    lintMethod(code)
+                |}
+                """.trimMargin(),
+
+                """
+                |val currentTime: Time
+                |    get() =
+                |            with(currentDateTime) {
+                |                Time(hour = hour, minute = minute, second = second)
+                |            }
+                """.trimMargin(),
+
+                """
+                |fun formatDateByPattern(date: String, pattern: String = "ddMMyy"): String =
+                |        DateTimeFormatter.ofPattern(pattern).format(LocalDate.parse(date))
+                """.trimMargin(),
+
+                """
+                |private fun createLayoutParams(): WindowManager.LayoutParams =
+                |        WindowManager.LayoutParams().apply { /* ... */ }
+                """.trimMargin(),
+
+                """
+                |val offsetDelta =
+                |        if (shimmerAnimationType != ShimmerAnimationType.FADE) translateAnim.dp
+                |        else 2000.dp
+                """.trimMargin(),
+
+                """
+                |private fun lerp(start: Float, stop: Float, fraction: Float): Float =
+                |        (1 - fraction) * start + fraction * stop
+                """.trimMargin(),
+            )
+
+    /**
+     * Creates an `IndentationConfig` from zero or more
+     * [config entries][configEntries]. Invoke without arguments to create a
+     * default `IndentationConfig`.
+     *
+     * @param configEntries the configuration entries to create this instance from.
+     * @see [IndentationConfig]
+     */
+    @Suppress("TestFunctionName", "FUNCTION_NAME_INCORRECT_CASE")
+    fun IndentationConfig(vararg configEntries: Pair<String, Any>): IndentationConfig =
+        IndentationConfig(mapOf(*configEntries).mapValues(Any::toString))
+
+    /**
+     * @param configEntries the optional values which override the state of this
+     *   [IndentationConfig].
+     * @return the content of this [IndentationConfig] as a map, with some
+     *   configuration entries overridden via [configEntries].
+     */
+    @Suppress("STRING_TEMPLATE_QUOTES")
+    fun IndentationConfig.withCustomParameters(vararg configEntries: Pair<String, Any>): Map<String, String> =
+        mutableMapOf(
+            "alignedParameters" to "$alignedParameters",
+            "indentationSize" to "$indentationSize",
+            "newlineAtEnd" to "$newlineAtEnd",
+            "extendedIndentOfParameters" to "$extendedIndentOfParameters",
+            "extendedIndentAfterOperators" to "$extendedIndentAfterOperators",
+            "extendedIndentBeforeDot" to "$extendedIndentBeforeDot",
+        ).apply {
+            configEntries.forEach { (key, value) ->
+                this[key] = value.toString()
+            }
+        }
+
+    /**
+     * Converts this map to a list containing a single [RulesConfig].
+     *
+     * @return the list containing a single [RulesConfig] entry.
+     */
+    fun Map<String, String>.asRulesConfigList(): List<RulesConfig> =
+        listOf(
+            RulesConfig(
+                name = WRONG_INDENTATION.name,
+                enabled = true,
+                configuration = this
+            )
+        )
+
+    /**
+     * @return the concatenated content of this array (elements separated with
+     *   blank lines).
+     */
+    fun Array<String>.concatenated(): String =
+        joinToString(separator = "\n\n")
+
+    /**
+     * @return `true` if known-to-fail unit tests can be muted on the CI server.
+     */
+    @Suppress("FUNCTION_BOOLEAN_PREFIX")
+    fun testsCanBeMuted(): Boolean =
+        getBooleanProperty("tests.can.be.muted")
+}

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
@@ -1,11 +1,17 @@
 package org.cqfn.diktat.util
 
 import org.cqfn.diktat.common.config.rules.RulesConfig
+import org.cqfn.diktat.test.framework.processing.FileComparisonResult
 import org.cqfn.diktat.test.framework.processing.TestComparatorUnit
 
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.RuleSetProvider
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assertions
+
+import java.nio.file.Path
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.div
 
 /**
  * @property resourceFilePath path to files which will be compared in tests
@@ -56,6 +62,7 @@ open class FixTestBase(protected val resourceFilePath: String,
      * @param expectedPath path to file with expected result, relative to [resourceFilePath]
      * @param testPath path to file with code that will be transformed by formatter, relative to [resourceFilePath]
      * @param overrideRulesConfigList optional override to [rulesConfigList]
+     * @see fixAndCompareContent
      */
     protected fun fixAndCompare(expectedPath: String,
                                 testPath: String,
@@ -68,5 +75,42 @@ open class FixTestBase(protected val resourceFilePath: String,
             testComparatorUnit
                 .compareFilesFromResources(expectedPath, testPath)
         )
+    }
+
+    /**
+     * Unlike [fixAndCompare], this method doesn't perform any assertions.
+     *
+     * @param actualContent the original file content (may well be modified as
+     *   fixes are applied).
+     * @param expectedContent the content the file is expected to have after the
+     *   fixes are applied.
+     * @param tempDir the temporary directory (usually injected by _JUnit_).
+     * @param overrideRulesConfigList an optional override for [rulesConfigList]
+     *   (the class-wide configuration).
+     * @return the result of file content comparison.
+     * @see fixAndCompare
+     */
+    @Suppress("FUNCTION_BOOLEAN_PREFIX")
+    protected fun fixAndCompareContent(
+        @Language("kotlin") actualContent: String,
+        @Language("kotlin") expectedContent: String = actualContent,
+        tempDir: Path,
+        overrideRulesConfigList: List<RulesConfig>? = null
+    ): FileComparisonResult {
+        val actual = tempDir / "actual.kt"
+        actual.bufferedWriter().use { out ->
+            out.write(actualContent)
+        }
+
+        val expected = tempDir / "expected.kt"
+        expected.bufferedWriter().use { out ->
+            out.write(expectedContent)
+        }
+
+        val testComparatorUnit = TestComparatorUnit(tempDir.toString()) { text, fileName ->
+            format(ruleSetProviderRef, text, fileName, overrideRulesConfigList ?: rulesConfigList, cb)
+        }
+
+        return testComparatorUnit.compareFilesFromFileSystem(expected, actual)
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -16,6 +16,7 @@ import com.pinterest.ktlint.core.VisitorProvider
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.SoftAssertions
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.slf4j.LoggerFactory
 
@@ -24,7 +25,8 @@ import java.util.function.Consumer
 
 internal const val TEST_FILE_NAME = "TestFileName.kt"
 
-private val log = LoggerFactory.getLogger("TestUtils")
+@Suppress("WRONG_WHITESPACE")
+private val log = LoggerFactory.getLogger({}.javaClass)
 
 @Suppress("TYPE_ALIAS")
 internal val defaultCallback: (lintError: LintError, corrected: Boolean) -> Unit = { lintError, _ ->
@@ -82,7 +84,7 @@ internal fun List<LintError>.assertEquals(vararg expectedLintErrors: LintError) 
 @OptIn(FeatureInAlphaState::class)
 @Suppress("LAMBDA_IS_NOT_LAST_PARAMETER")
 internal fun format(ruleSetProviderRef: (rulesConfigList: List<RulesConfig>?) -> RuleSetProvider,
-                    text: String,
+                    @Language("kotlin") text: String,
                     fileName: String,
                     rulesConfigList: List<RulesConfig>? = null,
                     cb: LintErrorCallback = defaultCallback

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
@@ -22,6 +22,7 @@ class FileComparator(
     private val actualResultList: List<String> = readFile(actualResultFile)
 ) {
     private val diffGenerator = DiffRowGenerator(
+        columnWidth = Int.MAX_VALUE,
         showInlineDiffs = true,
         mergeOriginalRevised = false,
         inlineDiffByWord = false,

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
@@ -7,17 +7,20 @@ import org.slf4j.LoggerFactory
 
 import java.io.File
 import java.io.IOException
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.util.ArrayList
-import java.util.stream.Collectors
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.name
+import kotlin.io.path.readLines
 
 /**
  * A class that is capable of comparing files content
  */
-class FileComparator {
-    private val expectedResultFile: File
-    private val actualResultList: List<String>
+class FileComparator(
+    private val expectedResultFile: Path,
+    private val expectedResultList: List<String> = readFile(expectedResultFile),
+    private val actualResultFile: Path,
+    private val actualResultList: List<String> = readFile(actualResultFile)
+) {
     private val diffGenerator = DiffRowGenerator(
         showInlineDiffs = true,
         mergeOriginalRevised = false,
@@ -26,15 +29,21 @@ class FileComparator {
         newTag = { _, start -> if (start) "<" else ">" },
     )
 
-    constructor(expectedResultFile: File, actualResultList: List<String>) {
-        this.expectedResultFile = expectedResultFile
-        this.actualResultList = actualResultList
-    }
+    constructor(
+        expectedResultFile: File,
+        actualResultList: List<String>
+    ) : this(
+        expectedResultFile.toPath(),
+        actualResultFile = Path("No file name.kt"),
+        actualResultList = actualResultList
+    )
 
-    constructor(expectedResultFile: File, actualResultFile: File) {
-        this.expectedResultFile = expectedResultFile
-        this.actualResultList = readFile(actualResultFile.absolutePath)
-    }
+    constructor(
+        expectedResultFile: File,
+        actualResultFile: File
+    ) : this(
+        expectedResultFile.toPath(),
+        actualResultFile = actualResultFile.toPath())
 
     /**
      * @return true in case files are different
@@ -47,12 +56,11 @@ class FileComparator {
     )
     fun compareFilesEqual(): Boolean {
         try {
-            val expect = readFile(expectedResultFile.absolutePath)
-            if (expect.isEmpty()) {
+            if (expectedResultList.isEmpty()) {
                 return false
             }
             val regex = (".*// ;warn:(\\d+):(\\d+): (.*)").toRegex()
-            val expectWithoutWarn = expect.filterNot { line ->
+            val expectWithoutWarn = expectedResultList.filterNot { line ->
                 line.contains(regex)
             }
             val patch = diff(expectWithoutWarn, actualResultList)
@@ -75,32 +83,31 @@ class FileComparator {
             }
 
             log.error("""
-                |Expected result from <${expectedResultFile.name}> and actual formatted are different.
+                |Expected result from <${expectedResultFile.name}> and <${actualResultFile.name}> formatted are different.
                 |See difference below:
                 |$joinedDeltas
                 """.trimMargin()
             )
         } catch (e: RuntimeException) {
-            log.error("Not able to prepare diffs between <${expectedResultFile.name}> and <$actualResultList>", e)
+            log.error("Not able to prepare diffs between <${expectedResultFile.name}> and <${actualResultFile.name}>", e)
         }
         return false
     }
 
-    /**
-     * @param fileName - file where to write these list to, separated with newlines
-     * @return a list of lines from the file
-     */
-    private fun readFile(fileName: String): List<String> {
-        var list: List<String> = ArrayList()
-        try {
-            Files.newBufferedReader(Paths.get(fileName)).use { list = it.lines().collect(Collectors.toList()) }
-        } catch (e: IOException) {
-            log.error("Not able to read file: $fileName")
-        }
-        return list
-    }
-
     companion object {
         private val log = LoggerFactory.getLogger(FileComparator::class.java)
+
+        /**
+         * @param file file where to write these list to, separated with newlines.
+         * @return a list of lines from the file, or an empty list if an I/O error
+         *   has occurred.
+         */
+        private fun readFile(file: Path): List<String> =
+            try {
+                file.readLines()
+            } catch (e: IOException) {
+                log.error("Not able to read file: $file")
+                emptyList()
+            }
     }
 }

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparisonResult.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparisonResult.kt
@@ -1,0 +1,23 @@
+package org.cqfn.diktat.test.framework.processing
+
+import org.intellij.lang.annotations.Language
+
+/**
+ * The result of files being compared by their content.
+ *
+ * @property isSuccessful `true` if file content match (the comparison is
+ *   successful), `false` otherwise. Even if [isSuccessful] is `true`,
+ *   [actualContent] and [expectedContent] are not necessarily the same
+ *   (theoretically, they may differ by the amount of trailing newlines).
+ *   Similarly, if [isSuccessful] is `false`, [actualContent] and
+ *   [expectedContent] are not necessarily different (consider the case when
+ *   both files are missing).
+ * @property actualContent the actual file content (possibly slightly different
+ *   from the original after `diktat:check` is run).
+ * @property expectedContent the expected file content.
+ */
+data class FileComparisonResult(
+    val isSuccessful: Boolean,
+    @Language("kotlin") val actualContent: String,
+    @Language("kotlin") val expectedContent: String
+)

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestComparatorUnit.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestComparatorUnit.kt
@@ -109,20 +109,20 @@ class TestComparatorUnit(private val resourceFilePath: String,
             expectedFileContent.joinToString("\n"))
     }
 
-    /**
-     * @param file the file whose content is to be read.
-     * @return file content as a list of lines, or an empty list if an I/O error
-     *   has occurred.
-     */
-    private fun readFile(file: Path): List<String> =
-        try {
-            file.readLines()
-        } catch (e: IOException) {
-            log.error("Not able to read file: $file")
-            emptyList()
-        }
+    private companion object {
+        private val log: Logger = LoggerFactory.getLogger(TestComparatorUnit::class.java)
 
-    companion object {
-        val log: Logger = LoggerFactory.getLogger(TestComparatorUnit::class.java)
+        /**
+         * @param file the file whose content is to be read.
+         * @return file content as a list of lines, or an empty list if an I/O error
+         *   has occurred.
+         */
+        private fun readFile(file: Path): List<String> =
+            try {
+                file.readLines()
+            } catch (e: IOException) {
+                log.error("Not able to read file: $file")
+                emptyList()
+            }
     }
 }


### PR DESCRIPTION
### What's done:

 * Added unit tests for mis-indented expression body functions.
 * See #1330.
