### PR TITLE
Don't reformat indent-style comments

### DIFF
--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingFixTest.kt
@@ -1,5 +1,7 @@
 package org.cqfn.diktat.ruleset.chapter2
 
+import org.cqfn.diktat.ruleset.chapter2.CommentsFormattingTest.Companion.indentStyleComment
+import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.describe
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.CommentsFormatting
 import org.cqfn.diktat.util.FixTestBase
 
@@ -7,9 +9,13 @@ import generated.WarningNames.COMMENT_WHITE_SPACE
 import generated.WarningNames.FIRST_COMMENT_NO_BLANK_LINE
 import generated.WarningNames.IF_ELSE_COMMENTS
 import generated.WarningNames.WRONG_NEWLINES_AROUND_KDOC
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Tags
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.nio.file.Path
 
 class CommentsFormattingFixTest : FixTestBase("test/paragraph2/kdoc/", ::CommentsFormatting) {
     @Test
@@ -39,5 +45,17 @@ class CommentsFormattingFixTest : FixTestBase("test/paragraph2/kdoc/", ::Comment
     @Tag(WRONG_NEWLINES_AROUND_KDOC)
     fun `regression - should not insert newline before the first comment in a file`() {
         fixAndCompare("NoPackageNoImportExpected.kt", "NoPackageNoImportTest.kt")
+    }
+
+    /**
+     * `indent(1)` and `style(9)` style comments.
+     */
+    @Test
+    @Tag(COMMENT_WHITE_SPACE)
+    fun `indent-style header in a block comment should be preserved`(@TempDir tempDir: Path) {
+        val lintResult = fixAndCompareContent(indentStyleComment, tempDir = tempDir)
+        assertThat(lintResult.actualContent)
+            .describedAs("lint result for ${indentStyleComment.describe()}")
+            .isEqualTo(lintResult.expectedContent)
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
@@ -8,6 +8,7 @@ import org.cqfn.diktat.util.LintTestBase
 
 import com.pinterest.ktlint.core.LintError
 import generated.WarningNames
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -490,5 +491,36 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code)
+    }
+
+    /**
+     * `indent(1)` and `style(9)` style comments.
+     */
+    @Test
+    @Tag(WarningNames.COMMENT_WHITE_SPACE)
+    fun `indent-style header in a block comment should produce no warnings`() =
+        lintMethod(indentStyleComment)
+
+    internal companion object {
+        @Language("kotlin")
+        internal val indentStyleComment = """
+        |/*-
+        | * This is an indent-style comment, and it's different from regular
+        | * block comments in C-like languages.
+        | *
+        | * Code formatters should not wrap or reflow its content, so you can
+        | * safely insert code fragments:
+        | *
+        | * ```
+        | * int i = 42;
+        | * ```
+        | *
+        | * or ASCII diagrams:
+        | *
+        | * +-----+
+        | * | Box |
+        | * +-----+
+        | */
+        """.trimMargin()
     }
 }


### PR DESCRIPTION
### What's done:

 * indent-style comments (those starting with `/*-`) are no longer reformatted.
 * See also:
   - [5.1.1 Block Comments](https://www.oracle.com/java/technologies/javase/codeconventions-comments.html)
   - [`indent(1)`](https://man.openbsd.org/indent.1)
   - [`style(9)`](https://www.freebsd.org/cgi/man.cgi?query=style&sektion=9)

## Which rule and warnings did you add?

## Actions checklist
* [X] Added tests on checks
* [X] Added tests on fixers
