### PR TITLE
Don't separate fully-qualified as a regular `dot qualified expression`

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -633,7 +633,7 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
         }
     }
 
-    private fun isTextContainsFunctionCall(node: ASTNode): Boolean = node.textContains('(') || node.textContains('}')
+    private fun isTextContainsFunctionCall(node: ASTNode): Boolean = node.textContains('(') || node.textContains('{')
 
     private fun List<ASTNode>.isNotValidCalls(node: ASTNode): Boolean {
         if (this.size == 1) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -161,9 +161,9 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
                 val without = listDot.filterIndexed { index, it ->
                     val nodeBeforeDotOrSafeAccess = it.findChildByType(DOT)?.treePrev ?: it.findChildByType(SAFE_ACCESS)?.treePrev
                     val firstElem = it.firstChildNode
-                    val isTextContainsParenthesized = firstElem.textContains('(') || firstElem.textContains('{')
+                    val isTextContainsParenthesized = isTextContainParentheses(firstElem)
                     val isWhiteSpaceBeforeDotOrSafeAccessContainNewLine = nodeBeforeDotOrSafeAccess?.elementType != WHITE_SPACE ||
-                            (nodeBeforeDotOrSafeAccess.elementType != WHITE_SPACE && !nodeBeforeDotOrSafeAccess.textContains('\n'))
+                        (nodeBeforeDotOrSafeAccess.elementType != WHITE_SPACE && !nodeBeforeDotOrSafeAccess.textContains('\n'))
                     isTextContainsParenthesized && (index > 0) && isWhiteSpaceBeforeDotOrSafeAccessContainNewLine
                 }
                 if (without.isNotEmpty()) {
@@ -627,11 +627,13 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
             }
         return if (dropLeadingProperties) {
             // fixme: we can't distinguish fully qualified names (like java.lang) from chain of property accesses (like list.size) for now
-            parentExpressionList?.dropWhile { !it.treeParent.textContains('(') && !it.treeParent.textContains('{') }
+            parentExpressionList?.dropWhile { !isTextContainParentheses(it.treeParent) }
         } else {
             parentExpressionList
         }
     }
