### PR TITLE
[gradle-plugin] use empty string as default value for reporter type

### DIFF
--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatExtension.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatExtension.kt
@@ -31,7 +31,7 @@ open class DiktatExtension(
     /**
      * Type of the reporter to use
      */
-    var reporter: String = "plain"
+    var reporter: String = ""
 
     /**
      * Destination for reporter. If empty, will write to stdout.

--- a/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginTest.kt
+++ b/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginTest.kt
@@ -40,7 +40,9 @@ class DiktatGradlePluginTest {
     @Test
     fun `check default reporter type value`() {
         val diktatExtension = project.extensions.getByName("diktat") as DiktatExtension
-        // fixme: verify that correct reporter flag is built from this setting.
         Assertions.assertEquals("", diktatExtension.reporter)
+
+        val reporterFlag = project.createReporterFlag(diktatExtension)
+        Assertions.assertEquals("--reporter=plain", reporterFlag)
     }
 }

--- a/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginTest.kt
+++ b/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginTest.kt
@@ -38,8 +38,9 @@ class DiktatGradlePluginTest {
     }
 
     @Test
-    fun `check that the right reporter dependency added`() {
+    fun `check default reporter type value`() {
         val diktatExtension = project.extensions.getByName("diktat") as DiktatExtension
-        Assertions.assertTrue(diktatExtension.reporter == "plain")
+        // fixme: verify that correct reporter flag is built from this setting.
+        Assertions.assertEquals("", diktatExtension.reporter)
     }
 }


### PR DESCRIPTION
In #1426 we've introduced a warning, that is currently being logged in unintended cases, because default value of `reporterType` is a non-empty string:
```
`diktat.githubActions` is set to true, so custom reporter [plain] will be ignored and SARIF reporter will be used
```
However, reporter type is not set explicitly so for the end user the warning makes no sense.

 With an empty string as the default there will be no warning and diktat will fall back to using `plain` reporter according to the `DiktatJavaExecTaskBase#setReporter` method