### PR TITLE
Add unit tests which reproduce #1347

### DIFF
--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestMixin.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestMixin.kt
@@ -65,7 +65,12 @@ internal interface IndentationRuleTestMixin {
                 """
                 |private fun lerp(start: Float, stop: Float, fraction: Float): Float =
                 |    (1 - fraction) * start + fraction * stop
-                """.trimMargin()
+                """.trimMargin(),
+
+                """
+                |fun foo() =
+                |    println()
+                """.trimMargin(),
             )
 
     /**
@@ -120,6 +125,83 @@ internal interface IndentationRuleTestMixin {
                 |private fun lerp(start: Float, stop: Float, fraction: Float): Float =
                 |        (1 - fraction) * start + fraction * stop
                 """.trimMargin(),
+
+                """
+                |fun foo() =
+                |        println()
+                """.trimMargin(),
+            )
+
+    /**
+     * See [#1347](https://github.com/saveourtool/diktat/issues/1347).
+     *
+     * @see whitespaceInStringLiteralsContinuationIndent
+     */
+    @Suppress("CUSTOM_GETTERS_SETTERS")
+    val whitespaceInStringLiteralsSingleIndent: Array<String>
+        @Language("kotlin")
+        get() =
+            arrayOf(
+                """
+                |@Test
+                |fun `test method name`() {
+                |    @Language("kotlin")
+                |    val code =
+                |        ""${'"'}
+                |            @Suppress("diktat")
+                |            fun foo() {
+                |                val a = 1
+                |            }
+                |        ""${'"'}.trimIndent()
+                |    lintMethod(code)
+                |}
+                """.trimMargin(),
+
+                """
+                |fun checkScript() {
+                |    lintMethod(
+                |        ""${'"'}
+                |                    |val A = "aa"
+                |        ""${'"'}.trimMargin(),
+                |    )
+                |}
+                """.trimMargin(),
+            )
+
+    /**
+     * See [#1347](https://github.com/saveourtool/diktat/issues/1347).
+     *
+     * @see whitespaceInStringLiteralsSingleIndent
+     */
+    @Suppress("CUSTOM_GETTERS_SETTERS")
+    val whitespaceInStringLiteralsContinuationIndent: Array<String>
+        @Language("kotlin")
+        get() =
+            arrayOf(
+                """
+                |@Test
+                |fun `test method name`() {
+                |    @Language("kotlin")
+                |    val code =
+                |            ""${'"'}
+                |                @Suppress("diktat")
+                |                fun foo() {
+                |                    val a = 1
+                |                }
+                |            ""${'"'}.trimIndent()
+                |    lintMethod(code)
+                |}
+                """.trimMargin(),
+
+                """
+                |fun checkScript() {
+                |    lintMethod(
+                |            ""${'"'}
+                |                        |val A = "aa"
+                |            ""${'"'}.trimMargin(),
+                |    )
+                |}
+                """.trimMargin(),
             )
 
     /**
@@ -170,11 +252,37 @@ internal interface IndentationRuleTestMixin {
         )
 
     /**
+     * Allows to simultaneously enable or disable _all_ `extendedIndent*` flags.
+     *
+     * @param enabled whether the _continuation indent_ should be enabled or
+     *   disabled.
+     * @return an array of map entries.
+     */
+    fun extendedIndent(enabled: Boolean): Array<Pair<String, Any>> =
+        arrayOf(
+            "extendedIndentOfParameters" to enabled,
+            "extendedIndentAfterOperators" to enabled,
+            "extendedIndentBeforeDot" to enabled)
+
+    /**
      * @return the concatenated content of this array (elements separated with
      *   blank lines).
      */
-    fun Array<String>.concatenated(): String =
+    private fun Array<String>.concatenated(): String =
         joinToString(separator = "\n\n")
+
+    /**
+     * @return a sequence which returns the elements of this array and,
+     *   additionally, the result of concatenation of all the elements.
+     */
+    fun Array<String>.asSequenceWithConcatenation(): Sequence<String> =
+        sequence {
+            yieldAll(asSequence())
+
+            if (size > 1) {
+                yield(concatenated())
+            }
+        }
 
     /**
      * @return `true` if known-to-fail unit tests can be muted on the CI server.

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
@@ -12,13 +12,16 @@ import org.assertj.core.api.AbstractSoftAssertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.MethodOrderer.MethodName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.opentest4j.MultipleFailuresError
 
 import java.util.function.Consumer
 
 @Suppress("LargeClass")
+@TestMethodOrder(MethodName::class)
 class IndentationRuleWarnTest : LintTestBase(::IndentationRule), IndentationRuleTestMixin {
     private val ruleId = "$DIKTAT_RULE_SET_ID:${IndentationRule.NAME_ID}"
     private val rulesConfigList = listOf(
@@ -864,14 +867,7 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule), IndentationRule
         }
 
         assertSoftly { softly ->
-            sequence {
-                yieldAll(fragments.asSequence())
-
-                /*
-                 * All fragments concatenated.
-                 */
-                yield(fragments.concatenated())
-            }.forEach { fragment ->
+            fragments.asSequenceWithConcatenation().forEach { fragment ->
                 softly.lintMethodSoftly(
                     fragment,
                     lintErrors = lintErrors,


### PR DESCRIPTION
### What's done:

 * Running `mvn diktat:fix` with `WRONG_INDENTATION` rule enabled injects
   whitespace into multiline string literals. Now, unit tests were added which
   reproduce this behaviour.

## Actions checklist
* [X] Added tests on fixers
