### PR TITLE
gradle-plugin: fix docs and tests for Groovy DSL

### DIFF
--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -27,8 +27,9 @@ repositories {
 }
 
 // default value is needed for correct gradle loading in IDEA; actual value from maven is used during build
-val ktlintVersion = project.properties.getOrDefault("ktlintVersion", "0.43.0") as String
-val diktatVersion = project.version.takeIf { it.toString() != Project.DEFAULT_VERSION } ?: "1.1.0"
+// To debug gradle plugin, please set `diktatVersion` manually to the current maven project version.
+val ktlintVersion = project.properties.getOrDefault("ktlintVersion", "0.46.1") as String
+val diktatVersion = project.version.takeIf { it.toString() != Project.DEFAULT_VERSION } ?: "1.2.1"
 val junitVersion = project.properties.getOrDefault("junitVersion", "5.8.1") as String
 val jacocoVersion = project.properties.getOrDefault("jacocoVersion", "0.8.7") as String
 dependencies {
@@ -107,7 +108,7 @@ val functionalTest = sourceSets.create("functionalTest") {
     runtimeClasspath += output + compileClasspath
 }
 tasks.getByName<Test>("functionalTest") {
-    dependsOn("test")
+    shouldRunAfter("test")
     testClassesDirs = functionalTest.output.classesDirs
     classpath = functionalTest.runtimeClasspath
     maxParallelForks = Runtime.getRuntime().availableProcessors()
@@ -131,7 +132,7 @@ jacocoTestKit {
     applyTo("functionalTestRuntimeOnly", tasks.named("functionalTest"))
 }
 tasks.jacocoTestReport {
-    dependsOn(tasks.withType<Test>())
+    shouldRunAfter(tasks.withType<Test>())
     executionData(
         fileTree("$buildDir/jacoco").apply {
             include("*.exec")

--- a/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginGroovyFunctionalTest.kt
+++ b/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginGroovyFunctionalTest.kt
@@ -27,14 +27,26 @@ class DiktatGradlePluginGroovyFunctionalTest {
     }
 
     @Test
-    fun `should execute diktatCheck on default values`() {
+    fun `should execute diktatCheck with default values`() {
         val result = runDiktat(testProjectDir, shouldSucceed = false)
 
-        val diktatCheckBuildResult = result.task(":${DiktatGradlePlugin.DIKTAT_CHECK_TASK}")
-        requireNotNull(diktatCheckBuildResult)
-        Assertions.assertEquals(TaskOutcome.FAILED, diktatCheckBuildResult.outcome)
-        Assertions.assertTrue(
-            result.output.contains("[FILE_NAME_MATCH_CLASS]")
+        assertDiktatExecuted(result)
+    }
+
+    @Test
+    fun `should execute diktatCheck with explicit configuration`() {
+        buildFile.appendText(
+            """${System.lineSeparator()}
+                diktat {
+                    inputs { it.include("src/**/*.kt") }
+                    reporter = "plain"
+                    diktatConfigFile = file(rootDir.path + "/diktat-analysis.yml")
+                }
+            """.trimIndent()
         )
+
+        val result = runDiktat(testProjectDir, shouldSucceed = false)
+
+        assertDiktatExecuted(result)
     }
 }

--- a/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/Utils.kt
+++ b/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/Utils.kt
@@ -2,7 +2,10 @@ package org.cqfn.diktat.plugin.gradle
 
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -70,4 +73,13 @@ private fun GradleRunner.withJaCoCo(number: Int) = apply {
                 it.write(text.replace("functionalTest.exec", "functionalTest-$number.exec"))
             }
         }
+}
+
+fun assertDiktatExecuted(result: BuildResult) {
+    val diktatCheckBuildResult = result.task(":${DiktatGradlePlugin.DIKTAT_CHECK_TASK}")
+    requireNotNull(diktatCheckBuildResult)
+    Assertions.assertEquals(TaskOutcome.FAILED, diktatCheckBuildResult.outcome)
+    Assertions.assertTrue(
+        result.output.contains("[FILE_NAME_MATCH_CLASS]")
+    )
 }

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatExtension.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatExtension.kt
@@ -34,8 +34,7 @@ open class DiktatExtension(
     var reporter: String = "plain"
 
     /**
-     * Type of output
-     * Default: System.out
+     * Destination for reporter. If empty, will write to stdout.
      */
     var output: String = ""
 

--- a/examples/gradle-groovy-dsl/build.gradle
+++ b/examples/gradle-groovy-dsl/build.gradle
@@ -7,5 +7,6 @@ repositories {
 }
 
 diktat {
-    inputs { include ("src/**/*.kt") }
+    inputs { it.include ("src/**/*.kt") }
+    diktatConfigFile = file(rootDir.path + "/diktat-analysis.yml")
 }


### PR DESCRIPTION
### What's done:
* Update build.gradle in examples
* Add functional test for Groovy DSL with explicit inputs
* Fix docs for `diktatExtension.output`: reporter treats any non-empty string as a file name, there are no special values
* Remove `dependsOn` relation between `test` and `functionalTest`, use `shouldRunAfter` instead

This pull request closes #1422