### PR TITLE
Hotfix for Data Classes rule

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
@@ -252,7 +252,7 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
      * @property type a type to which the reference is being cast
      * @property node a node that holds the entire expression
      */
-    class AsExpressions(
+    data class AsExpressions(
         val identifier: String,
         val type: String,
         val node: ASTNode
@@ -262,7 +262,7 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
      * @property identifier a reference that is checked
      * @property type a type with which the reference is being compared
      */
-    class IsExpressions(val identifier: String, val type: String)
+    data class IsExpressions(val identifier: String, val type: String)
 
     companion object {
         const val NAME_ID = "smart-cast-rule"

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/DataClassesRule.kt
@@ -104,7 +104,7 @@ class DataClassesRule(configRules: List<RulesConfig>) : DiktatRule(
                     ?: false &&
                 getFirstChildWithType(SUPER_TYPE_LIST) == null
         }
-        return classBody?.getAllChildrenWithType(FUN)?.isEmpty() ?: false &&
+        return classBody?.getFirstChildWithType(FUN) == null &&
             getFirstChildWithType(SUPER_TYPE_LIST) == null &&
             // if there is any prop with logic in accessor then don't recommend to convert class to data class
             classBody?.let(::areGoodProps)

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
@@ -28,6 +28,18 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
 
     @Test
     @Tag(USE_DATA_CLASS)
+    fun `_regression_ trigger on default class without a body`() {
+        lintMethod(
+            """
+                    |class Some(val a: Int = 5)
+                    |
+            """.trimMargin(),
+            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Some")
+        )
+    }
+
+    @Test
+    @Tag(USE_DATA_CLASS)
     fun `should trigger - dont forget to consider this class in fix`() {
         lintMethod(
             """


### PR DESCRIPTION
### What's done:
- covered cases when data class does not have a body: class (val a: Int)
Previously we handled only class (val a: Int) {} because of the invalid logic for `hasAppropriateClassBody`