### PR TITLE
Report unit test results via GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -118,6 +118,9 @@ jobs:
     name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
+      # We need multiple builds to run even if the 1st one is failing, because
+      # test failures may be OS-specific (or the tests themselves flaky).
+      fail-fast: false
       matrix:
         os: [ windows-latest, macos-latest ]
     steps:
@@ -147,6 +150,28 @@ jobs:
           mvn -B -T1C clean install
         shell: cmd
 
+        # This step needs a Git repository, so it's impossible to extract it
+        # into a separate job (or, otherwise, we'd need to upload the content
+        # of the whole `.git` folder as an artifact).
+      - name: JUnit Tests (dorny/test-reporter@v1)
+        uses: dorny/test-reporter@v1
+        if: ${{ always() }}
+        with:
+          name: JUnit Tests (${{ runner.os }}, dorny/test-reporter@v1)
+          # Comma-separated values.
+          path: "**/target/*-reports/TEST-*.xml, **/build/test-results/*/TEST-*.xml"
+          reporter: java-junit
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: xml-test-reports-${{ runner.os }}
+          path: |
+            **/target/*-reports/TEST-*.xml
+            **/build/test-results/*/TEST-*.xml
+          retention-days: 1
+
       - name: Upload gradle reports
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
@@ -154,3 +179,42 @@ jobs:
           name: gradle-test-report-${{ matrix.os }}
           path: 'diktat-gradle-plugin/build/reports/'
           retention-days: 1
+
+  report:
+    name: Publish JUnit test results
+    if: ${{ always() }}
+    needs: build_and_test
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ windows-latest, macos-latest ]
+
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/download-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: xml-test-reports-${{ runner.os }}
+
+        # Uses Docker, that's why Linux-only.
+      - name: JUnit Tests (EnricoMi/publish-unit-test-result-action@v1, Linux)
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: ${{ runner.os == 'Linux' }}
+        with:
+          check_name: JUnit Tests (${{ runner.os }}, EnricoMi/publish-unit-test-result-action@v1)
+          files: |
+            **/target/*-reports/TEST-*.xml
+            **/build/test-results/*/TEST-*.xml
+
+      - name: JUnit Tests (EnricoMi/publish-unit-test-result-action@v1, Windows or Mac OS X)
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        if: ${{ runner.os == 'Windows' || runner.os == 'macOS' }}
+        with:
+          check_name: JUnit Tests (${{ runner.os }}, EnricoMi/publish-unit-test-result-action@v1)
+          files: |
+            **/target/*-reports/TEST-*.xml
+            **/build/test-results/*/TEST-*.xml


### PR DESCRIPTION
### What's done:

 * XML test reports (from surefire/failsafe/gradle) are now published as artifacts.
 * XML test reports are now processed and presented in a human-readable form.
