### PR TITLE
gradle-plugin: target Kotlin runtime 1.6

### DIFF
--- a/diktat-common/pom.xml
+++ b/diktat-common/pom.xml
@@ -94,6 +94,8 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <apiVersion>1.6</apiVersion>
+                    <languageVersion>1.6</languageVersion>
                     <compilerPlugins>
                         <plugin>kotlinx-serialization</plugin>
                     </compilerPlugins>

--- a/diktat-gradle-plugin/pom.xml
+++ b/diktat-gradle-plugin/pom.xml
@@ -26,11 +26,11 @@
     <dependencies>
         <dependency>
             <groupId>org.cqfn.diktat</groupId>
-            <artifactId>diktat-rules</artifactId>
+            <artifactId>diktat-common</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <!-- Since we need diktat-rules only for property name, we can exclude everything else -->
+                    <!-- Since we need diktat-common only for property name, we can exclude everything else -->
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>


### PR DESCRIPTION
Since Gradle's embedded Kotlin support runtime target 1.4, we should decrease target of diktat-gradle-plugin and its transitive dependencies to be able to reference it in Gradle precompiled plugins, e.g. `buildSrc`.

### What's done:
* Changed dependency in diktat-gradle-plugin/pom.xml from diktat-rule sto diktat-common
* Build diktat-common for languageVersion 1.6