+
+    private fun isTextContainParentheses(node: ASTNode): Boolean = node.textContains('(') || node.textContains('}')
 
     private fun List<ASTNode>.isNotValidCalls(node: ASTNode): Boolean {
         if (this.size == 1) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -161,10 +161,10 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
                 val without = listDot.filterIndexed { index, it ->
                     val nodeBeforeDotOrSafeAccess = it.findChildByType(DOT)?.treePrev ?: it.findChildByType(SAFE_ACCESS)?.treePrev
                     val firstElem = it.firstChildNode
-                    val isTextContainsParenthesized = isTextContainParentheses(firstElem)
-                    val isWhiteSpaceBeforeDotOrSafeAccessContainNewLine = nodeBeforeDotOrSafeAccess?.elementType != WHITE_SPACE ||
+                    val isTextContainsParenthesized = isTextContainsFunctionCall(firstElem)
+                    val isNotWhiteSpaceBeforeDotOrSafeAccessContainNewLine = nodeBeforeDotOrSafeAccess?.elementType != WHITE_SPACE ||
                         (nodeBeforeDotOrSafeAccess.elementType != WHITE_SPACE && !nodeBeforeDotOrSafeAccess.textContains('\n'))
-                    isTextContainsParenthesized && (index > 0) && isWhiteSpaceBeforeDotOrSafeAccessContainNewLine
+                    isTextContainsParenthesized && (index > 0) && isNotWhiteSpaceBeforeDotOrSafeAccessContainNewLine
                 }
                 if (without.isNotEmpty()) {
                     WRONG_NEWLINES.warnAndFix(configRules, emitWarn, isFixMode, "wrong split long `dot qualified expression` or `safe access expression`",
@@ -627,13 +627,13 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
             }
         return if (dropLeadingProperties) {
             // fixme: we can't distinguish fully qualified names (like java.lang) from chain of property accesses (like list.size) for now
-            parentExpressionList?.dropWhile { !isTextContainParentheses(it.treeParent) }
+            parentExpressionList?.dropWhile { !isTextContainsFunctionCall(it.treeParent) }
         } else {
             parentExpressionList
         }
     }
 
-    private fun isTextContainParentheses(node: ASTNode): Boolean = node.textContains('(') || node.textContains('}')
+    private fun isTextContainsFunctionCall(node: ASTNode): Boolean = node.textContains('(') || node.textContains('}')
 
     private fun List<ASTNode>.isNotValidCalls(node: ASTNode): Boolean {
         if (this.size == 1) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -86,14 +86,12 @@ import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import com.pinterest.ktlint.core.ast.nextCodeSibling
 import com.pinterest.ktlint.core.ast.parent
 import com.pinterest.ktlint.core.ast.prevCodeSibling
-import com.sun.org.apache.xpath.internal.operations.Bool
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
-import org.jetbrains.kotlin.fir.builder.Context
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameterList
@@ -164,10 +162,11 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
                     val whiteSpaceBeforeDotOrSafeAccess = it.findChildByType(DOT)?.treePrev ?: it.findChildByType(SAFE_ACCESS)?.treePrev
                     val firstElem = it.firstChildNode
                     (firstElem.textContains('(') || firstElem.textContains('{')) && (index > 0) && ((whiteSpaceBeforeDotOrSafeAccess?.elementType != WHITE_SPACE) ||
-                            (whiteSpaceBeforeDotOrSafeAccess.elementType != WHITE_SPACE && !whiteSpaceBeforeDotOrSafeAccess.textContains('\n')))
+                        (whiteSpaceBeforeDotOrSafeAccess.elementType != WHITE_SPACE && !whiteSpaceBeforeDotOrSafeAccess.textContains('\n')))
                 }
                 if (without.isNotEmpty()) {
-                    WRONG_NEWLINES.warnAndFix(configRules, emitWarn, isFixMode, "should be split before second and other dot/safe access after first call expression", node.startOffset, node) {
+                    WRONG_NEWLINES.warnAndFix(configRules, emitWarn, isFixMode, "should be split before second and other dot/safe access after first call expression",
+                        node.startOffset, node) {
                         fixDotQualifiedExpression(listDot)
                     }
                 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
@@ -26,7 +26,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
             mapOf("maxCallsInOneLine" to "1"))
     )
     private val ruleId = "$DIKTAT_RULE_SET_ID:${NewlinesRule.NAME_ID}"
-    private val dotQuaOrSafeAccessOrPostfixExpression = "${WRONG_NEWLINES.warnText()} should be split before second and other dot/safe access"
+    private val dotQuaOrSafeAccessOrPostfixExpression = "${WRONG_NEWLINES.warnText()} should be split before second and other dot/safe access after first call expression"
     private val shouldBreakAfter = "${WRONG_NEWLINES.warnText()} should break a line after and not before"
     private val shouldBreakBefore = "${WRONG_NEWLINES.warnText()} should break a line before and not after"
     private val functionalStyleWarn = "${WRONG_NEWLINES.warnText()} should follow functional style at"

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
@@ -26,7 +26,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
             mapOf("maxCallsInOneLine" to "1"))
     )
     private val ruleId = "$DIKTAT_RULE_SET_ID:${NewlinesRule.NAME_ID}"
-    private val dotQuaOrSafeAccessOrPostfixExpression = "${WRONG_NEWLINES.warnText()} should be split before second and other dot/safe access after first call expression"
+    private val dotQuaOrSafeAccessOrPostfixExpression = "${WRONG_NEWLINES.warnText()} wrong split long `dot qualified expression` or `safe access expression`"
     private val shouldBreakAfter = "${WRONG_NEWLINES.warnText()} should break a line after and not before"
     private val shouldBreakBefore = "${WRONG_NEWLINES.warnText()} should break a line before and not after"
     private val functionalStyleWarn = "${WRONG_NEWLINES.warnText()} should follow functional style at"

