### PR TITLE
Rewrite `getParenthesisIndentationChange()` to return `IndentationAmount`

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentedElementType.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentedElementType.kt
@@ -1,0 +1,29 @@
+@file:Suppress(
+    "HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE",
+    "TOP_LEVEL_ORDER",
+)
+
+package org.cqfn.diktat.ruleset.rules.chapter3.files
+
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
+
+/**
+ * An [IElementType] along with the indentation change it induces.
+ */
+internal typealias IndentedElementType = Pair<IElementType, IndentationAmount>
+
+/**
+ * @return the element type.
+ */
+@Suppress("CUSTOM_GETTERS_SETTERS")
+internal val IndentedElementType.type: IElementType
+    get() =
+        first
+
+/**
+ * @return the indentation change.
+ */
+@Suppress("CUSTOM_GETTERS_SETTERS")
+internal val IndentedElementType.indentationChange: IndentationAmount
+    get() =
+        second


### PR DESCRIPTION
### What's done:

 * `isParenthesisAffectingIndent()` renamed to `getParenthesisIndentationChange()`.
 * The return type changed from `Boolean` to `IndentationAmount`.
 * The value returned by `getParenthesisIndentationChange()` is now stored on
   the "indentation stack" along with the corresponding element types.
 * This is merely a refactoring, so no user-visible behaviour has been changed.
 * See #1448.
