### PR TITLE
Solo `binary exprssion` contained in `parentheses`

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
@@ -79,8 +79,9 @@ import java.net.URL
 
 /**
  * The rule checks for lines in the file that exceed the maximum length.
- * Rule ignores URL in KDoc. Rule also can fix some cases.
- * Rule can fix long binary expressions in condition inside `if` and in property declarations and one line functions
+ * Rule ignores URL in KDoc. This rule can also fix some particular corner cases.
+ * This inspection can fix long binary expressions in condition inside `if`,
+ * in property declarations and in single line functions.
  */
 @Suppress("ForbiddenComment")
 class LineLength(configRules: List<RulesConfig>) : DiktatRule(

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
@@ -541,7 +541,12 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
      */
     private class BinaryExpression(node: ASTNode) : LongLineFixableCases(node) {
         override fun fix() {
-            val nodeOperationReference = node.findChildByType(OPERATION_REFERENCE)
+            val binNode = if (node.elementType == PARENTHESIZED) {
+                node.findChildByType(BINARY_EXPRESSION)
+            } else {
+                node
+            }
+            val nodeOperationReference = binNode?.findChildByType(OPERATION_REFERENCE)
             val nextNode = if (nodeOperationReference?.firstChildNode?.elementType != ELVIS) {
                 nodeOperationReference?.treeNext
             } else {
@@ -551,7 +556,7 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
                     nodeOperationReference
                 }
             }
-            node.appendNewlineMergingWhiteSpace(nextNode, nextNode)
+            binNode?.appendNewlineMergingWhiteSpace(nextNode, nextNode)
         }
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthFixTest.kt
@@ -107,4 +107,9 @@ class LineLengthFixTest : FixTestBase("test/paragraph3/long_line", ::LineLength)
     fun `fix bin expression first symbol last word`() {
         fixAndCompare("LongBinaryExpressionLastWordExpected.kt", "LongBinaryExpressionLastWordTest.kt", rulesConfigListErrorLineLength1)
     }
+
+    @Test
+    fun `fix bin 1expression first symbol last word`() {
+        fixAndCompare("LongComplexExpressionExpected.kt", "LongComplexExpressionTest.kt", rulesConfigListErrorLineLength1)
+    }
 }

--- a/diktat-rules/src/test/resources/test/paragraph3/long_line/LongComplexExpressionExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/long_line/LongComplexExpressionExpected.kt
@@ -1,0 +1,9 @@
+package test.paragraph3.long_line
+
+fun foo(){
+    val attrs.disabled = (selfRole == Role.OWNER && isSelfRecord(props.selfUserInfo, user)) || !(selfRole.isHigherOrEqualThan(Role.OWNER) ||
+ userRole.isLowerThan(selfRole))
+}
+
+val attrs.disabled = (selfRole == Role.OWNER && isSelfRecord(props.selfUserInfo, user)) || !(selfRole.isHigherOrEqualThan(Role.OWNER) ||
+ userRole.isLowerThan(selfRole))

--- a/diktat-rules/src/test/resources/test/paragraph3/long_line/LongComplexExpressionTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/long_line/LongComplexExpressionTest.kt
@@ -1,0 +1,7 @@
+package test.paragraph3.long_line
+
+fun foo(){
+    val attrs.disabled = (selfRole == Role.OWNER && isSelfRecord(props.selfUserInfo, user)) || !(selfRole.isHigherOrEqualThan(Role.OWNER) || userRole.isLowerThan(selfRole))
+}
+
+val attrs.disabled = (selfRole == Role.OWNER && isSelfRecord(props.selfUserInfo, user)) || !(selfRole.isHigherOrEqualThan(Role.OWNER) || userRole.isLowerThan(selfRole))


### PR DESCRIPTION
## Whats added:

Error in method fix in class Binary Expression - if `binary expression` contained in `parentheses` find child with type `operation references` is null 

## This pull request closes #1415

## Actions checklist
* [ ] Correct logic 
* [ ] Added test on fixer

## Any information:
* In issue - Error message - ([LONG_LINE] this line is longer than allowed: max line length 180, but was 196), but this line has a large indentation - 32. The line has a length of 165.
*  Without other code modes does not work
* In this fix test maximum linelength is 151 