--- a/diktat-rules/src/test/resources/test/paragraph3/newlines/LongDotQualifiedExpressionExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/newlines/LongDotQualifiedExpressionExpected.kt
@@ -1,21 +1,20 @@
 package test.paragraph3.newlines
 
-val elem1 = firstArgumentDot?.secondArgumentDot
+val elem1 = firstArgumentDot()?.secondArgumentDot
 ?.thirdArgumentDot
 ?.fourthArgumentDot
 ?.fifthArgumentDot
 ?.sixthArgumentDot
 
 
-val elem2 = firstArgumentDot?.secondArgumentDot
+val elem2 = firstArgumentDot?.secondArgumentDot()
 ?.thirdArgumentDot
     ?.fourthArgumentDot
 ?.fifthArgumentDot
 ?.sixthArgumentDot
 
 
-val elem3 = firstArgumentDot?.secondArgumentDot
-?.thirdArgumentDot
+val elem3 = firstArgumentDot?.secondArgumentDot?.thirdArgumentDot()
 ?.fourthArgumentDot
     ?.fifthArgumentDot
 ?.sixthArgumentDot
@@ -24,70 +23,79 @@ val elem3 = firstArgumentDot?.secondArgumentDot
 val elem4 = firstArgumentDot?.secondArgumentDot?.thirdArgumentDot + firstArgumentDot?.secondArgumentDot?.thirdArgumentDot?.fourthArgumentDot
 
 
-val elem5 = firstArgumentDot!!.secondArgumentDot!!
+val elem5 = firstArgumentDot()!!.secondArgumentDot()!!
 .thirdArgumentDot!!
 .fourthArgumentDot!!
 .fifthArgumentDot!!
-.sixthArgumentDot
+.sixthArgumentDot()
 
 
-val elem6 = firstArgumentDot!!.secondArgumentDot!!
-.thirdArgumentDot!!
+val elem6 = firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot()!!
     .fourthArgumentDot!!
-.fifthArgumentDot!!
+.fifthArgumentDot()!!
 .sixthArgumentDot
 
 
-val elem7 = firstArgumentDot!!.secondArgumentDot!!
+val elem7 = firstArgumentDot!!.secondArgumentDot()!!
 .thirdArgumentDot!!
-.fourthArgumentDot!!
+.fourthArgumentDot()!!
     .fifthArgumentDot!!
 .sixthArgumentDot
 
 
-val elem8 = firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot + firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot!!.fourthArgumentDot
+val elem8 = firstArgumentDot()!!.secondArgumentDot!!.thirdArgumentDot + firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot!!.fourthArgumentDot
 
 
-val elem9 = firstArgumentDot.secondArgumentDot
-.thirdArgumentDot
+val elem9 = firstArgumentDot().secondArgumentDot
+.thirdArgumentDot()
 .fourthArgumentDot
 .fifthArgumentDot
 .sixthArgumentDot
 
 
-val elem10 = firstArgumentDot.secondArgumentDot
+val elem10 = firstArgumentDot.secondArgumentDot()
 .thirdArgumentDot
     .fourthArgumentDot
-.fifthArgumentDot
+.fifthArgumentDot()
 .sixthArgumentDot
 
 
-val elem11 = firstArgumentDot.secondArgumentDot
-.thirdArgumentDot
+val elem11 = firstArgumentDot.secondArgumentDot.thirdArgumentDot()
 .fourthArgumentDot
     .fifthArgumentDot
 .sixthArgumentDot
 
 
-val elem12 = firstArgumentDot.secondArgumentDot.thirdArgumentDot + firstArgumentDot.secondArgumentDot.thirdArgumentDot.fourthArgumentDot
+val elem12 = firstArgumentDot.secondArgumentDot.thirdArgumentDot + firstArgumentDot.secondArgumentDot().thirdArgumentDot.fourthArgumentDot
 
 
-val elem13 = firstArgumentDot!!.secondArgumentDot
-?.thirdArgumentDot
+val elem13 = firstArgumentDot!!.secondArgumentDot?.thirdArgumentDot()
 .fourthArgumentDot!!
