### PR TITLE
Fix the compilation error (Kotlin 1.7+)

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
@@ -82,6 +82,9 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
         } ?: if (visitorCounter.incrementAndGet() == 1) {
             log.error("Not able to find an external configuration for domain" +
                 " name in the common configuration (is it missing in yml config?)")
+        } else {
+            @Suppress("RedundantUnitExpression")
+            Unit
         }
     }
 


### PR DESCRIPTION
### What's done:

 * Non-exhaustive `if` and `when` blocks are no longer allowed when used as expressions
   (see [KT-44705](https://youtrack.jetbrains.com/issue/KT-44705)).
