### PR TITLE
Set `extendedIndentAfterOperators` to `true` by default

### DIFF
--- a/diktat-analysis.yml
+++ b/diktat-analysis.yml
@@ -215,7 +215,7 @@
     # ij_kotlin_continuation_indent_for_expression_bodies in .editorconfig.
     extendedIndentForExpressionBodies: false
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: false
+    extendedIndentAfterOperators: true
     # If true: when dot qualified expression starts on a new line, this line will be indented with two indentations instead of one
     extendedIndentBeforeDot: false
     # The indentation size for each file

--- a/diktat-common/src/test/resources/test-rules-config.yml
+++ b/diktat-common/src/test/resources/test-rules-config.yml
@@ -128,7 +128,7 @@
     extendedIndentOfParameters: false
     alignedParameters: true
     extendedIndentForExpressionBodies: false
-    extendedIndentAfterOperators: false
+    extendedIndentAfterOperators: true
     indentationSize: 4
 - name: EMPTY_BLOCK_STRUCTURE_ERROR
   enabled: true

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -236,7 +236,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
     }
 
     private fun getJavaExecJvmVersion(): JavaVersion = if (GradleVersion.version(gradleVersionString) >= GradleVersion.version("6.7") &&
-        javaLauncher.isPresent
+            javaLauncher.isPresent
     ) {
         // Java Launchers are available since 6.7, but may not always be configured
         javaLauncher.map { it.metadata.jvmVersion }.map(JavaVersion::toVersion).get()

--- a/diktat-maven-plugin/src/main/kotlin/org/cqfn/diktat/plugin/maven/DiktatBaseMojo.kt
+++ b/diktat-maven-plugin/src/main/kotlin/org/cqfn/diktat/plugin/maven/DiktatBaseMojo.kt
@@ -112,7 +112,7 @@ abstract class DiktatBaseMojo : AbstractMojo() {
             throw MojoExecutionException("Configuration file $diktatConfigFile doesn't exist")
         }
         log.info("Running diKTat plugin with configuration file $configFile and inputs $inputs" +
-            if (excludes.isNotEmpty()) " and excluding $excludes" else ""
+                if (excludes.isNotEmpty()) " and excluding $excludes" else ""
         )
 
         val ruleSets by lazy {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/constants/Warnings.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/constants/Warnings.kt
@@ -106,7 +106,7 @@ enum class Warnings(
     NO_BRACES_IN_CONDITIONALS_AND_LOOPS(true, "3.2.1", "in if, else, when, for, do, and while statements braces should be used. Exception: single line ternary operator statement"),
     WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES(true, "3.1.4", "the declaration part of a class-like code structures (class/interface/etc.) should be in the proper order"),
     BLANK_LINE_BETWEEN_PROPERTIES(true, "3.1.4", "there should be no blank lines between properties without comments; comment, KDoc or annotation on property should have blank" +
-        " line before"),
+            " line before"),
     TOP_LEVEL_ORDER(true, "3.1.5", "the declaration part of a top level elements should be in the proper order"),
     BRACES_BLOCK_STRUCTURE_ERROR(true, "3.2.2", "braces should follow 1TBS style"),
     WRONG_INDENTATION(true, "3.3.1", "only spaces are allowed for indentation and each indentation should equal to 4 spaces (tabs are not allowed)"),

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
@@ -111,7 +111,7 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
     )
     override fun get(): RuleSet {
         log.debug("Will run $DIKTAT_RULE_SET_ID with $diktatConfigFile" +
-            " (it can be placed to the run directory or the default file from resources will be used)")
+                " (it can be placed to the run directory or the default file from resources will be used)")
         val configPath = possibleConfigs
             .firstOrNull { it != null && File(it).exists() }
         diktatConfigFile = configPath
@@ -119,12 +119,12 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
                 val possibleConfigsList = possibleConfigs.toList()
                 log.warn(
                     "Configuration file not found in directory where diktat is run (${possibleConfigsList[0]}) " +
-                        "or in the directory where diktat.jar is stored (${possibleConfigsList[1]}) " +
-                        "or in system property <diktat.config.path> (${possibleConfigsList[2]}), " +
-                        "the default file included in jar will be used. " +
-                        "Some configuration options will be disabled or substituted with defaults. " +
-                        "Custom configuration file should be placed in diktat working directory if run from CLI " +
-                        "or provided as configuration options in plugins."
+                            "or in the directory where diktat.jar is stored (${possibleConfigsList[1]}) " +
+                            "or in system property <diktat.config.path> (${possibleConfigsList[2]}), " +
+                            "the default file included in jar will be used. " +
+                            "Some configuration options will be disabled or substituted with defaults. " +
+                            "Custom configuration file should be placed in diktat working directory if run from CLI " +
+                            "or provided as configuration options in plugins."
                 )
                 diktatConfigFile
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
@@ -169,7 +169,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
                 }
                 // check if identifier of a property has a confusing name
                 if (confusingIdentifierNames.contains(variableName.text) && !isValidCatchIdentifier(variableName) &&
-                    node.elementType == ElementType.PROPERTY
+                        node.elementType == ElementType.PROPERTY
                 ) {
                     warnConfusingName(variableName)
                 }
@@ -193,7 +193,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
                             ?.forEach { (it.node.firstChildNode as LeafPsiElement).rawReplaceWithText(correctVariableName) }
                         if (variableName.treeParent.psi.run {
                             (this is KtProperty && isMember) ||
-                                (this is KtParameter && getParentOfType<KtPrimaryConstructor>(true)?.valueParameters?.contains(this) == true)
+                                    (this is KtParameter && getParentOfType<KtPrimaryConstructor>(true)?.valueParameters?.contains(this) == true)
                         }) {
                             // For class members also check `@property` KDoc tag.
                             // If we are here, then `variableName` is definitely a node from a class or an object.
@@ -257,7 +257,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
             destructingDeclaration.getAllChildrenWithType(DESTRUCTURING_DECLARATION_ENTRY)
                 .map { it.getIdentifierName()!! }
         } else if (node.parents().count() > 1 && node.treeParent.elementType == VALUE_PARAMETER_LIST &&
-            node.treeParent.treeParent.elementType == FUNCTION_TYPE
+                node.treeParent.treeParent.elementType == FUNCTION_TYPE
         ) {
             listOfNotNull(node.getIdentifierName())
         } else {
@@ -440,7 +440,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
         nodes.forEach {
             val isValidOneCharVariable = oneCharIdentifiers.contains(it.text) && isVariable
             if (it.text != "_" && !it.isTextLengthInRange(MIN_IDENTIFIER_LENGTH..MAX_IDENTIFIER_LENGTH) &&
-                !isValidOneCharVariable && !isValidCatchIdentifier(it)
+                    !isValidOneCharVariable && !isValidCatchIdentifier(it)
             ) {
                 IDENTIFIER_LENGTH.warn(configRules, emitWarn, isFixMode, it.text, it.startOffset, it)
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
@@ -82,7 +82,7 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
             }
         } ?: if (visitorCounter.incrementAndGet() == 1) {
             log.error("Not able to find an external configuration for domain" +
-                " name in the common configuration (is it missing in yml config?)")
+                    " name in the common configuration (is it missing in yml config?)")
         } else {
             @Suppress("RedundantUnitExpression")
             Unit
@@ -127,7 +127,7 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
 
         return if (!filePathParts.contains(PACKAGE_PATH_ANCHOR)) {
             log.error("Not able to determine a path to a scanned file or \"$PACKAGE_PATH_ANCHOR\" directory cannot be found in it's path." +
-                " Will not be able to determine correct package name. It can happen due to missing <$PACKAGE_PATH_ANCHOR> directory in the path")
+                    " Will not be able to determine correct package name. It can happen due to missing <$PACKAGE_PATH_ANCHOR> directory in the path")
             emptyList()
         } else {
             // creating a real package name:
@@ -202,8 +202,8 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
         val wordFromPackage = word.replace("_", "")
 
         return wordFromPackage[0].isDigit() ||
-            wordFromPackage.isKotlinKeyWord() ||
-            wordFromPackage.isJavaKeyWord()
+                wordFromPackage.isKotlinKeyWord() ||
+                wordFromPackage.isJavaKeyWord()
     }
 
     /**

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/CommentsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/CommentsRule.kt
@@ -95,11 +95,11 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
             .forEach { (offset, parsedNode) ->
                 val invalidNode = errorNodesWithText.find {
                     it.second.trim().contains(parsedNode.text, false) ||
-                        parsedNode.text.contains(it.second.trim(), false)
+                            parsedNode.text.contains(it.second.trim(), false)
                 }?.first
                 if (invalidNode == null) {
                     logger.warn("Text [${parsedNode.text}] is a piece of code, created from comment; " +
-                        "but no matching text in comments has been found in the file ${node.getFilePath()}")
+                            "but no matching text in comments has been found in the file ${node.getFilePath()}")
                 } else {
                     COMMENTED_OUT_CODE.warn(
                         configRules,
@@ -168,9 +168,9 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
      * are considered for this case.
      */
     private fun String.isPossibleImport(): Boolean = trimStart().startsWith(importKeywordWithSpace) &&