-.fifthArgumentDot
+.fifthArgumentDot()
 ?.sixthArgumentDot
 
 
-val elem14 = firstArgumentDot.secondArgumentDot
-?.thirdArgumentDot!!
+val elem14 = firstArgumentDot.secondArgumentDot?.thirdArgumentDot()!!
 .fourthArgumentDot
 ?.fifthArgumentDot
 .sixthArgumentDot
 
 
-val elem15 = firstArgumentDot?.secondArgumentDot!!
-.thirdArgumentDot
-.fourthArgumentDot
+val elem15 = firstArgumentDot?.secondArgumentDot!!.thirdArgumentDot.fourthArgumentDot()
 .fifthArgumentDot!!
 .sixthArgumentDot
+
+
+val elem16 = firstArgumentDot.secondArgumentDot.thirdArgumentDot.fourthArgumentDot.fifthArgumentDot.sixthArgumentDot
+
+
+val elem17 = firstArgumentDot!!.secondArgumentDot.thirdArgumentDot!!.fourthArgumentDot.fifthArgumentDot!!.sixthArgumentDot
+
+
+val elem18 = firstArgumentDot.secondArgumentDot?.thirdArgumentDot.fourthArgumentDot?.fifthArgumentDot.sixthArgumentDot
+
+
+private val holder: java.util.concurrent.atomic.AtomicReference<T> = java.util.concurrent.atomic.AtomicReference(valueToStore)
+
+
+private val holder: kotlin.native.concurrent.AtomicReference<T> = kotlin.native.concurrent.AtomicReference(valueToStore)

--- a/diktat-rules/src/test/resources/test/paragraph3/newlines/LongDotQualifiedExpressionTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/newlines/LongDotQualifiedExpressionTest.kt
@@ -1,51 +1,66 @@
 package test.paragraph3.newlines
 
-val elem1 = firstArgumentDot?.secondArgumentDot?.thirdArgumentDot?.fourthArgumentDot?.fifthArgumentDot?.sixthArgumentDot
+val elem1 = firstArgumentDot()?.secondArgumentDot?.thirdArgumentDot?.fourthArgumentDot?.fifthArgumentDot?.sixthArgumentDot
 
 
-val elem2 = firstArgumentDot?.secondArgumentDot?.thirdArgumentDot
+val elem2 = firstArgumentDot?.secondArgumentDot()?.thirdArgumentDot
     ?.fourthArgumentDot?.fifthArgumentDot?.sixthArgumentDot
 
 
-val elem3 = firstArgumentDot?.secondArgumentDot?.thirdArgumentDot?.fourthArgumentDot
+val elem3 = firstArgumentDot?.secondArgumentDot?.thirdArgumentDot()?.fourthArgumentDot
     ?.fifthArgumentDot?.sixthArgumentDot
 
 
 val elem4 = firstArgumentDot?.secondArgumentDot?.thirdArgumentDot + firstArgumentDot?.secondArgumentDot?.thirdArgumentDot?.fourthArgumentDot
 
 
-val elem5 = firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot!!.fourthArgumentDot!!.fifthArgumentDot!!.sixthArgumentDot
+val elem5 = firstArgumentDot()!!.secondArgumentDot()!!.thirdArgumentDot!!.fourthArgumentDot!!.fifthArgumentDot!!.sixthArgumentDot()
 
 
-val elem6 = firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot!!
-    .fourthArgumentDot!!.fifthArgumentDot!!.sixthArgumentDot
+val elem6 = firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot()!!
+    .fourthArgumentDot!!.fifthArgumentDot()!!.sixthArgumentDot
 
 
-val elem7 = firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot!!.fourthArgumentDot!!
+val elem7 = firstArgumentDot!!.secondArgumentDot()!!.thirdArgumentDot!!.fourthArgumentDot()!!
     .fifthArgumentDot!!.sixthArgumentDot
 
 
