### PR TITLE
Properly indent chained dot-qualified or safe-access expressions

### DIFF
--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
@@ -8,6 +8,7 @@ import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.assertNo
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.describe
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.extendedIndent
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.withCustomParameters
+import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.dotQualifiedExpressions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionBodyFunctions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionsWrappedAfterOperator
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.parenthesesSurroundedInfixExpressions
@@ -244,6 +245,40 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
             lintMultipleMethods(
                 actualContent = parenthesesSurroundedInfixExpressions[!extendedIndentAfterOperators].assertNotNull(),
                 expectedContent = parenthesesSurroundedInfixExpressions[extendedIndentAfterOperators].assertNotNull(),
+                tempDir = tempDir,
+                rulesConfigList = customConfig.asRulesConfigList())
+        }
+    }
+
+    /**
+     * See [#1336](https://github.com/saveourtool/diktat/issues/1336).
+     */
+    @Nested
+    @TestMethodOrder(DisplayName::class)
+    inner class `Dot- and safe-qualified expressions` {
+        @ParameterizedTest(name = "extendedIndentBeforeDot = {0}")
+        @ValueSource(booleans = [false, true])
+        @Tag(WarningNames.WRONG_INDENTATION)
+        fun `should be properly indented`(extendedIndentBeforeDot: Boolean, @TempDir tempDir: Path) {
+            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+            val customConfig = defaultConfig.withCustomParameters("extendedIndentBeforeDot" to extendedIndentBeforeDot)
+
+            lintMultipleMethods(
+                dotQualifiedExpressions[extendedIndentBeforeDot].assertNotNull(),
+                tempDir = tempDir,
+                rulesConfigList = customConfig.asRulesConfigList())
+        }
+
+        @ParameterizedTest(name = "extendedIndentBeforeDot = {0}")
+        @ValueSource(booleans = [false, true])
+        @Tag(WarningNames.WRONG_INDENTATION)
+        fun `should be reformatted if mis-indented`(extendedIndentBeforeDot: Boolean, @TempDir tempDir: Path) {
+            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+            val customConfig = defaultConfig.withCustomParameters("extendedIndentBeforeDot" to extendedIndentBeforeDot)
+
+            lintMultipleMethods(
+                actualContent = dotQualifiedExpressions[!extendedIndentBeforeDot].assertNotNull(),
+                expectedContent = dotQualifiedExpressions[extendedIndentBeforeDot].assertNotNull(),
                 tempDir = tempDir,
                 rulesConfigList = customConfig.asRulesConfigList())
         }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
@@ -979,6 +979,161 @@ internal object IndentationRuleTestResources {
         false to parenthesesSurroundedInfixExpressionsSingleIndent,
         true to parenthesesSurroundedInfixExpressionsContinuationIndent)
 
+    /**
+     * Dot-qualified and safe-access expressions, single indent
+     * (`extendedIndentBeforeDot` is **off**).
+     *
+     * When adding new code fragments to this list, be sure to also add their
+     * counterparts (preserving order) to
+     * [dotQualifiedExpressionsContinuationIndent].
+     *
+     * See [#1336](https://github.com/saveourtool/diktat/issues/1336).
+     *
+     * @see dotQualifiedExpressionsContinuationIndent
+     */
+    @Language("kotlin")
+    val dotQualifiedExpressionsSingleIndent = arrayOf(
+        """
+        |fun LocalDateTime.updateTime(
+        |    hour: Int? = null,
+        |    minute: Int? = null,
+        |    second: Int? = null,
+        |): LocalDateTime = withHour(hour ?: getHour())
+        |    .withMinute(minute ?: getMinute())
+        |    .withSecond(second ?: getSecond())
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    first()
+        |        .second()
+        |        .third()
+        |}
+        """.trimMargin(),
+
+        """
+        |val a = first()
+        |    .second()
+        |    .third()
+        """.trimMargin(),
+
+        """
+        |val b = first()
+        |    ?.second()
+        |    ?.third()
+        """.trimMargin(),
+
+        """
+        |fun f1() = first()
+        |    .second()
+        |    .third()
+        """.trimMargin(),
+
+        """
+        |fun f2() =
+        |    first()
+        |        .second()
+        |        .third()
+        """.trimMargin(),
+
+        """
+        |fun f3() = g(first()
+        |    .second()
+        |    .third()
+        |    .fourth())
+        """.trimMargin(),
+
+        """
+        |fun f4() = g(
+        |    first()
+        |        .second()
+        |        .third()
+        |        .fourth())
+        """.trimMargin(),
+    )
+
+    /**
+     * Dot-qualified and safe-access expressions, continuation indent
+     * (`extendedIndentBeforeDot` is **on**).
+     *
+     * When adding new code fragments to this list, be sure to also add their
+     * counterparts (preserving order) to
+     * [dotQualifiedExpressionsSingleIndent].
+     *
+     * See [#1336](https://github.com/saveourtool/diktat/issues/1336).
+     *
+     * @see dotQualifiedExpressionsSingleIndent
+     */
+    @Language("kotlin")
+    val dotQualifiedExpressionsContinuationIndent = arrayOf(
+        """
+        |fun LocalDateTime.updateTime(
+        |    hour: Int? = null,
+        |    minute: Int? = null,
+        |    second: Int? = null,
+        |): LocalDateTime = withHour(hour ?: getHour())
+        |        .withMinute(minute ?: getMinute())
+        |        .withSecond(second ?: getSecond())
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    first()
+        |            .second()
+        |            .third()
+        |}
+        """.trimMargin(),
+
+        """
+        |val a = first()
+        |        .second()
+        |        .third()
+        """.trimMargin(),
+
+        """
+        |val b = first()
+        |        ?.second()
+        |        ?.third()
+        """.trimMargin(),
+
+        """
+        |fun f1() = first()
+        |        .second()
+        |        .third()
+        """.trimMargin(),
+
+        """
+        |fun f2() =
+        |    first()
+        |            .second()
+        |            .third()
+        """.trimMargin(),
+
+        """
+        |fun f3() = g(first()
+        |        .second()
+        |        .third()
+        |        .fourth())
+        """.trimMargin(),
+
+        """
+        |fun f4() = g(
+        |    first()
+        |            .second()
+        |            .third()
+        |            .fourth())
+        """.trimMargin(),
+    )
+
+    /**
+     * Dot-qualified and safe-access expressions.
+     *
+     * See [#1336](https://github.com/saveourtool/diktat/issues/1336).
+     */
+    val dotQualifiedExpressions = mapOf(
+        false to dotQualifiedExpressionsSingleIndent,
+        true to dotQualifiedExpressionsContinuationIndent)
+
     @Language("kotlin")
     @Suppress("COMMENT_WHITE_SPACE")
     private val ifExpressionsSingleIndent = arrayOf(


### PR DESCRIPTION
### What's done:

 * This fixes #1336

## Which rule and warnings did you add?

## Actions checklist
* [X] Added tests on checks
* [X] Added tests on fixers