-        substringAfter(importKeywordWithSpace, "").run {
-            startsWith('`') && endsWith('`') || !contains(' ')
-        }
+            substringAfter(importKeywordWithSpace, "").run {
+                startsWith('`') && endsWith('`') || !contains(' ')
+            }
 
     @Suppress("MaxLineLength")
     companion object {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
@@ -61,7 +61,7 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun checkHeaderKdoc(node: ASTNode) {
         node.findChildBefore(PACKAGE_DIRECTIVE, KDOC)?.let { headerKdoc ->
             if (headerKdoc.treeNext != null && headerKdoc.treeNext.elementType == WHITE_SPACE &&
-                headerKdoc.treeNext.text.count { it == '\n' } != 2) {
+                    headerKdoc.treeNext.text.count { it == '\n' } != 2) {
                 HEADER_WRONG_FORMAT.warnAndFix(configRules, emitWarn, isFixMode,
                     "header KDoc should have a new line after", headerKdoc.startOffset, headerKdoc) {
                     node.replaceChild(headerKdoc.treeNext, PsiWhiteSpaceImpl("\n\n"))
@@ -70,7 +70,7 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
         }
             ?: run {
                 val numDeclaredClassesAndObjects = node.getAllChildrenWithType(ElementType.CLASS).size +
-                    node.getAllChildrenWithType(ElementType.OBJECT_DECLARATION).size
+                        node.getAllChildrenWithType(ElementType.OBJECT_DECLARATION).size
                 if (numDeclaredClassesAndObjects != 1) {
                     HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warn(configRules, emitWarn, isFixMode,
                         "there are $numDeclaredClassesAndObjects declared classes and/or objects", node.startOffset, node)
@@ -148,12 +148,12 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
         val headerComment = node.findChildBefore(PACKAGE_DIRECTIVE, BLOCK_COMMENT)
         // Depends only on content and doesn't consider years
         val isCopyrightMatchesPatternExceptFirstYear = isCopyRightTextMatchesPattern(headerComment, copyrightText) ||
-            isCopyRightTextMatchesPattern(headerComment, copyrightWithCorrectYear)
+                isCopyRightTextMatchesPattern(headerComment, copyrightWithCorrectYear)
 
         val isWrongCopyright = headerComment != null &&
-            !isCopyrightMatchesPatternExceptFirstYear &&
-            !isHeaderCommentContainText(headerComment, copyrightText) &&
-            !isHeaderCommentContainText(headerComment, copyrightWithCorrectYear)
+                !isCopyrightMatchesPatternExceptFirstYear &&
+                !isHeaderCommentContainText(headerComment, copyrightText) &&
+                !isHeaderCommentContainText(headerComment, copyrightWithCorrectYear)
 
         val isMissingCopyright = headerComment == null && configuration.isCopyrightMandatory()
         val isCopyrightInsideKdoc = (node.getAllChildrenWithType(KDOC) + node.getAllChildrenWithType(ElementType.EOL_COMMENT))

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/CommentsFormatting.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/CommentsFormatting.kt
@@ -113,7 +113,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
                 return
             }
         } else if (node.treeParent.lastChildNode != node && node.treeParent.elementType != IF &&
-            node.treeParent.firstChildNode == node && node.treeParent.elementType != VALUE_ARGUMENT_LIST) {
+                node.treeParent.firstChildNode == node && node.treeParent.elementType != VALUE_ARGUMENT_LIST) {
             // Else it's a class comment
             checkClassComment(node)
         }
@@ -224,41 +224,41 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
     @Suppress("ComplexMethod", "TOO_LONG_FUNCTION")
     private fun checkWhiteSpaceBeginInComment(node: ASTNode, configuration: CommentsFormattingConfiguration) {
         if (node.elementType == EOL_COMMENT &&
-            node
-                .text
-                .trimStart('/')
-                .takeWhile { it == ' ' }
-                .length == configuration.maxSpacesInComment) {
+                node
+                    .text
+                    .trimStart('/')
+                    .takeWhile { it == ' ' }
+                    .length == configuration.maxSpacesInComment) {
             return
         }
 
         if (node.elementType == BLOCK_COMMENT &&
-            (node.isIndentStyleComment() ||
-                node
-                    .text
-                    .trim('/', '*')
-                    .takeWhile { it == ' ' }
-                    .length == configuration.maxSpacesInComment ||
-                node
-                    .text
-                    .trim('/', '*')
-                    .takeWhile { it == '\n' }
-                    .isNotEmpty())) {
+                (node.isIndentStyleComment() ||
+                        node
+                            .text
+                            .trim('/', '*')
+                            .takeWhile { it == ' ' }
+                            .length == configuration.maxSpacesInComment ||
+                        node
+                            .text
+                            .trim('/', '*')
+                            .takeWhile { it == '\n' }
+                            .isNotEmpty())) {
             return
         }
 
         if (node.elementType == KDOC) {
             val section = node.getFirstChildWithType(KDOC_SECTION)
             if (section != null &&
-                section.findChildrenMatching(KDOC_TEXT) { (it.treePrev != null && it.treePrev.elementType == KDOC_LEADING_ASTERISK) || it.treePrev == null }
-                    .all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
+                    section.findChildrenMatching(KDOC_TEXT) { (it.treePrev != null && it.treePrev.elementType == KDOC_LEADING_ASTERISK) || it.treePrev == null }
+                        .all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
                 // it.treePrev == null if there is no \n at the beginning of KDoc
                 return
             }
 
             if (section != null &&
-                section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).isNotEmpty() &&
-                section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
+                    section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).isNotEmpty() &&
+                    section.getAllChildrenWithType(KDOC_CODE_BLOCK_TEXT).all { it.text.startsWith(" ".repeat(configuration.maxSpacesInComment)) }) {
                 return
             }
         }
@@ -304,7 +304,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
                 node.treeParent.treeParent.addChild(PsiWhiteSpaceImpl("\n"), node.treeParent)
             }
         } else if (node.treeParent.elementType != FILE &&
-            (node.treeParent.treePrev.numNewLines() == 1 || node.treeParent.treePrev.numNewLines() > 2)) {
+                (node.treeParent.treePrev.numNewLines() == 1 || node.treeParent.treePrev.numNewLines() > 2)) {
             WRONG_NEWLINES_AROUND_KDOC.warnAndFix(configRules, emitWarn, isFixMode, node.text, node.startOffset, node) {
                 (node.treeParent.treePrev as LeafPsiElement).rawReplaceWithText("\n\n")
             }
@@ -313,7 +313,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun checkFirstCommentSpaces(node: ASTNode) {
         if (node.treePrev.isWhiteSpace() &&
-            (node.treePrev.numNewLines() > 1 || node.treePrev.numNewLines() == 0)) {
+                (node.treePrev.numNewLines() > 1 || node.treePrev.numNewLines() == 0)) {
             FIRST_COMMENT_NO_BLANK_LINE.warnAndFix(configRules, emitWarn, isFixMode, node.text, node.startOffset, node) {
                 (node.treePrev as LeafPsiElement).rawReplaceWithText("\n")
             }
@@ -332,7 +332,7 @@ class CommentsFormatting(configRules: List<RulesConfig>) : DiktatRule(
         // `treeParent` is the first not-empty node in a file
         true
     } else if (node.treeParent.elementType != FILE && node.treeParent.treePrev != null &&
-        node.treeParent.treePrev.treePrev != null) {
+            node.treeParent.treePrev.treePrev != null) {
         // When comment inside of a PROPERTY
         node.treeParent
             .treePrev

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
@@ -111,8 +111,8 @@ class KdocComments(configRules: List<RulesConfig>) : DiktatRule(
     @Suppress("UnsafeCallOnNullableType", "ComplexMethod")
     private fun checkValueParameter(valueParameterNode: ASTNode) {
         if (valueParameterNode.parents().none { it.elementType == PRIMARY_CONSTRUCTOR } ||
-            !valueParameterNode.hasChildOfType(VAL_KEYWORD) &&
-                !valueParameterNode.hasChildOfType(VAR_KEYWORD)
+                !valueParameterNode.hasChildOfType(VAL_KEYWORD) &&
+                        !valueParameterNode.hasChildOfType(VAR_KEYWORD)
         ) {
             return
         }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
@@ -162,11 +162,11 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun findBeforeAndAfterSpaces(tag: KDocTag) = Pair(tag.node.findChildBefore(KDOC_TEXT, WHITE_SPACE).let {
         it?.text != " " &&
-            !(it?.isWhiteSpaceWithNewline() ?: false)
+                !(it?.isWhiteSpaceWithNewline() ?: false)
     },
         tag.node.findChildAfter(KDOC_TAG_NAME, WHITE_SPACE).let {
             it?.text != " " &&
-                !(it?.isWhiteSpaceWithNewline() ?: false)
+                    !(it?.isWhiteSpaceWithNewline() ?: false)
         }
     )
 
@@ -290,11 +290,11 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
         val poorlyFormattedTagNodes = presentSpecialTagNodes?.filterNot { specialTagNode ->
             // empty line with just * followed by white space or end of block
             specialTagNode.lastChildNode.elementType == KDOC_LEADING_ASTERISK &&
-                (specialTagNode.treeNext == null || specialTagNode.treeNext.elementType == WHITE_SPACE &&
-                    specialTagNode.treeNext.text.count { it == '\n' } == 1) &&
-                // and with no empty line before
-                specialTagNode.lastChildNode.treePrev.elementType == WHITE_SPACE &&
-                specialTagNode.lastChildNode.treePrev.treePrev.elementType != KDOC_LEADING_ASTERISK
+                    (specialTagNode.treeNext == null || specialTagNode.treeNext.elementType == WHITE_SPACE &&
+                            specialTagNode.treeNext.text.count { it == '\n' } == 1) &&
+                    // and with no empty line before
+                    specialTagNode.lastChildNode.treePrev.elementType == WHITE_SPACE &&
+                    specialTagNode.lastChildNode.treePrev.treePrev.elementType != KDOC_LEADING_ASTERISK
         }
 
         if (poorlyFormattedTagNodes != null && poorlyFormattedTagNodes.isNotEmpty()) {
@@ -324,7 +324,7 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
         node.kDocTags()
             .filter {
                 it.knownTag == KDocKnownTag.AUTHOR ||
-                    it.knownTag == KDocKnownTag.SINCE && it.hasInvalidVersion()
+                        it.knownTag == KDocKnownTag.SINCE && it.hasInvalidVersion()
             }
             .forEach {
                 KDOC_CONTAINS_DATE_OR_AUTHOR.warn(configRules, emitWarn, isFixMode, it.text.trim(), it.startOffset, it.node)
@@ -335,7 +335,7 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
     private fun ASTNode.hasEmptyLineAfter(): Boolean {
         require(this.elementType == KDOC_TAG) { "This check is only for KDOC_TAG" }
         return lastChildNode.elementType == KDOC_LEADING_ASTERISK &&
-            (treeNext == null || treeNext.elementType == WHITE_SPACE && treeNext.text.count { it == '\n' } == 1)
+                (treeNext == null || treeNext.elementType == WHITE_SPACE && treeNext.text.count { it == '\n' } == 1)
     }
 
     private fun ASTNode.kDocBasicTags() = kDocTags().filter { basicTagsList.contains(it.knownTag) }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
@@ -277,11 +277,11 @@ class KdocMethods(configRules: List<RulesConfig>) : DiktatRule(
     ) {
         MISSING_KDOC_ON_FUNCTION.warnAndFix(configRules, emitWarn, isFixMode, name, node.startOffset, node) {
             val kdocTemplate = "/**\n" +
-                (missingParameters.joinToString("") { " * @param $it\n" } +
-                    (if (returnCheckFailed) " * @return\n" else "") +
-                    explicitlyThrownExceptions.joinToString("") { " * @throws $it\n" } +
-                    " */\n"
-                )
+                    (missingParameters.joinToString("") { " * @param $it\n" } +
+                            (if (returnCheckFailed) " * @return\n" else "") +
+                            explicitlyThrownExceptions.joinToString("") { " * @throws $it\n" } +
+                            " */\n"
+                    )
             val kdocNode = KotlinParser().createNode(kdocTemplate).findChildByType(KDOC)!!
             node.appendNewlineMergingWhiteSpace(node.firstChildNode, node.firstChildNode)
             node.addChild(kdocNode, node.firstChildNode)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BooleanExpressionsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BooleanExpressionsRule.kt
@@ -94,10 +94,10 @@ class BooleanExpressionsRule(configRules: List<RulesConfig>) : DiktatRule(
         val logicalExpressions = otherBinaryExpressions.filter { otherBinaryExpression ->
             // keeping only boolean expressions, keeping things like `a + b < 6` and excluding `a + b`
             (otherBinaryExpression.psi as KtBinaryExpression).operationReference.text in logicalInfixMethods &&
-                // todo: support xor; for now skip all expressions that are nested in xor
-                otherBinaryExpression.parents()
-                    .takeWhile { it != node }
-                    .none { (it.psi as? KtBinaryExpression)?.isXorExpression() ?: false }
+                    // todo: support xor; for now skip all expressions that are nested in xor
+                    otherBinaryExpression.parents()
+                        .takeWhile { it != node }
+                        .none { (it.psi as? KtBinaryExpression)?.isXorExpression() ?: false }
         }
         // Boolean expressions like `a > 5 && b < 7` or `x.isEmpty() || (y.isNotEmpty())` we convert to individual parts.
         val elementaryBooleanExpressions = booleanBinaryExpressions
@@ -110,13 +110,13 @@ class BooleanExpressionsRule(configRules: List<RulesConfig>) : DiktatRule(
             .filterNot {
                 // finally, if parts are binary expressions themselves, they should be present in our lists and we will process them later.
                 it.elementType == BINARY_EXPRESSION ||
-                    // !(a || b) should be skipped too, `a` and `b` should be present later
-                    (it.psi as? KtPrefixExpression)?.lastChild
-                        ?.node
-                        ?.removeAllParentheses()
-                        ?.elementType == BINARY_EXPRESSION ||
-                    // `true` and `false` are valid tokens for jBool, so we keep them.
-                    it.text == "true" || it.text == "false"
+                        // !(a || b) should be skipped too, `a` and `b` should be present later
+                        (it.psi as? KtPrefixExpression)?.lastChild
+                            ?.node
+                            ?.removeAllParentheses()
+                            ?.elementType == BINARY_EXPRESSION ||
+                        // `true` and `false` are valid tokens for jBool, so we keep them.
+                        it.text == "true" || it.text == "false"
             }
         (logicalExpressions + elementaryBooleanExpressions).forEach { expression ->
             expressionsReplacement.addExpression(expression)
@@ -136,9 +136,9 @@ class BooleanExpressionsRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun ASTNode.collectElementaryExpressions() = this
         .findAllNodesWithCondition { astNode ->
             astNode.elementType == BINARY_EXPRESSION &&
-                // filter out boolean conditions in nested lambdas, e.g. `if (foo.filter { a && b })`
-                (astNode == this || astNode.parents().takeWhile { it != this }
-                    .all { it.elementType in setOf(BINARY_EXPRESSION, PARENTHESIZED, PREFIX_EXPRESSION) })
+                    // filter out boolean conditions in nested lambdas, e.g. `if (foo.filter { a && b })`
+                    (astNode == this || astNode.parents().takeWhile { it != this }
+                        .all { it.elementType in setOf(BINARY_EXPRESSION, PARENTHESIZED, PREFIX_EXPRESSION) })
         }
         .partition {
             val operationReferenceText = (it.psi as KtBinaryExpression).operationReference.text

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BracesInConditionalsAndLoopsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/BracesInConditionalsAndLoopsRule.kt
@@ -161,7 +161,7 @@ class BracesInConditionalsAndLoopsRule(configRules: List<RulesConfig>) : DiktatR
             .map { it.expression as KtBlockExpression }
             .filter { block ->
                 block.statements.size == 1 &&
-                    block.findChildrenMatching { it.isPartOfComment() }.isEmpty()
+                        block.findChildrenMatching { it.isPartOfComment() }.isEmpty()
             }
             .forEach {
                 NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnAndFix(configRules, emitWarn, isFixMode, "WHEN", it.node.startOffset, it.node) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ClassLikeStructuresOrderRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ClassLikeStructuresOrderRule.kt
@@ -72,9 +72,9 @@ class ClassLikeStructuresOrderRule(configRules: List<RulesConfig>) : DiktatRule(
             .allBlockFlattened()
             .map { astNode ->
                 listOf(astNode) +
-                    astNode.siblings(false)
-                        .takeWhile { it.elementType == WHITE_SPACE || it.isPartOfComment() }
-                        .toList()
+                        astNode.siblings(false)
+                            .takeWhile { it.elementType == WHITE_SPACE || it.isPartOfComment() }
+                            .toList()
             }
 
         node.checkAndReorderBlocks(blocks)
@@ -97,7 +97,7 @@ class ClassLikeStructuresOrderRule(configRules: List<RulesConfig>) : DiktatRule(
             .annotationEntries
             .any { it.node.isFollowedByNewline() }
         val hasCustomAccessors = (node.psi as KtProperty).accessors.isNotEmpty() ||
-            (previousProperty.psi as KtProperty).accessors.isNotEmpty()
+                (previousProperty.psi as KtProperty).accessors.isNotEmpty()
 
         val whiteSpaceBefore = previousProperty.nextSibling { it.elementType == WHITE_SPACE } ?: return
         val isBlankLineRequired = hasCommentBefore || hasAnnotationsBefore || hasCustomAccessors
@@ -105,7 +105,7 @@ class ClassLikeStructuresOrderRule(configRules: List<RulesConfig>) : DiktatRule(
         val actualNewLines = whiteSpaceBefore.text.count { it == '\n' }
         // for some cases (now - if this or previous property has custom accessors), blank line is allowed before it
         if (!hasCustomAccessors && actualNewLines != numRequiredNewLines ||
-            hasCustomAccessors && actualNewLines > numRequiredNewLines) {
+                hasCustomAccessors && actualNewLines > numRequiredNewLines) {
             BLANK_LINE_BETWEEN_PROPERTIES.warnAndFix(configRules, emitWarn, isFixMode, node.getIdentifierName()?.text ?: node.text, node.startOffset, node) {
                 whiteSpaceBefore.leaveExactlyNumNewLines(numRequiredNewLines)
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
@@ -88,7 +88,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val nestedIfNode = parentThenNode.findChildByType(IF) ?: return null
         // We won't collapse if-statements, if some of them have `else` node
         if ((parentNode.psi as KtIfExpression).`else` != null ||
-            (nestedIfNode.psi as KtIfExpression).`else` != null) {
+                (nestedIfNode.psi as KtIfExpression).`else` != null) {
             return null
         }
         // We monitor which types of nodes are followed before and after nested `if`
@@ -101,7 +101,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val listOfNodesAfterNestedIf = parentThenNode.getChildren(null).takeLastWhile { it != parentThenNode.findChildByType(IF) }
         val allowedTypes = listOf(LBRACE, WHITE_SPACE, RBRACE, BLOCK_COMMENT, EOL_COMMENT)
         if (listOfNodesBeforeNestedIf.any { it.elementType !in allowedTypes } ||
-            listOfNodesAfterNestedIf.any { it.elementType !in allowedTypes }) {
+                listOfNodesAfterNestedIf.any { it.elementType !in allowedTypes }) {
             return null
         }
         return nestedIfNode
@@ -138,7 +138,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         // we need to put it to the brackets, according algebra of logic
         val mergeCondition =
             if (nestedCondition?.node?.elementType == BINARY_EXPRESSION &&
-                nestedCondition.node?.findChildByType(OPERATION_REFERENCE)?.text == "||"
+                    nestedCondition.node?.findChildByType(OPERATION_REFERENCE)?.text == "||"
             ) {
                 "if ($parentConditionText &&$commentsText($nestedConditionText)) {}"
             } else {
@@ -171,7 +171,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val comments = takeCommentsBeforeNestedIf(parentNode)
         comments.forEach {
             if (it.treeNext.elementType == WHITE_SPACE &&
-                it.treePrev.elementType == WHITE_SPACE) {
+                    it.treePrev.elementType == WHITE_SPACE) {
                 parentNode.removeChild(it.treePrev)
             }
             parentNode.removeChild(it)
@@ -183,12 +183,12 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         repeat(2) {
             val firstElType = nestedContent.first().elementType
             if (firstElType == WHITE_SPACE ||
-                firstElType == LBRACE) {
+                    firstElType == LBRACE) {
                 nestedContent.removeFirst()
             }
             val lastElType = nestedContent.last().elementType
             if (lastElType == WHITE_SPACE ||
-                lastElType == RBRACE) {
+                    lastElType == RBRACE) {
                 nestedContent.removeLast()
             }
         }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ConsecutiveSpacesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/ConsecutiveSpacesRule.kt
@@ -55,7 +55,7 @@ class ConsecutiveSpacesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun squeezeSpacesToOne(node: ASTNode, configuration: TooManySpacesRuleConfiguration) {
         val spaces = node.textLength
         if (spaces > configuration.numberOfSpaces && !node.isWhiteSpaceWithNewline() &&
-            !node.hasEolComment()) {
+                !node.hasEolComment()) {
             TOO_MANY_CONSECUTIVE_SPACES.warnAndFix(configRules, emitWarn, isFixMode,
                 "found: $spaces. need to be: ${configuration.numberOfSpaces}", node.startOffset, node) {
                 node.squeezeSpaces()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/DebugPrintRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/DebugPrintRule.kt
@@ -29,9 +29,9 @@ class DebugPrintRule(configRules: List<RulesConfig>) : DiktatRule(
             val referenceExpression = node.findChildByType(ElementType.REFERENCE_EXPRESSION)?.text
             val valueArgumentList = node.findChildByType(ElementType.VALUE_ARGUMENT_LIST)
             if (referenceExpression in setOf("print", "println") &&
-                node.treePrev?.elementType != ElementType.DOT &&
-                valueArgumentList?.getChildren(TokenSet.create(ElementType.VALUE_ARGUMENT))?.size?.let { it <= 1 } == true &&
-                node.findChildByType(ElementType.LAMBDA_ARGUMENT) == null) {
+                    node.treePrev?.elementType != ElementType.DOT &&
+                    valueArgumentList?.getChildren(TokenSet.create(ElementType.VALUE_ARGUMENT))?.size?.let { it <= 1 } == true &&
+                    node.findChildByType(ElementType.LAMBDA_ARGUMENT) == null) {
                 Warnings.DEBUG_PRINT.warn(
                     configRules, emitWarn, isFixMode,
                     "found $referenceExpression()", node.startOffset, node,
@@ -45,7 +45,7 @@ class DebugPrintRule(configRules: List<RulesConfig>) : DiktatRule(
         if (node.elementType == ElementType.DOT_QUALIFIED_EXPRESSION) {
             val isConsole = node.firstChildNode.let { referenceExpression ->
                 referenceExpression.elementType == ElementType.REFERENCE_EXPRESSION &&
-                    referenceExpression.firstChildNode.let { it.elementType == ElementType.IDENTIFIER && it.text == "console" }
+                        referenceExpression.firstChildNode.let { it.elementType == ElementType.IDENTIFIER && it.text == "console" }
             }
             if (isConsole) {
                 val logMethod = node.lastChildNode

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
@@ -628,7 +628,7 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
             val expression = rightBinList.firstOrNull { (it, offset) ->
                 val binOperationReference = it.getFirstChildWithType(OPERATION_REFERENCE)?.firstChildNode?.elementType
                 offset + (it.getFirstChildWithType(OPERATION_REFERENCE)?.text?.length ?: 0) <= configuration.lineLength + 1 &&
-                    binOperationReference !in logicListOperationReference && binOperationReference !in compressionListOperationReference && binOperationReference != EXCL
+                        binOperationReference !in logicListOperationReference && binOperationReference !in compressionListOperationReference && binOperationReference != EXCL
             }
             returnList.add(expression)
             return returnList
@@ -660,7 +660,7 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
             val expression = rightBinList.firstOrNull { (it, offset) ->
                 val binOperationReference = it.getFirstChildWithType(OPERATION_REFERENCE)
                 offset + (it.getFirstChildWithType(OPERATION_REFERENCE)?.text?.length ?: 0) <= configuration.lineLength + 1 &&
-                    binOperationReference?.firstChildNode?.elementType in typesList
+                        binOperationReference?.firstChildNode?.elementType in typesList
             }
             returnList.add(expression)
         }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
@@ -62,10 +62,10 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
         val isEnums = node.parent({ it.elementType == ENUM_ENTRY }) != null
         val isRanges = node.treeParent.run {
             this.elementType == BINARY_EXPRESSION &&
-                this.findChildByType(OPERATION_REFERENCE)?.hasChildOfType(RANGE) ?: false
+                    this.findChildByType(OPERATION_REFERENCE)?.hasChildOfType(RANGE) ?: false
         }
         val isExtensionFunctions = node.parent({ it.elementType == FUN && (it.psi as KtFunction).isExtensionDeclaration() }) != null &&
-            node.parents().find { it.elementType == PROPERTY } == null
+                node.parents().find { it.elementType == PROPERTY } == null
         val result = listOf(isHashFunction, isPropertyDeclaration, isLocalVariable, isValueParameter, isConstant,
             isCompanionObjectProperty, isEnums, isRanges, isExtensionFunctions).zip(mapConfiguration.map { configuration.getParameter(it.key) })
         if (result.any { it.first && it.first != it.second } && !isIgnoreNumber) {
@@ -109,7 +109,7 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
          * Check if string include a char of number type
          */
         private fun String.isOtherNumberType(): Boolean = ((this.last().uppercase() == "L" || this.last().uppercase() == "U") && this.substring(0, this.lastIndex).isNumber()) ||
-            (this.substring(this.lastIndex - 1).uppercase() == "UL" && this.substring(0, this.lastIndex - 1).isNumber())
+                (this.substring(this.lastIndex - 1).uppercase() == "UL" && this.substring(0, this.lastIndex - 1).isNumber())
     }
 
     companion object {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/NullableTypeRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/NullableTypeRule.kt
@@ -54,11 +54,11 @@ class NullableTypeRule(configRules: List<RulesConfig>) : DiktatRule(
             val typeReferenceNode = node.findChildByType(TYPE_REFERENCE)!!
             // check that property has nullable type, right value one of allow expression
             if (!node.hasChildOfType(NULL) &&
-                node.findAllDescendantsWithSpecificType(DOT_QUALIFIED_EXPRESSION).isEmpty() &&
-                typeReferenceNode.hasChildOfType(NULLABLE_TYPE) &&
-                typeReferenceNode.findChildByType(NULLABLE_TYPE)!!.hasChildOfType(QUEST) &&
-                (node.findChildByType(CALL_EXPRESSION)?.findChildByType(REFERENCE_EXPRESSION) == null ||
-                    node.findChildByType(CALL_EXPRESSION)!!.findChildByType(REFERENCE_EXPRESSION)!!.text in allowExpression)) {
+                    node.findAllDescendantsWithSpecificType(DOT_QUALIFIED_EXPRESSION).isEmpty() &&
+                    typeReferenceNode.hasChildOfType(NULLABLE_TYPE) &&
+                    typeReferenceNode.findChildByType(NULLABLE_TYPE)!!.hasChildOfType(QUEST) &&
+                    (node.findChildByType(CALL_EXPRESSION)?.findChildByType(REFERENCE_EXPRESSION) == null ||
+                            node.findChildByType(CALL_EXPRESSION)!!.findChildByType(REFERENCE_EXPRESSION)!!.text in allowExpression)) {
                 NULLABLE_PROPERTY_TYPE.warn(configRules, emitWarn, isFixMode, "don't use nullable type",
                     node.findChildByType(TYPE_REFERENCE)!!.startOffset, node)
             } else if (node.hasChildOfType(NULL)) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/SortRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/SortRule.kt
@@ -46,7 +46,7 @@ class SortRule(configRules: List<RulesConfig>) : DiktatRule(
             sortEnum(classBody)
         }
         if ((node.psi as? KtObjectDeclaration)?.isCompanion() == true && classBody != null &&
-            configuration.sortProperty) {
+                configuration.sortProperty) {
             sortProperty(classBody)
         }
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringConcatenationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringConcatenationRule.kt
@@ -94,7 +94,7 @@ class StringConcatenationRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun isStringVar(firstChild: ASTNode, lastChild: ASTNode) = firstChild.elementType == STRING_TEMPLATE ||
-        ((firstChild.text.endsWith("toString()")) && firstChild.elementType == DOT_QUALIFIED_EXPRESSION && lastChild.elementType == STRING_TEMPLATE)
+            ((firstChild.text.endsWith("toString()")) && firstChild.elementType == DOT_QUALIFIED_EXPRESSION && lastChild.elementType == STRING_TEMPLATE)
 
     @Suppress("COMMENT_WHITE_SPACE")
     private fun isPlusBinaryExpression(node: ASTNode): Boolean {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringTemplateFormatRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/StringTemplateFormatRule.kt
@@ -101,8 +101,8 @@ class StringTemplateFormatRule(configRules: List<RulesConfig>) : DiktatRule(
                 .first()
                 // checking if first letter is valid
                 .isLetterOrDigit() ||
-                node.treeNext.text.startsWith("_")) ||
-                node.treeNext.elementType == CLOSING_QUOTE
+                    node.treeNext.text.startsWith("_")) ||
+                    node.treeNext.elementType == CLOSING_QUOTE
             )
         } else if (!isArrayAccessExpression) {
             node.hasAnyChildOfTypes(FLOAT_CONSTANT, INTEGER_CONSTANT)  // it also fixes "${1.0}asd" cases

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
@@ -63,7 +63,7 @@ class TrailingCommaRule(configRules: List<RulesConfig>) : DiktatRule(
     private val configuration by lazy {
         if (trailingConfig.isEmpty()) {
             log.warn("You have enabled TRAILING_COMMA, but rule will remain inactive until you explicitly set" +
-                " configuration options. See [available-rules.md] for possible configuration options.")
+                    " configuration options. See [available-rules.md] for possible configuration options.")
         }
         TrailingCommaConfiguration(trailingConfig)
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/WhenMustHaveElseRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/WhenMustHaveElseRule.kt
@@ -120,7 +120,7 @@ class WhenMustHaveElseRule(configRules: List<RulesConfig>) : DiktatRule(
 
         // Checks if `when` is the last statement in lambda body
         if (node.treeParent.elementType == BLOCK && node.treeParent.treeParent.elementType == FUNCTION_LITERAL &&
-            node.treeParent.lastChildNode == node) {
+                node.treeParent.lastChildNode == node) {
             return false
         }
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/BlankLinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/BlankLinesRule.kt
@@ -41,7 +41,7 @@ class BlankLinesRule(configRules: List<RulesConfig>) : DiktatRule(
         if (node.treeParent.let {
             // kts files are parsed as a SCRIPT node containing BLOCK, therefore WHITE_SPACEs from these BLOCKS shouldn't be checked
             it.elementType == BLOCK && it.treeParent?.elementType != SCRIPT ||
-                it.elementType == CLASS_BODY || it.elementType == FUNCTION_LITERAL
+                    it.elementType == CLASS_BODY || it.elementType == FUNCTION_LITERAL
         }) {
             node.findParentNodeWithSpecificType(LAMBDA_ARGUMENT)?.let {
                 // Lambda body is always has a BLOCK -> run { } - (LBRACE, WHITE_SPACE, BLOCK "", RBRACE)
@@ -64,7 +64,7 @@ class BlankLinesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun handleTooManyBlankLines(node: ASTNode) {
         TOO_MANY_BLANK_LINES.warnAndFix(configRules, emitWarn, isFixMode, "do not use more than two consecutive blank lines", node.startOffset, node) {
             if (node.treeParent.elementType != FILE && (node.treeParent.getFirstChildWithType(WHITE_SPACE) == node ||
-                node.treeParent.getAllChildrenWithType(WHITE_SPACE).last() == node)) {
+                    node.treeParent.getAllChildrenWithType(WHITE_SPACE).last() == node)) {
                 node.leaveExactlyNumNewLines(1)
             } else {
                 node.leaveExactlyNumNewLines(2)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
@@ -140,12 +140,12 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
             ?: node.children().firstOrNull {
                 // taking nodes with actual code
                 !it.isWhiteSpace() && !it.isPartOfComment() &&
-                    // but not the ones we are going to move
-                    it.elementType != FILE_ANNOTATION_LIST &&
-                    // if we are here, then IMPORT_LIST either is not present in the AST, or is empty. Either way, we don't need to select it.
-                    it.elementType != IMPORT_LIST &&
-                    // if we are here, then package is default and we don't need to select the empty PACKAGE_DIRECTIVE node.
-                    it.elementType != PACKAGE_DIRECTIVE
+                        // but not the ones we are going to move
+                        it.elementType != FILE_ANNOTATION_LIST &&
+                        // if we are here, then IMPORT_LIST either is not present in the AST, or is empty. Either way, we don't need to select it.
+                        it.elementType != IMPORT_LIST &&
+                        // if we are here, then package is default and we don't need to select the empty PACKAGE_DIRECTIVE node.
+                        it.elementType != PACKAGE_DIRECTIVE
             }
             ?: return  // at this point it means the file contains only comments
         // We consider the first block comment of the file to be the one that possibly contains copyright information.
@@ -166,7 +166,7 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
         val otherNodesBeforeCode = firstCodeNode.siblings(forward = false)
             .filterNot {
                 it.isWhiteSpace() ||
-                    it == copyrightComment || it == headerKdoc || it == fileAnnotations
+                        it == copyrightComment || it == headerKdoc || it == fileAnnotations
             }
             .toList()
             .reversed()
@@ -236,8 +236,8 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
                 val importName = ktImportDirective.importPath?.importedName?.asString()
                 val importPath = ktImportDirective.importPath?.pathStr!!  // importPath - ifNOtParsed & Nullable
                 if (ktImportDirective.aliasName == null &&
-                    packageName.isNotEmpty() && importPath.startsWith("$packageName.") &&
-                    importPath.substring(packageName.length + 1).indexOf('.') == -1
+                        packageName.isNotEmpty() && importPath.startsWith("$packageName.") &&
+                        importPath.substring(packageName.length + 1).indexOf('.') == -1
                 ) {
                     // this branch corresponds to imports from the same package
                     deleteImport(importPath, node, ktImportDirective)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
@@ -264,10 +264,10 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
     ) {
         val nextNodeDot = getNextDotExpression(whiteSpace.node.treeNext)
         if (nextNodeDot != null &&
-            nextNodeDot.elementType == DOT_QUALIFIED_EXPRESSION &&
-            nextNodeDot.firstChildNode.elementType == STRING_TEMPLATE &&
-            nextNodeDot.firstChildNode.text.startsWith("\"\"\"") &&
-            nextNodeDot.findChildByType(CALL_EXPRESSION).isTrimIndentOrMarginCall()) {
+                nextNodeDot.elementType == DOT_QUALIFIED_EXPRESSION &&
+                nextNodeDot.firstChildNode.elementType == STRING_TEMPLATE &&
+                nextNodeDot.firstChildNode.text.startsWith("\"\"\"") &&
+                nextNodeDot.findChildByType(CALL_EXPRESSION).isTrimIndentOrMarginCall()) {
             fixStringLiteral(nextNodeDot.firstChildNode, expectedIndent, actualIndent)
         }
     }
@@ -319,8 +319,8 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
                         val escapedText = text.replace(NEWLINE.toString(), "\\n")
 
                         "A LITERAL_STRING_TEMPLATE_ENTRY at index $index contains extra characters in addition to the newline, " +
-                            "entry: \"$escapedText\", " +
-                            "string template: ${stringTemplate.text}"
+                                "entry: \"$escapedText\", " +
+                                "string template: ${stringTemplate.text}"
                     }
                 }
 
@@ -546,7 +546,7 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
              * @return boolean result
              */
             fun isActive(currentNode: ASTNode): Boolean = currentNode.psi.parentsWithSelf.any { it.node == initiator } &&
-                (includeLastChild || currentNode.treeNext != initiator.lastChildNode)
+                    (includeLastChild || currentNode.treeNext != initiator.lastChildNode)
         }
     }
 
@@ -698,9 +698,9 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
 
             check(lastRegularStringPartType == REGULAR_STRING_PART) {
                 "Unexpected type of the 1st child of the string template entry, " +
-                    "expected: $REGULAR_STRING_PART, " +
-                    "actual: $lastRegularStringPartType, " +
-                    "string template: ${parent.parent.text}"
+                        "expected: $REGULAR_STRING_PART, " +
+                        "actual: $lastRegularStringPartType, " +
+                        "string template: ${parent.parent.text}"
             }
 
             return this

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -164,7 +164,7 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
                     val firstElem = it.firstChildNode
                     val isTextContainsParenthesized = isTextContainsFunctionCall(firstElem)
                     val isNotWhiteSpaceBeforeDotOrSafeAccessContainNewLine = nodeBeforeDotOrSafeAccess?.elementType != WHITE_SPACE ||
-                        (nodeBeforeDotOrSafeAccess.elementType != WHITE_SPACE && !nodeBeforeDotOrSafeAccess.textContains('\n'))
+                            (nodeBeforeDotOrSafeAccess.elementType != WHITE_SPACE && !nodeBeforeDotOrSafeAccess.textContains('\n'))
                     isTextContainsParenthesized && (index > 0) && isNotWhiteSpaceBeforeDotOrSafeAccessContainNewLine
                 }
                 if (without.isNotEmpty()) {
@@ -252,7 +252,7 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
                 val isSingleLineIfElse = parent({ it.elementType == IF }, true)?.isSingleLineIfElse() ?: false
                 // to follow functional style these operators should be started by newline
                 (isFollowedByNewline() || !isBeginByNewline()) && !isSingleLineIfElse &&
-                    (!isFirstCall() || !isMultilineLambda(treeParent))
+                        (!isFirstCall() || !isMultilineLambda(treeParent))
             } else {
                 if (isInvalidCallsChain(dropLeadingProperties = false) && node.isInParentheses()) {
                     checkForComplexExpression(node)
@@ -470,9 +470,9 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
         if (numEntries > configuration.maxParametersInOneLine) {
             when (node.elementType) {
                 VALUE_PARAMETER_LIST -> handleFirstValue(node, VALUE_PARAMETER, "first parameter should be placed on a separate line " +
-                    "or all other parameters should be aligned with it in declaration of <${node.getParentIdentifier()}>")
+                        "or all other parameters should be aligned with it in declaration of <${node.getParentIdentifier()}>")
                 VALUE_ARGUMENT_LIST -> handleFirstValue(node, VALUE_ARGUMENT, "first value argument (%s) should be placed on the new line " +
-                    "or all other parameters should be aligned with it")
+                        "or all other parameters should be aligned with it")
                 else -> {
                 }
             }
@@ -513,8 +513,8 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
         .children()
         .filter {
             (it.elementType == COMMA && !it.treeNext.isNewLineNode()) ||
-                // Move RPAR to the new line
-                (it.elementType == RPAR && it.treePrev.elementType != COMMA && !it.treePrev.isNewLineNode())
+                    // Move RPAR to the new line
+                    (it.elementType == RPAR && it.treePrev.elementType != COMMA && !it.treePrev.isNewLineNode())
         }
         .toList()
         .takeIf { it.isNotEmpty() }
@@ -553,10 +553,10 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
         // if statements here have the only right order - don't change it
 
         if (psi.children.isNotEmpty() && !psi.isFirstChildElementType(DOT_QUALIFIED_EXPRESSION) &&
-            !psi.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
+                !psi.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
             val firstChild = psi.firstChild
             if (firstChild.isFirstChildElementType(DOT_QUALIFIED_EXPRESSION) ||
-                firstChild.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
+                    firstChild.isFirstChildElementType(SAFE_ACCESS_EXPRESSION)) {
                 getOrderedCallExpressions(firstChild.firstChild, result)
             }
             result.add(firstChild.node
@@ -606,7 +606,7 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
 
     // fixme: there could be other cases when dot means something else
     private fun ASTNode.isDotFromPackageOrImport() = elementType == DOT &&
-        parent({ it.elementType == IMPORT_DIRECTIVE || it.elementType == PACKAGE_DIRECTIVE }, true) != null
+            parent({ it.elementType == IMPORT_DIRECTIVE || it.elementType == PACKAGE_DIRECTIVE }, true) != null
 
     private fun PsiElement.isFirstChildElementType(elementType: IElementType) =
         this.firstChild.node.elementType == elementType
@@ -687,8 +687,8 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
      * This method should be called on OPERATION_REFERENCE in the middle of BINARY_EXPRESSION
      */
     private fun ASTNode.isInfixCall() = elementType == OPERATION_REFERENCE &&
-        firstChildNode.elementType == IDENTIFIER &&
-        treeParent.elementType == BINARY_EXPRESSION
+            firstChildNode.elementType == IDENTIFIER &&
+            treeParent.elementType == BINARY_EXPRESSION
 
     /**
      * This method checks that complex expression should be replace with new variable

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/WhiteSpaceRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/WhiteSpaceRule.kt
@@ -153,7 +153,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
         if (node.treeNext.numWhiteSpaces()?.let { it > 0 } == true) {
             // there is either whitespace or newline after constructor keyword
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "keyword '${node.text}' should not be separated from " +
-                "'(' with a whitespace", node.startOffset, node) {
+                    "'(' with a whitespace", node.startOffset, node) {
                 node.treeParent.removeChild(node.treeNext)
             }
         }
@@ -169,7 +169,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
                 return
             }
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "keyword '${node.text}' should be separated from " +
-                "'${nextCodeLeaf.text}' with a whitespace", nextCodeLeaf.startOffset, nextCodeLeaf) {
+                    "'${nextCodeLeaf.text}' with a whitespace", nextCodeLeaf.startOffset, nextCodeLeaf) {
                 node.leaveSingleWhiteSpace()
             }
         }
@@ -177,9 +177,9 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun handleRbrace(node: ASTNode) {
         if (node.treeParent.elementType == FUNCTION_LITERAL &&
-            !node.treePrev.isWhiteSpace() &&
-            node.treePrev.elementType == BLOCK &&
-            node.treePrev.text.isNotEmpty()) {
+                !node.treePrev.isWhiteSpace() &&
+                node.treePrev.elementType == BLOCK &&
+                node.treePrev.text.isNotEmpty()) {
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "there should be a whitespace before }", node.startOffset, node) {
                 node.treeParent.addChild(PsiWhiteSpaceImpl(" "), node)
             }
@@ -200,10 +200,10 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
             .takeIf { it.size == NUM_PARENTS_FOR_LAMBDA }
             ?.let {
                 it[0].elementType == FUNCTION_LITERAL &&
-                    it[1].elementType == LAMBDA_EXPRESSION &&
-                    it[2].elementType == VALUE_ARGUMENT &&
-                    // lambda is not passed as a named argument
-                    !it[2].hasChildOfType(EQ)
+                        it[1].elementType == LAMBDA_EXPRESSION &&
+                        it[2].elementType == VALUE_ARGUMENT &&
+                        // lambda is not passed as a named argument
+                        !it[2].hasChildOfType(EQ)
             }
             ?: false
 
@@ -228,7 +228,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
             // Handling this case: `foo({ it.bar() }, 2, 3)`
             if (numWhiteSpace != 0 && isFirstArgument) {
                 WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "there should be no whitespace before '{' of lambda" +
-                    " inside argument list", node.startOffset, node) {
+                        " inside argument list", node.startOffset, node) {
                     whitespaceOrPrevNode.treeParent.removeChild(whitespaceOrPrevNode)
                 }
             }
@@ -244,7 +244,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun handleWhiteSpaceAfterLeftBrace(node: ASTNode) {
         if (node.treeParent.elementType == FUNCTION_LITERAL && !node.treeNext.isWhiteSpace() &&
-            node.treeNext.elementType == BLOCK && node.treeNext.text.isNotEmpty()) {
+                node.treeNext.elementType == BLOCK && node.treeNext.text.isNotEmpty()) {
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, "there should be a whitespace after {", node.startOffset, node) {
                 node.treeParent.addChild(PsiWhiteSpaceImpl(" "), node.treeNext)
             }
@@ -290,7 +290,7 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
             return
         }
         if (node.elementType == OPERATION_REFERENCE && node.treeParent.elementType.let { it == BINARY_EXPRESSION || it == POSTFIX_EXPRESSION || it == PROPERTY } ||
-            node.elementType != OPERATION_REFERENCE) {
+                node.elementType != OPERATION_REFERENCE) {
             val requiredNumSpaces = if (operatorNode.elementType in operatorsWithNoWhitespace) 0 else 1
             handleToken(node, requiredNumSpaces, requiredNumSpaces)
         }
@@ -318,9 +318,9 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
         val isErrorAfter = requiredSpacesAfter != null && spacesAfter != null && spacesAfter != requiredSpacesAfter
         if (isErrorBefore || isErrorAfter) {
             val freeText = "${node.text} should have" +
-                getDescription(requiredSpacesBefore != null, requiredSpacesAfter != null, requiredSpacesBefore, requiredSpacesAfter) +
-                ", but has" +
-                getDescription(isErrorBefore, isErrorAfter, spacesBefore, spacesAfter)
+                    getDescription(requiredSpacesBefore != null, requiredSpacesAfter != null, requiredSpacesBefore, requiredSpacesAfter) +
+                    ", but has" +
+                    getDescription(isErrorBefore, isErrorAfter, spacesBefore, spacesAfter)
             WRONG_WHITESPACE.warnAndFix(configRules, emitWarn, isFixMode, freeText, node.startOffset, node) {
                 node.fixSpaceAround(requiredSpacesBefore, requiredSpacesAfter)
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/identifiers/LocalVariablesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/identifiers/LocalVariablesRule.kt
@@ -64,9 +64,9 @@ class LocalVariablesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun collectLocalPropertiesWithUsages(node: ASTNode) = node
         .findAllVariablesWithUsages { propertyNode ->
             propertyNode.isLocal && propertyNode.name != null && propertyNode.parent is KtBlockExpression &&
-                (propertyNode.isVar && propertyNode.initializer == null ||
-                    (propertyNode.initializer?.containsOnlyConstants() ?: false) ||
-                    (propertyNode.initializer as? KtCallExpression).isWhitelistedMethod())
+                    (propertyNode.isVar && propertyNode.initializer == null ||
+                            (propertyNode.initializer?.containsOnlyConstants() ?: false) ||
+                            (propertyNode.initializer as? KtCallExpression).isWhitelistedMethod())
         }
 
         .filterNot { it.value.isEmpty() }
@@ -208,7 +208,7 @@ class LocalVariablesRule(configRules: List<RulesConfig>) : DiktatRule(
             // `referenceExpression()` can return something different than just a name, e.g. when function returns a function:
             // `foo()()` `referenceExpression()` will be a `KtCallExpression` as well
             (referenceExpression() as? KtNameReferenceExpression)?.getReferencedName() in functionInitializers &&
-                valueArguments.isEmpty()
+                    valueArguments.isEmpty()
         } ?: false
 
     private fun warnMessage(

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/ImmutableValNoVarRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/ImmutableValNoVarRule.kt
@@ -43,7 +43,7 @@ class ImmutableValNoVarRule(configRules: List<RulesConfig>) : DiktatRule(
             usages.forEach { (property, usages) ->
                 val usedInAccumulators = usages.any {
                     it.getParentOfType<KtLoopExpression>(true) != null ||
-                        it.getParentOfType<KtLambdaExpression>(true) != null
+                            it.getParentOfType<KtLambdaExpression>(true) != null
                 }
 
                 if (!usedInAccumulators) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
@@ -113,7 +113,7 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
             ?.let { it.findChildByType(BLOCK) ?: it }
             ?.let { astNode ->
                 astNode.hasChildOfType(BREAK) &&
-                    (astNode.psi as? KtBlockExpression)?.statements?.size != 1
+                        (astNode.psi as? KtBlockExpression)?.statements?.size != 1
             } ?: false
         return (!isBlockInIfWithBreak && !isOneLineBlockInIfWithBreak)
     }
@@ -170,8 +170,8 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
     ): String = when {
         // if (a != null) {  } -> a ?: editedElse
         (thenCodeLines.isNullOrEmpty() && elseEditedCodeLines.isNotEmpty()) ||
-            // if (a != null) { a } else { ... } -> a ?: editedElse
-            (thenCodeLines?.singleOrNull() == variableName && elseEditedCodeLines.isNotEmpty()) -> variableName
+                // if (a != null) { a } else { ... } -> a ?: editedElse
+                (thenCodeLines?.singleOrNull() == variableName && elseEditedCodeLines.isNotEmpty()) -> variableName
         // if (a != null) { a.foo() } -> a?.foo()
         thenCodeLines?.singleOrNull()?.startsWith("$variableName.") ?: false -> "$variableName?${thenCodeLines?.firstOrNull()!!.removePrefix(variableName)}"
         // if (a != null) { break } -> a?.let { ... }
@@ -239,12 +239,12 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun isNullCheckBinaryExpression(condition: KtBinaryExpression): Boolean =
         // check that binary expression has `null` as right or left operand
         setOf(condition.right, condition.left).map { it!!.node.elementType }.contains(NULL) &&
-            // checks that it is the comparison condition
-            setOf(ElementType.EQEQ, ElementType.EQEQEQ, ElementType.EXCLEQ, ElementType.EXCLEQEQEQ)
-                .contains(condition.operationToken) &&
-            // no need to raise warning or fix null checks in complex expressions
-            !condition.isComplexCondition() &&
-            !condition.isInLambda()
+                // checks that it is the comparison condition
+                setOf(ElementType.EQEQ, ElementType.EQEQEQ, ElementType.EXCLEQ, ElementType.EXCLEQEQEQ)
+                    .contains(condition.operationToken) &&
+                // no need to raise warning or fix null checks in complex expressions
+                !condition.isComplexCondition() &&
+                !condition.isInLambda()
 
     /**
      * checks if condition is a complex expression. For example:

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
@@ -195,7 +195,7 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
         val exprToChange = asExpr.filter {
             blocks.any { isExpr ->
                 isExpr.identifier == it.identifier &&
-                    isExpr.type == it.type
+                        isExpr.type == it.type
             }
         }
 
@@ -223,9 +223,9 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
                 .mapNotNull { it as? KtProperty }
                 .find {
                     it.isLocal &&
-                        it.hasInitializer() &&
-                        it.name?.equals(getReferencedName())
-                            ?: false
+                            it.hasInitializer() &&
+                            it.name?.equals(getReferencedName())
+                                ?: false
                 }
         }
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/VariableGenericTypeDeclarationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/VariableGenericTypeDeclarationRule.kt
@@ -61,8 +61,8 @@ class VariableGenericTypeDeclarationRule(configRules: List<RulesConfig>) : Dikta
         }
 
         if (rightSide != null && leftSide != null &&
-            rightSide.size == leftSide.size &&
-            rightSide.zip(leftSide).all { (first, second) -> first.text == second.text }) {
+                rightSide.size == leftSide.size &&
+                rightSide.zip(leftSide).all { (first, second) -> first.text == second.text }) {
             GENERIC_VARIABLE_WRONG_DECLARATION.warnAndFix(configRules, emitWarn, isFixMode,
                 "type arguments are unnecessary in ${callExpr.text}", node.startOffset, node) {
                 callExpr.removeChild(callExpr.findChildByType(TYPE_ARGUMENT_LIST)!!)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/calculations/AccurateCalculationsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/calculations/AccurateCalculationsRule.kt
@@ -56,7 +56,7 @@ class AccurateCalculationsRule(configRules: List<RulesConfig>) : DiktatRule(
                     ?.let { it.getArgumentExpression() as? KtCallExpression }
                     ?.isAbsOfFloat()
                     ?: false ||
-                    (receiverExpression as? KtCallExpression).isAbsOfFloat()
+                        (receiverExpression as? KtCallExpression).isAbsOfFloat()
             }
             ?: false
 
@@ -137,13 +137,13 @@ class AccurateCalculationsRule(configRules: List<RulesConfig>) : DiktatRule(
 @Suppress("UnsafeCallOnNullableType")
 private fun PsiElement.isFloatingPoint(): Boolean =
     node.elementType == ElementType.FLOAT_LITERAL ||
-        node.elementType == ElementType.FLOAT_CONSTANT ||
-        ((this as? KtNameReferenceExpression)
-            ?.findLocalDeclaration()
-            ?.initializer
-            ?.node
-            ?.run { elementType == ElementType.FLOAT_LITERAL || elementType == ElementType.FLOAT_CONSTANT }
-            ?: false) ||
-        ((this as? KtBinaryExpression)
-            ?.run { left!!.isFloatingPoint() && right!!.isFloatingPoint() }
-            ?: false)
+            node.elementType == ElementType.FLOAT_CONSTANT ||
+            ((this as? KtNameReferenceExpression)
+                ?.findLocalDeclaration()
+                ?.initializer
+                ?.node
+                ?.run { elementType == ElementType.FLOAT_LITERAL || elementType == ElementType.FLOAT_CONSTANT }
+                ?: false) ||
+            ((this as? KtBinaryExpression)
+                ?.run { left!!.isFloatingPoint() && right!!.isFloatingPoint() }
+                ?: false)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/AvoidNestedFunctionsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/AvoidNestedFunctionsRule.kt
@@ -67,7 +67,7 @@ class AvoidNestedFunctionsRule(configRules: List<RulesConfig>) : DiktatRule(
 
     private fun isNestedFunction(node: ASTNode): Boolean =
         node.hasParent(FUN) && node.hasFunParentUntil(CLASS_BODY) && !node.hasChildOfType(MODIFIER_LIST) &&
-            !node.isAnonymousFunction()
+                !node.isAnonymousFunction()
 
     private fun ASTNode.hasFunParentUntil(stopNode: IElementType): Boolean =
         parents()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/CustomLabel.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter5/CustomLabel.kt
@@ -30,7 +30,7 @@ class CustomLabel(configRules: List<RulesConfig>) : DiktatRule(
         if (node.elementType == LABEL_QUALIFIER && node.text !in labels && node.treeParent.elementType in stopWords) {
             val nestedCount = node.parents().count {
                 it.elementType in loopType ||
-                    (it.elementType == CALL_EXPRESSION && it.findChildByType(REFERENCE_EXPRESSION)?.text in forEachReference)
+                        (it.elementType == CALL_EXPRESSION && it.findChildByType(REFERENCE_EXPRESSION)?.text in forEachReference)
             }
             if (nestedCount == 1) {
                 CUSTOM_LABEL.warn(configRules, emitWarn, isFixMode, node.text, node.startOffset, node)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/AvoidUtilityClass.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/AvoidUtilityClass.kt
@@ -45,7 +45,7 @@ class AvoidUtilityClass(configRules: List<RulesConfig>) : DiktatRule(
     private fun checkClass(node: ASTNode) {
         // checks that class/object doesn't contain primary constructor and its identifier doesn't has "utli"
         if (!node.hasChildOfType(IDENTIFIER) || node.hasChildOfType(PRIMARY_CONSTRUCTOR) ||
-            !node.findChildByType(IDENTIFIER)!!.text.lowercase(Locale.getDefault()).contains("util")) {
+                !node.findChildByType(IDENTIFIER)!!.text.lowercase(Locale.getDefault()).contains("util")) {
             return
         }
         node.findChildByType(CLASS_BODY)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/PropertyAccessorFields.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/PropertyAccessorFields.kt
@@ -42,8 +42,8 @@ class PropertyAccessorFields(configRules: List<RulesConfig>) : DiktatRule(
             .mapNotNull { it.findChildByType(IDENTIFIER) }
             .firstOrNull {
                 it.text == leftValue.text &&
-                    (it.treeParent.treeParent.elementType != DOT_QUALIFIED_EXPRESSION ||
-                        it.treeParent.treeParent.firstChildNode.elementType == THIS_EXPRESSION)
+                        (it.treeParent.treeParent.elementType != DOT_QUALIFIED_EXPRESSION ||
+                                it.treeParent.treeParent.firstChildNode.elementType == THIS_EXPRESSION)
             }
         val isContainLocalVarSameName = node
             .findChildByType(BLOCK)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/TrivialPropertyAccessors.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/TrivialPropertyAccessors.kt
@@ -59,9 +59,9 @@ class TrivialPropertyAccessors(configRules: List<RulesConfig>) : DiktatRule(
             val blockChildren = block.getChildren(null).filter { it.elementType !in excessChildrenTypes }
 
             if (blockChildren.size == 1 &&
-                blockChildren.first().elementType == BINARY_EXPRESSION &&
-                (blockChildren.first().psi as KtBinaryExpression).left?.text == "field" &&
-                (blockChildren.first().psi as KtBinaryExpression).right?.text == valueParamName
+                    blockChildren.first().elementType == BINARY_EXPRESSION &&
+                    (blockChildren.first().psi as KtBinaryExpression).left?.text == "field" &&
+                    (blockChildren.first().psi as KtBinaryExpression).right?.text == valueParamName
             ) {
                 raiseWarning(node)
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UseLastIndex.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UseLastIndex.kt
@@ -32,7 +32,7 @@ class UseLastIndex(configRules: List<RulesConfig>) : DiktatRule(
             val operation = node.getFirstChildWithType(OPERATION_REFERENCE)
             val number = node.getFirstChildWithType(INTEGER_CONSTANT)
             it.elementType == DOT_QUALIFIED_EXPRESSION && it.lastChildNode.text == "length" && it.lastChildNode.elementType == REFERENCE_EXPRESSION &&
-                operation?.text == "-" && number?.text == "1"
+                    operation?.text == "-" && number?.text == "1"
         }
         if (listWithRightLength.toList().isNotEmpty()) {
             Warnings.USE_LAST_INDEX.warnAndFix(configRules, emitWarn, isFixMode, node.text, node.startOffset, node) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UselessSupertype.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/UselessSupertype.kt
@@ -121,7 +121,7 @@ class UselessSupertype(configRules: List<RulesConfig>) : DiktatRule(
         }
         val superNodes = fileNode.findAllNodesWithCondition { superClass ->
             superClass.elementType == CLASS &&
-                superClass.getIdentifierName()!!.text in superNodesIdentifier
+                    superClass.getIdentifierName()!!.text in superNodesIdentifier
         }.mapNotNull { it.findChildByType(CLASS_BODY) }
         if (superNodes.size != superTypeList.size) {
             return null
@@ -131,7 +131,7 @@ class UselessSupertype(configRules: List<RulesConfig>) : DiktatRule(
             val overrideFunctions = classBody.findAllDescendantsWithSpecificType(FUN)
                 .filter {
                     (if (classBody.treeParent.hasChildOfType(CLASS_KEYWORD)) it.findChildByType(MODIFIER_LIST)!!.hasChildOfType(OPEN_KEYWORD) else true) &&
-                        it.getIdentifierName()!!.text in methodsName
+                            it.getIdentifierName()!!.text in methodsName
                 }
             overrideFunctions.forEach {
                 functionNameMap.compute(it.getIdentifierName()!!.text) { _, oldValue -> (oldValue ?: 0) + 1 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
@@ -69,10 +69,10 @@ class CompactInitialization(configRules: List<RulesConfig>) : DiktatRule(
                 .takeWhile {
                     // statements like `name.field = value` where name == propertyName
                     it is KtBinaryExpression && it.node.findChildByType(OPERATION_REFERENCE)?.findChildByType(EQ) != null &&
-                        (it.left as? KtDotQualifiedExpression)?.run {
-                            (receiverExpression as? KtNameReferenceExpression)?.getReferencedName() == propertyName
-                        }
-                            ?: false
+                            (it.left as? KtDotQualifiedExpression)?.run {
+                                (receiverExpression as? KtNameReferenceExpression)?.getReferencedName() == propertyName
+                            }
+                                ?: false
                 }
                 .map {
                     // collect as an assignment associated with assigned field name

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/DataClassesRule.kt
@@ -99,16 +99,16 @@ class DataClassesRule(configRules: List<RulesConfig>) : DiktatRule(
             val list = getFirstChildWithType(MODIFIER_LIST)!!
             return list.getChildren(null)
                 .none { it.elementType in badModifiers } &&
-                classBody?.getAllChildrenWithType(FUN)
-                    ?.isEmpty()
-                    ?: false &&
-                getFirstChildWithType(SUPER_TYPE_LIST) == null
+                    classBody?.getAllChildrenWithType(FUN)
+                        ?.isEmpty()
+                        ?: false &&
+                    getFirstChildWithType(SUPER_TYPE_LIST) == null
         }
         return classBody?.getFirstChildWithType(FUN) == null &&
-            getFirstChildWithType(SUPER_TYPE_LIST) == null &&
-            // if there is any prop with logic in accessor then don't recommend to convert class to data class
-            classBody?.let(::areGoodProps)
-                ?: true
+                getFirstChildWithType(SUPER_TYPE_LIST) == null &&
+                // if there is any prop with logic in accessor then don't recommend to convert class to data class
+                classBody?.let(::areGoodProps)
+                    ?: true
     }
 
     /**

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/InlineClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/InlineClassesRule.kt
@@ -33,9 +33,9 @@ class InlineClassesRule(configRules: List<RulesConfig>) : DiktatRule(
     override fun logic(node: ASTNode) {
         val configuration = configRules.getCommonConfiguration()
         if (node.elementType == CLASS &&
-            !(node.psi as KtClass).isInterface() &&
-            configuration.kotlinVersion >= minKtVersion &&
-            configuration.kotlinVersion < maxKtVersion
+                !(node.psi as KtClass).isInterface() &&
+                configuration.kotlinVersion >= minKtVersion &&
+                configuration.kotlinVersion < maxKtVersion
         ) {
             handleClasses(node.psi as KtClass)
         }
@@ -44,11 +44,11 @@ class InlineClassesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun handleClasses(classPsi: KtClass) {
         // Fixme: In Kotlin 1.4.30 inline classes may be used with internal constructors. When it will be released need to check it
         if (hasValidProperties(classPsi) &&
-            !isExtendingClass(classPsi.node) &&
-            classPsi.node
-                .getFirstChildWithType(MODIFIER_LIST)
-                ?.getChildren(null)
-                ?.all { it.elementType in goodModifiers } != false) {
+                !isExtendingClass(classPsi.node) &&
+                classPsi.node
+                    .getFirstChildWithType(MODIFIER_LIST)
+                    ?.getChildren(null)
+                    ?.all { it.elementType in goodModifiers } != false) {
             // Fixme: since it's an experimental feature we shouldn't do fixer
             INLINE_CLASS_CAN_BE_USED.warn(configRules, emitWarn, isFixMode, "class ${classPsi.name}", classPsi.node.startOffset, classPsi.node)
         }
@@ -59,14 +59,14 @@ class InlineClassesRule(configRules: List<RulesConfig>) : DiktatRule(
             return !classPsi.getProperties().single().isVar
         } else if (classPsi.getProperties().isEmpty() && classPsi.hasExplicitPrimaryConstructor()) {
             return classPsi.primaryConstructorParameters.size == 1 &&
-                !classPsi.primaryConstructorParameters
-                    .first()
-                    .node
-                    .hasChildOfType(VAR_KEYWORD) &&
-                classPsi.primaryConstructor
-                    ?.visibilityModifierType()
-                    ?.value
-                    ?.let { it == "public" } ?: true
+                    !classPsi.primaryConstructorParameters
+                        .first()
+                        .node
+                        .hasChildOfType(VAR_KEYWORD) &&
+                    classPsi.primaryConstructor
+                        ?.visibilityModifierType()
+                        ?.value
+                        ?.let { it == "public" } ?: true
         }
         return false
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/SingleConstructorRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/SingleConstructorRule.kt
@@ -145,11 +145,11 @@ class SingleConstructorRule(configRules: List<RulesConfig>) : DiktatRule(
             .filterValues { left ->
                 // we keep only statements where property is referenced via this (like `this.foo = ...`)
                 left is KtDotQualifiedExpression && left.receiverExpression is KtThisExpression && left.selectorExpression is KtNameReferenceExpression ||
-                    // or directly (like `foo = ...`)
-                    left is KtNameReferenceExpression && localProperties.none {
-                        // check for shadowing
-                        left.node.isGoingAfter(it.node) && it.name == left.name
-                    }
+                        // or directly (like `foo = ...`)
+                        left is KtNameReferenceExpression && localProperties.none {
+                            // check for shadowing
+                            left.node.isGoingAfter(it.node) && it.name == left.name
+                        }
             }
             .mapValues { (_, left) ->
                 when (left) {
@@ -254,15 +254,15 @@ class SingleConstructorRule(configRules: List<RulesConfig>) : DiktatRule(
             ?.text
             ?.plus(" constructor ")
             ?: "") +
-            "(" +
-            declarationsAssignedInCtor.run {
-                joinToString(
-                    ", ",
-                    postfix = if (isNotEmpty() && valueParameters.isNotEmpty()) ", " else ""
-                ) { it.text }
-            } +
-            valueParameters.joinToString(", ") { it.text } +
-            ")"
+                "(" +
+                declarationsAssignedInCtor.run {
+                    joinToString(
+                        ", ",
+                        postfix = if (isNotEmpty() && valueParameters.isNotEmpty()) ", " else ""
+                    ) { it.text }
+                } +
+                valueParameters.joinToString(", ") { it.text } +
+                ")"
     )
         .node
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/StatelessClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/StatelessClassesRule.kt
@@ -67,8 +67,8 @@ class StatelessClassesRule(configRules: List<RulesConfig>) : DiktatRule(
         val properties = (node.psi as KtClass).getProperties()
         val functions = node.findAllDescendantsWithSpecificType(FUN)
         return properties.isEmpty() &&
-            functions.isNotEmpty() &&
-            !(node.psi as KtClass).hasExplicitPrimaryConstructor()
+                functions.isNotEmpty() &&
+                !(node.psi as KtClass).hasExplicitPrimaryConstructor()
     }
 
     private fun isClassExtendsValidInterface(node: ASTNode, interfaces: List<ASTNode>): Boolean =

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -190,9 +190,9 @@ fun ASTNode.isFollowedByNewlineWithComment() =
             EOL_COMMENT, BLOCK_COMMENT, KDOC -> isFollowedByNewline()
             else -> false
         } ||
-            parent({ it.treeNext != null }, strict = false)?.let {
-                it.treeNext.elementType == EOL_COMMENT && it.treeNext.isFollowedByNewline()
-            } ?: false
+                parent({ it.treeNext != null }, strict = false)?.let {
+                    it.treeNext.elementType == EOL_COMMENT && it.treeNext.isFollowedByNewline()
+                } ?: false
     } ?: false
 
 /**
@@ -202,7 +202,7 @@ fun ASTNode.isFollowedByNewlineWithComment() =
 fun ASTNode.isBeginByNewline() =
     parent({ it.treePrev != null }, strict = false)?.let {
         it.treePrev.elementType == WHITE_SPACE && it.treePrev.text.contains("\n") ||
-            (it.treePrev.elementType == IMPORT_LIST && it.treePrev.isLeaf() && it.treePrev.treePrev.isLeaf())
+                (it.treePrev.elementType == IMPORT_LIST && it.treePrev.isLeaf() && it.treePrev.treePrev.isLeaf())
     } ?: false
 
 /**
@@ -489,7 +489,7 @@ fun ASTNode.prettyPrint(level: Int = 0, maxLevel: Int = -1): String {
             this.getChildren(null).forEach { child ->
                 result.append(
                     "${"-".repeat(level + 1)} " +
-                        child.doPrettyPrint(level + 1, maxLevel - 1)
+                            child.doPrettyPrint(level + 1, maxLevel - 1)
                 )
             }
         }
@@ -506,7 +506,7 @@ fun ASTNode?.isAccessibleOutside(): Boolean =
     this?.run {
         require(this.elementType == MODIFIER_LIST)
         this.hasAnyChildOfTypes(PUBLIC_KEYWORD, PROTECTED_KEYWORD, INTERNAL_KEYWORD) ||
-            !this.hasAnyChildOfTypes(PUBLIC_KEYWORD, INTERNAL_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD)
+                !this.hasAnyChildOfTypes(PUBLIC_KEYWORD, INTERNAL_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD)
     }
         ?: true
 
@@ -688,7 +688,7 @@ fun List<ASTNode>.handleIncorrectOrder(
         val (afterThisNode, beforeThisNode) = astNode.getSiblingBlocks()
         val isPositionIncorrect =
             (afterThisNode != null && !astNode.treeParent.isChildAfterAnother(astNode, afterThisNode)) ||
-                !astNode.treeParent.isChildBeforeAnother(astNode, beforeThisNode)
+                    !astNode.treeParent.isChildBeforeAnother(astNode, beforeThisNode)
 
         if (isPositionIncorrect) {
             incorrectPositionHandler(astNode, beforeThisNode)
@@ -839,10 +839,10 @@ private fun <T> Sequence<T>.takeWhileInclusive(pred: (T) -> Boolean): Sequence<T
 private fun Collection<KtAnnotationEntry>.containSuppressWithName(name: String) =
     this.any {
         it.shortName.toString() == (Suppress::class.simpleName) &&
-            (it.valueArgumentList
-                ?.arguments
-                ?.any { annotation -> annotation.text.trim('"') == name }
-                ?: false)
+                (it.valueArgumentList
+                    ?.arguments
+                    ?.any { annotation -> annotation.text.trim('"') == name }
+                    ?: false)
     }
 
 private fun ASTNode.findOffsetByLine(line: Int, positionByOffset: (Int) -> Pair<Int, Int>): Int {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/KdocUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/KdocUtils.kt
@@ -46,10 +46,10 @@ fun Iterable<KDocTag>.hasKnownKdocTag(knownTag: KDocKnownTag): Boolean =
  * @return true if there is a trailing newline
  */
 fun KDocTag.hasTrailingNewlineInTagBody() = node.lastChildNode.isWhiteSpaceWithNewline() ||
-    node.reversedChildren()
-        .takeWhile { it.elementType == WHITE_SPACE || it.elementType == ElementType.KDOC_LEADING_ASTERISK }
-        .firstOrNull { it.elementType == ElementType.KDOC_LEADING_ASTERISK }
-        ?.takeIf { it.treeNext == null || it.treeNext.elementType == WHITE_SPACE } != null
+        node.reversedChildren()
+            .takeWhile { it.elementType == WHITE_SPACE || it.elementType == ElementType.KDOC_LEADING_ASTERISK }
+            .firstOrNull { it.elementType == ElementType.KDOC_LEADING_ASTERISK }
+            ?.takeIf { it.treeNext == null || it.treeNext.elementType == WHITE_SPACE } != null
 
 /**
  * This method inserts a new tag into KDoc before specified another tag, aligning it with the rest of this KDoc

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/PsiUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/PsiUtils.kt
@@ -32,13 +32,13 @@ fun KtExpression.containsOnlyConstants(): Boolean =
         // left and right are marked @Nullable @IfNotParsed, so it should be safe to `!!`
         is KtBinaryExpression -> left!!.containsOnlyConstants() && right!!.containsOnlyConstants()
         is KtDotQualifiedExpression -> receiverExpression.containsOnlyConstants() &&
-            (selectorExpression is KtReferenceExpression ||
-                ((selectorExpression as? KtCallExpression)
-                    ?.valueArgumentList
-                    ?.arguments
-                    ?.all { it.getArgumentExpression()!!.containsOnlyConstants() }
-                    ?: false)
-            )
+                (selectorExpression is KtReferenceExpression ||
+                        ((selectorExpression as? KtCallExpression)
+                            ?.valueArgumentList
+                            ?.arguments
+                            ?.all { it.getArgumentExpression()!!.containsOnlyConstants() }
+                            ?: false)
+                )
         else -> false
     }
 
@@ -65,9 +65,9 @@ fun KtNameReferenceExpression.findLocalDeclaration(): KtProperty? = parents
             .mapNotNull { it as? KtProperty }
             .find {
                 it.isLocal &&
-                    it.hasInitializer() &&
-                    it.name?.equals(getReferencedName())
-                        ?: false
+                        it.hasInitializer() &&
+                        it.name?.equals(getReferencedName())
+                            ?: false
             }
     }
     .firstOrNull()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/Checkers.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/Checkers.kt
@@ -87,11 +87,11 @@ internal class ValueParameterListChecker(configuration: IndentationConfig) : Cus
             .node
             .elementType
             .let { it == VALUE_PARAMETER_LIST || it == VALUE_ARGUMENT_LIST } &&
-            whiteSpace.siblings(forward = false, withItself = false).none { it is PsiWhiteSpace && it.textContains('\n') } &&
-            // no need to trigger when there are no more parameters in the list
-            whiteSpace.siblings(forward = true, withItself = false).any {
-                it.node.elementType.run { this == VALUE_ARGUMENT || this == VALUE_PARAMETER }
-            }
+                whiteSpace.siblings(forward = false, withItself = false).none { it is PsiWhiteSpace && it.textContains('\n') } &&
+                // no need to trigger when there are no more parameters in the list
+                whiteSpace.siblings(forward = true, withItself = false).any {
+                    it.node.elementType.run { this == VALUE_ARGUMENT || this == VALUE_PARAMETER }
+                }
 
     override fun checkNode(whiteSpace: PsiWhiteSpace, indentError: IndentationError): CheckResult? {
         if (isCheckNeeded(whiteSpace)) {
@@ -102,8 +102,8 @@ internal class ValueParameterListChecker(configuration: IndentationConfig) : Cus
                 ?.treeNext
                 ?.takeIf {
                     it.elementType != WHITE_SPACE &&
-                        // there can be multiline arguments and in this case we don't align parameters with them
-                        !it.textContains('\n')
+                            // there can be multiline arguments and in this case we don't align parameters with them
+                            !it.textContains('\n')
                 }
 
             val expectedIndent = if (parameterAfterLpar != null && configuration.alignedParameters && parameterList.elementType == VALUE_PARAMETER_LIST) {
@@ -137,7 +137,7 @@ internal class ExpressionIndentationChecker(configuration: IndentationConfig) : 
     override fun checkNode(whiteSpace: PsiWhiteSpace, indentError: IndentationError): CheckResult? {
         if (whiteSpace.parent.node.elementType == BINARY_EXPRESSION && whiteSpace.prevSibling.node.elementType == OPERATION_REFERENCE) {
             val expectedIndent = (whiteSpace.parentIndent() ?: indentError.expected) +
-                (if (configuration.extendedIndentAfterOperators) 2 else 1) * configuration.indentationSize
+                    (if (configuration.extendedIndentAfterOperators) 2 else 1) * configuration.indentationSize
             return CheckResult.from(indentError.actual, expectedIndent, true)
         }
         return null
@@ -186,7 +186,7 @@ internal class SuperTypeListChecker(config: IndentationConfig) : CustomIndentati
  */
 internal class DotCallChecker(config: IndentationConfig) : CustomIndentationChecker(config) {
     private fun ASTNode.isDotBeforeCallOrReference() = elementType.let { it == DOT || it == SAFE_ACCESS } &&
-        treeNext.elementType.let { it == CALL_EXPRESSION || it == REFERENCE_EXPRESSION }
+            treeNext.elementType.let { it == CALL_EXPRESSION || it == REFERENCE_EXPRESSION }
 
     private fun ASTNode.isCommentBeforeDot(): Boolean {
         if (elementType == EOL_COMMENT || elementType == BLOCK_COMMENT) {
@@ -208,15 +208,15 @@ internal class DotCallChecker(config: IndentationConfig) : CustomIndentationChec
             .node
             .takeIf { nextNode ->
                 (nextNode.isDotBeforeCallOrReference() ||
-                    nextNode.elementType == OPERATION_REFERENCE && nextNode.firstChildNode.elementType.let { type ->
-                        type == ELVIS || type == IS_EXPRESSION || type == AS_KEYWORD || type == AS_SAFE
-                    } || nextNode.isCommentBeforeDot()) && whiteSpace.parents.none { it.node.elementType == LONG_STRING_TEMPLATE_ENTRY }
+                        nextNode.elementType == OPERATION_REFERENCE && nextNode.firstChildNode.elementType.let { type ->
+                            type == ELVIS || type == IS_EXPRESSION || type == AS_KEYWORD || type == AS_SAFE
+                        } || nextNode.isCommentBeforeDot()) && whiteSpace.parents.none { it.node.elementType == LONG_STRING_TEMPLATE_ENTRY }
             }
             ?.let { node ->
                 val indentIncrement = (if (configuration.extendedIndentBeforeDot) 2 else 1) * configuration.indentationSize
                 if (node.isFromStringTemplate()) {
                     return CheckResult.from(indentError.actual, indentError.expected +
-                        indentIncrement, true)
+                            indentIncrement, true)
                 }
 
                 // we need to get indent before the first expression in calls chain
@@ -255,7 +255,7 @@ internal class ConditionalsAndLoopsWithoutBracesChecker(config: IndentationConfi
         return when (parent) {
             is KtLoopExpression -> nextNode?.elementType == BODY && parent.body !is KtBlockExpression
             is KtIfExpression -> nextNode?.elementType == THEN && parent.then !is KtBlockExpression ||
-                nextNode?.elementType == ELSE && parent.`else`.let { it !is KtBlockExpression && it !is KtIfExpression }
+                    nextNode?.elementType == ELSE && parent.`else`.let { it !is KtBlockExpression && it !is KtIfExpression }
             else -> false
         }
             .takeIf { it }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
@@ -65,7 +65,7 @@ internal class IndentationConfig(config: Map<String, String>) : RuleConfiguratio
     /**
      * If true, if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
      */
-    val extendedIndentAfterOperators = config["extendedIndentAfterOperators"]?.toBoolean() ?: false
+    val extendedIndentAfterOperators = config["extendedIndentAfterOperators"]?.toBoolean() ?: true
 
     /**
      * If true, when dot qualified expression starts on a new line, this line will be indented with

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesSearch.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesSearch.kt
@@ -103,11 +103,11 @@ abstract class VariablesSearch(val node: ASTNode,
             // FixMe: in class or a file the declaration can easily go after the usage (by lines of code)
             block.getChildrenOfType<KtProperty>()
                 .any { it.nameAsName == property.nameAsName && expression.node.isGoingAfter(it.node) } ||
-                block.parent
-                    .let { it as? KtFunctionLiteral }
-                    ?.valueParameters
-                    ?.any { it.nameAsName == property.nameAsName }
-                    ?: false
+                    block.parent
+                        .let { it as? KtFunctionLiteral }
+                        ?.valueParameters
+                        ?.any { it.nameAsName == property.nameAsName }
+                        ?: false
             // FixMe: also see very strange behavior of Kotlin in tests (disabled)
         }
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithAssignmentSearch.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithAssignmentSearch.kt
@@ -37,11 +37,11 @@ class VariablesWithAssignmentSearch(fileNode: ASTNode,
             // FixMe: Currently we check only val a = 5, ++a is not checked here
             // FixMe: also there can be some tricky cases with setters, but I am not able to imagine them now
             it.isGoingAfter(property.node) &&
-                (it.psi as KtBinaryExpression).operationToken == ElementType.EQ &&
-                (it.psi as KtBinaryExpression)
-                    .left
-                    ?.node
-                    ?.elementType == ElementType.REFERENCE_EXPRESSION
+                    (it.psi as KtBinaryExpression).operationToken == ElementType.EQ &&
+                    (it.psi as KtBinaryExpression)
+                        .left
+                        ?.node
+                        ?.elementType == ElementType.REFERENCE_EXPRESSION
         }
         .map { (it.psi as KtBinaryExpression).left as KtNameReferenceExpression }
         // checking that name of the property in usage matches with the name in the declaration
@@ -49,8 +49,8 @@ class VariablesWithAssignmentSearch(fileNode: ASTNode,
         .filterNot { expression ->
             // to avoid false triggering on objects' fields with same name as property
             expression.isReferenceToFieldOfObject() ||
-                // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
-                isReferenceToOtherVariableWithSameName(expression, this, property)
+                    // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
+                    isReferenceToOtherVariableWithSameName(expression, this, property)
         }
         .toList()
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithUsagesSearch.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/search/VariablesWithUsagesSearch.kt
@@ -30,8 +30,8 @@ class VariablesWithUsagesSearch(fileNode: ASTNode,
         .filterNot { expression ->
             // to avoid false triggering on objects' fields with same name as property
             expression.isReferenceToFieldOfObject() ||
-                // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
-                isReferenceToOtherVariableWithSameName(expression, this, property)
+                    // to exclude usages of local properties from other context (shadowed) and lambda arguments with same name
+                    isReferenceToOtherVariableWithSameName(expression, this, property)
         }
 }
 

--- a/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
@@ -217,7 +217,7 @@
     # ij_kotlin_continuation_indent_for_expression_bodies in .editorconfig.
     extendedIndentForExpressionBodies: false
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: false
+    extendedIndentAfterOperators: true
     # If true: when dot qualified expression starts on a new line, this line will be indented with two indentations instead of one
     extendedIndentBeforeDot: false
     # The indentation size for each file

--- a/diktat-rules/src/main/resources/diktat-analysis.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis.yml
@@ -217,7 +217,7 @@
     # ij_kotlin_continuation_indent_for_expression_bodies in .editorconfig.
     extendedIndentForExpressionBodies: false
     # If true: if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
-    extendedIndentAfterOperators: false
+    extendedIndentAfterOperators: true
     # The indentation size for each file
     indentationSize: 4
 # Checks that there is no empty blocks in a file.

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
@@ -24,11 +24,11 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
             mapOf("lineLength" to "40"))
     )
     private val wrongUrl = "dhttps://www.google.com/search?q=djfhvkdfhvkdh+gthtdj%" +
-        "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
-        "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
+            "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
+            "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
     private val correctUrl = "https://www.google.com/search?q=djfhvkdfhvkdh+gthtdj%" +
-        "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
-        "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
+            "3Bb&rlz=1C1GCEU_enRU909RU909&oq=posible+gthtdj%3Bb&aqs=chrome.." +
+            "69i57j0l3.2680j1j7&sourceid=chrome&ie=UTF-8"
 
     @Test
     @Tag(WarningNames.LONG_LINE)

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringConcatenationWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringConcatenationWarnTest.kt
@@ -23,7 +23,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " \"my string\" + \"string\" + value + \"other value\"", canBeAutoCorrected)
+                    " \"my string\" + \"string\" + value + \"other value\"", canBeAutoCorrected)
         )
     }
 
@@ -36,7 +36,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " \"my string\" + 1 + 2 + 3", canBeAutoCorrected)
+                    " \"my string\" + 1 + 2 + 3", canBeAutoCorrected)
         )
     }
 
@@ -50,7 +50,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " (1 + 2).toString() + \"my string\" + 3", canBeAutoCorrected)
+                    " (1 + 2).toString() + \"my string\" + 3", canBeAutoCorrected)
         )
     }
 
@@ -64,7 +64,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " (1 + 2).toString() + \"my string\" + 3 + \"string\" + myObject + myObject", canBeAutoCorrected)
+                    " (1 + 2).toString() + \"my string\" + 3 + \"string\" + myObject + myObject", canBeAutoCorrected)
         )
     }
 
@@ -78,7 +78,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " (1 + 2).toString() + \"my string\" + (\"string\" + myObject) + myObject", canBeAutoCorrected)
+                    " (1 + 2).toString() + \"my string\" + (\"string\" + myObject) + myObject", canBeAutoCorrected)
         )
     }
 
@@ -92,7 +92,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | }
             """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
+                    " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
 
@@ -106,7 +106,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
+                    " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
 
@@ -120,7 +120,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + 2 + 3)", canBeAutoCorrected)
+                    " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
 
@@ -133,8 +133,8 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + (2 + 3)) +" +
-                " (\"third string\" + (\"str\" + 5))", canBeAutoCorrected)
+                    " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + (2 + 3)) +" +
+                    " (\"third string\" + (\"str\" + 5))", canBeAutoCorrected)
         )
     }
 
@@ -147,7 +147,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |
             """.trimMargin(),
             LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
-                " \"my string\" + (\"third string\" + (\"str\" + 5 * 12 / 100))", canBeAutoCorrected)
+                    " \"my string\" + (\"third string\" + (\"str\" + 5 * 12 / 100))", canBeAutoCorrected)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
@@ -343,7 +343,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |}
             """.trimMargin(),
             LintError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                "should be aligned with it in declaration of <foo>", true),
+                    "should be aligned with it in declaration of <foo>", true),
             LintError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <foo>", true)
         )
     }
@@ -690,13 +690,13 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |) { }
             """.trimMargin(),
             LintError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                "should be aligned with it in declaration of <Foo>", true),
+                    "should be aligned with it in declaration of <Foo>", true),
             LintError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
             LintError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                "should be aligned with it in declaration of <Foo>", true),
+                    "should be aligned with it in declaration of <Foo>", true),
             LintError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
             LintError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (arg1) should be placed on the new line or " +
-                "all other parameters should be aligned with it", true),
+                    "all other parameters should be aligned with it", true),
             LintError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true)
         )
     }
@@ -722,7 +722,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |) { }
             """.trimMargin(),
             LintError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
-                "should be aligned with it in declaration of <bar>", true),
+                    "should be aligned with it in declaration of <bar>", true),
             LintError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <bar>", true)
         )
     }
@@ -767,7 +767,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |}
             """.trimMargin(),
             LintError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (\"id\") should be placed on the new line or " +
-                "all other parameters should be aligned with it", true),
+                    "all other parameters should be aligned with it", true),
             LintError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true),
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
@@ -99,7 +99,7 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
 
         assertSoftly { softly ->
             (actualContent.asSequenceWithConcatenation() zip
-                expectedContent.asSequenceWithConcatenation()).forEach { (actual, expected) ->
+                    expectedContent.asSequenceWithConcatenation()).forEach { (actual, expected) ->
                 val lintResult = fixAndCompareContent(
                     actual,
                     expected,

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
@@ -67,11 +67,11 @@ internal object IndentationRuleTestResources {
         |        } else {
         |            @Suppress("DEPRECATION")
         |            systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE or
-        |                View.SYSTEM_UI_FLAG_FULLSCREEN or
-        |                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-        |                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
-        |                View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
-        |                View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+        |                    View.SYSTEM_UI_FLAG_FULLSCREEN or
+        |                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+        |                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+        |                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+        |                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
         |        }
         |    }
         """.trimMargin(),
@@ -95,14 +95,14 @@ internal object IndentationRuleTestResources {
         """
         |fun f() =
         |    x + (y +
-        |        g(x)
+        |            g(x)
         |    )
         """.trimMargin(),
 
         """
         |fun f() =
         |    (1 +
-        |        2)
+        |            2)
         """.trimMargin(),
     )
 
@@ -162,11 +162,11 @@ internal object IndentationRuleTestResources {
         |            } else {
         |                @Suppress("DEPRECATION")
         |                systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE or
-        |                    View.SYSTEM_UI_FLAG_FULLSCREEN or
-        |                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-        |                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
-        |                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
-        |                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+        |                        View.SYSTEM_UI_FLAG_FULLSCREEN or
+        |                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+        |                        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+        |                        View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+        |                        View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
         |            }
         |        }
         """.trimMargin(),
@@ -190,14 +190,14 @@ internal object IndentationRuleTestResources {
         """
         |fun f() =
         |        x + (y +
-        |            g(x)
+        |                g(x)
         |        )
         """.trimMargin(),
 
         """
         |fun f() =
         |        (1 +
-        |            2)
+        |                2)
         """.trimMargin(),
     )
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
@@ -621,20 +621,20 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |        ?.count()
                     |
                     |    list.any { predicate(it) } &&
-                    |        list.any {
-                    |            predicate(it)
-                    |        }
+                    |            list.any {
+                    |                predicate(it)
+                    |            }
                     |
                     |    list.any { predicate(it) } &&
-                    |        // comment
-                    |        list.any {
-                    |            predicate(it)
-                    |        }
+                    |            // comment
+                    |            list.any {
+                    |                predicate(it)
+                    |            }
                     |
                     |    list.filter {
                     |        predicate(it) &&
-                    |            // comment
-                    |            predicate(it)
+                    |                // comment
+                    |                predicate(it)
                     |    }
                     |}
                     |
@@ -665,9 +665,9 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             """
                     |fun foo() {
                     |    return x +
-                    |        (y +
-                    |            foo(x)
-                    |        )
+                    |            (y +
+                    |                    foo(x)
+                    |            )
                     |}
                     |
             """.trimMargin()

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/WhiteSpaceRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/WhiteSpaceRuleWarnTest.kt
@@ -24,13 +24,13 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                           reqBefore: Int?,
                           reqAfter: Int?
     ) = "${WRONG_WHITESPACE.warnText()} $token should have" +
-        (reqBefore?.let { " $it space(s) before" } ?: "") +
-        (if (reqBefore != null && reqAfter != null) " and" else "") +
-        (reqAfter?.let { " $it space(s) after" } ?: "") +
-        ", but has" +
-        (before?.let { " $it space(s) before" } ?: "") +
-        (if (before != null && after != null) " and" else "") +
-        (after?.let { " $it space(s) after" } ?: "")
+            (reqBefore?.let { " $it space(s) before" } ?: "") +
+            (if (reqBefore != null && reqAfter != null) " and" else "") +
+            (reqAfter?.let { " $it space(s) after" } ?: "") +
+            ", but has" +
+            (before?.let { " $it space(s) before" } ?: "") +
+            (if (before != null && after != null) " and" else "") +
+            (after?.let { " $it space(s) after" } ?: "")
 
     @Test
     @Tag(WarningNames.WRONG_WHITESPACE)

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NullChecksRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NullChecksRuleWarnTest.kt
@@ -47,7 +47,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
             """.trimMargin(),
             LintError(3, 11, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                " use '.let/.also/?:/e.t.c' instead of myVar == null", true),
+                    " use '.let/.also/?:/e.t.c' instead of myVar == null", true),
         )
     }
 
@@ -64,7 +64,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
             """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
+                    " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
         )
     }
 
@@ -83,7 +83,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
             """.trimMargin(),
             LintError(2, 27, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
+                    " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
         )
     }
 
@@ -101,7 +101,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
             """.trimMargin(),
             LintError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                " use '.let/.also/?:/e.t.c' instead of myVar !== null", true),
+                    " use '.let/.also/?:/e.t.c' instead of myVar !== null", true),
         )
     }
 
@@ -172,7 +172,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
             """.trimMargin(),
             LintError(2, 10, ruleId, "${Warnings.AVOID_NULL_CHECKS.warnText()} use '.let/.also/?:/e.t.c'" +
-                " instead of myVar != null", true),
+                    " instead of myVar != null", true),
         )
     }
 
@@ -186,7 +186,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 | }
             """.trimMargin(),
             LintError(2, 14, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
-                " use 'requireNotNull' instead of require(myVar != null)", true),
+                    " use 'requireNotNull' instead of require(myVar != null)", true),
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -226,7 +226,7 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
             LintError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
             LintError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
             LintError(9, 3, "$DIKTAT_RULE_SET_ID:${EmptyBlock.NAME_ID}", EMPTY_BLOCK_STRUCTURE_ERROR.warnText() +
-                " empty blocks are forbidden unless it is function with override keyword", false),
+                    " empty blocks are forbidden unless it is function with override keyword", false),
             LintError(12, 10, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
             LintError(14, 8, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
             LintError(19, 20, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false)
@@ -265,7 +265,7 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
         fixAndCompareSmokeTest("kotlin-library-expected.gradle.kts", "kotlin-library.gradle.kts")
         Assertions.assertEquals(
             LintError(2, 1, "$DIKTAT_RULE_SET_ID:${CommentsRule.NAME_ID}", "[COMMENTED_OUT_CODE] you should not comment out code, " +
-                "use VCS to save it in history and delete this block: import org.jetbrains.kotlin.gradle.dsl.jvm", false),
+                    "use VCS to save it in history and delete this block: import org.jetbrains.kotlin.gradle.dsl.jvm", false),
             unfixedLintErrors.single()
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -126,7 +126,6 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
             rulesToOverride = mapOf(
                 WRONG_INDENTATION.name to mapOf(
                     "extendedIndentForExpressionBodies" to "true",
-                    "extendedIndentAfterOperators" to "true",
                     "extendedIndentBeforeDot" to "true",
                 )
             )
@@ -169,16 +168,6 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
     @Test
     @Tag("DiktatRuleSetProvider")
     fun `smoke test #4`() {
-        overrideRulesConfig(
-            rulesToDisable = emptyList(),
-            rulesToOverride = mapOf(
-                WRONG_INDENTATION.name to mapOf(
-                    "extendedIndentForExpressionBodies" to "true",
-                    "extendedIndentAfterOperators" to "true",
-                    "extendedIndentBeforeDot" to "false",
-                )
-            )
-        )
         fixAndCompareSmokeTest("Example4Expected.kt", "Example4Test.kt")
     }
 
@@ -201,8 +190,6 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
             rulesToDisable = emptyList(),
             rulesToOverride = mapOf(
                 WRONG_INDENTATION.name to mapOf(
-                    "extendedIndentForExpressionBodies" to "true",
-                    "extendedIndentAfterOperators" to "true",
                     "extendedIndentBeforeDot" to "true",
                 )
             )
@@ -226,8 +213,6 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
             rulesToOverride = mapOf(
                 WRONG_INDENTATION.name to mapOf(
                     "extendedIndentForExpressionBodies" to "true",
-                    "extendedIndentAfterOperators" to "true",
-                    "extendedIndentBeforeDot" to "false",
                 )
             )
         )
@@ -256,7 +241,6 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
             mapOf(
                 WRONG_INDENTATION.name to mapOf(
                     "newlineAtEnd" to "false",
-                    "extendedIndentOfParameters" to "false",
                 )
             )
         )  // so that trailing newline isn't checked, because it's incorrectly read in tests and we are comparing file with itself
@@ -349,6 +333,14 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
     @Test
     @Tag("DiktatRuleSetProvider")
     fun `fix can cause long line`() {
+        overrideRulesConfig(
+            rulesToDisable = emptyList(),
+            rulesToOverride = mapOf(
+                WRONG_INDENTATION.name to mapOf(
+                    "extendedIndentAfterOperators" to "false",
+                )
+            )
+        )
         fixAndCompareSmokeTest("ManyLineTransformInLongLineExpected.kt", "ManyLineTransformInLongLineTest.kt")
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/AvailableRulesDocTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/AvailableRulesDocTest.kt
@@ -19,7 +19,7 @@ class AvailableRulesDocTest {
             val ruleName = splitMarkDown[SPLIT_MARK].trim()
 
             if (!ruleName.startsWith(TABLE_DELIMITER) &&
-                !ruleName.startsWith(RULE_NAME_HEADER)) {
+                    !ruleName.startsWith(RULE_NAME_HEADER)) {
                 listWithRulesFromDoc.add(ruleName)
             }
         }
@@ -36,7 +36,7 @@ class AvailableRulesDocTest {
             val ruleFound = allRulesFromDoc.find { it.trim() == ruleName } != null
             Assertions.assertTrue(ruleFound) {
                 val docs = "| | | $ruleName" +
-                    "|  |  |  | |"
+                        "|  |  |  | |"
                 """
                     Cannot find warning $ruleName in $AVAILABLE_RULES_FILE.
                     You can fix it by adding the following description below with more info to $AVAILABLE_RULES_FILE:

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/SuppressingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/SuppressingTest.kt
@@ -65,7 +65,7 @@ class SuppressingTest : LintTestBase(::IdentifierNaming) {
                 9,
                 ruleId,
                 "[IDENTIFIER_LENGTH] identifier's length is incorrect, it" +
-                    " should be in range of [2, 64] symbols: a", false),
+                        " should be in range of [2, 64] symbols: a", false),
             rulesConfigList = rulesConfigBooleanFunctions,
         )
     }

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestProcessingFactory.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestProcessingFactory.kt
@@ -27,7 +27,7 @@ class TestProcessingFactory(private val argReader: TestArgumentsReader) {
             ?.let { File(it.file) }
             ?: run {
                 log.error("Not able to get directory with test configuration files: " +
-                    argReader.properties.testConfigsRelativePath)
+                        argReader.properties.testConfigsRelativePath)
                 exitProcess(STATUS_FIVE)
             }
         try {


### PR DESCRIPTION
### What's done:

 * Once we now have a separate flag for assignment
   (`extendedIndentForExpressionBodies`, `false` by default, see #1443), let's set
   `extendedIndentAfterOperators` back to `true` to be consistent with how IDEA
   formats Kotlin source files.

## Which rule and warnings did you add?

## Actions checklist
* [X] Updated diktat-analysis.yml