-val elem8 = firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot + firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot!!.fourthArgumentDot
+val elem8 = firstArgumentDot()!!.secondArgumentDot!!.thirdArgumentDot + firstArgumentDot!!.secondArgumentDot!!.thirdArgumentDot!!.fourthArgumentDot
 
 
-val elem9 = firstArgumentDot.secondArgumentDot.thirdArgumentDot.fourthArgumentDot.fifthArgumentDot.sixthArgumentDot
+val elem9 = firstArgumentDot().secondArgumentDot.thirdArgumentDot().fourthArgumentDot.fifthArgumentDot.sixthArgumentDot
 
 
-val elem10 = firstArgumentDot.secondArgumentDot.thirdArgumentDot
-    .fourthArgumentDot.fifthArgumentDot.sixthArgumentDot
+val elem10 = firstArgumentDot.secondArgumentDot().thirdArgumentDot
+    .fourthArgumentDot.fifthArgumentDot().sixthArgumentDot
 
 
-val elem11 = firstArgumentDot.secondArgumentDot.thirdArgumentDot.fourthArgumentDot
+val elem11 = firstArgumentDot.secondArgumentDot.thirdArgumentDot().fourthArgumentDot
     .fifthArgumentDot.sixthArgumentDot
 
 
-val elem12 = firstArgumentDot.secondArgumentDot.thirdArgumentDot + firstArgumentDot.secondArgumentDot.thirdArgumentDot.fourthArgumentDot
+val elem12 = firstArgumentDot.secondArgumentDot.thirdArgumentDot + firstArgumentDot.secondArgumentDot().thirdArgumentDot.fourthArgumentDot
 
 
-val elem13 = firstArgumentDot!!.secondArgumentDot?.thirdArgumentDot.fourthArgumentDot!!.fifthArgumentDot?.sixthArgumentDot
+val elem13 = firstArgumentDot!!.secondArgumentDot?.thirdArgumentDot().fourthArgumentDot!!.fifthArgumentDot()?.sixthArgumentDot
 
 
-val elem14 = firstArgumentDot.secondArgumentDot?.thirdArgumentDot!!.fourthArgumentDot?.fifthArgumentDot.sixthArgumentDot
+val elem14 = firstArgumentDot.secondArgumentDot?.thirdArgumentDot()!!.fourthArgumentDot?.fifthArgumentDot.sixthArgumentDot
 
 
-val elem15 = firstArgumentDot?.secondArgumentDot!!.thirdArgumentDot.fourthArgumentDot.fifthArgumentDot!!.sixthArgumentDot
+val elem15 = firstArgumentDot?.secondArgumentDot!!.thirdArgumentDot.fourthArgumentDot().fifthArgumentDot!!.sixthArgumentDot
+
+
+val elem16 = firstArgumentDot.secondArgumentDot.thirdArgumentDot.fourthArgumentDot.fifthArgumentDot.sixthArgumentDot
+
+
+val elem17 = firstArgumentDot!!.secondArgumentDot.thirdArgumentDot!!.fourthArgumentDot.fifthArgumentDot!!.sixthArgumentDot
+
+
+val elem18 = firstArgumentDot.secondArgumentDot?.thirdArgumentDot.fourthArgumentDot?.fifthArgumentDot.sixthArgumentDot
+
+
+private val holder: java.util.concurrent.atomic.AtomicReference<T> = java.util.concurrent.atomic.AtomicReference(valueToStore)
+
+
+private val holder: kotlin.native.concurrent.AtomicReference<T> = kotlin.native.concurrent.AtomicReference(valueToStore)


### PR DESCRIPTION
## Whats added

 Add analytic fully qualified - split long `dot qualified expression` and `safe access expression` and and their combinations after first `call expression`
 
## This pull request closes #1403

## Actions checklist
* [ ] correct Warning message
* [ ] Added tests on fixers - 5 last test in `long dot qualified expression`


<!-- Is there anything left out of scope of this PR? -->
