### PR TITLE
Add support for an extended indent after an opening `(` in expressions

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
@@ -504,7 +504,7 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
                  * indentation if it's immediately followed by a newline.
                  */
                 LPAR -> when {
-                    treeNext.isWhiteSpaceWithNewline() -> SINGLE
+                    treeNext.isWhiteSpaceWithNewline() -> IndentationAmount.valueOf(configuration.extendedIndentAfterOperators)
                     else -> NONE
                 }
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/indentation/IndentationConfig.kt
@@ -9,18 +9,18 @@ internal class IndentationConfig(config: Map<String, String>) : RuleConfiguratio
     /**
      * Is newline at the end of a file needed
      */
-    val newlineAtEnd = config["newlineAtEnd"]?.toBoolean() ?: true
+    val newlineAtEnd = config[NEWLINE_AT_END]?.toBoolean() ?: true
 
     /**
      * If true, in parameter list when parameters are split by newline they are indented with two indentations instead of one
      */
-    val extendedIndentOfParameters = config["extendedIndentOfParameters"]?.toBoolean() ?: false
+    val extendedIndentOfParameters = config[EXTENDED_INDENT_OF_PARAMETERS]?.toBoolean() ?: false
 
     /**
      * If true, if first parameter in parameter list is on the same line as opening parenthesis, then other parameters
      * can be aligned with it
      */
-    val alignedParameters = config["alignedParameters"]?.toBoolean() ?: true
+    val alignedParameters = config[ALIGNED_PARAMETERS]?.toBoolean() ?: true
 
     /**
      * If `true`, expression bodies which begin on a separate line are indented
@@ -60,29 +60,63 @@ internal class IndentationConfig(config: Map<String, String>) : RuleConfiguratio
      *
      * @since 1.2.2
      */
-    val extendedIndentForExpressionBodies = config["extendedIndentForExpressionBodies"]?.toBoolean() ?: false
+    val extendedIndentForExpressionBodies = config[EXTENDED_INDENT_FOR_EXPRESSION_BODIES]?.toBoolean() ?: false
 
     /**
      * If true, if expression is split by newline after operator like +/-/`*`, then the next line is indented with two indentations instead of one
      */
-    val extendedIndentAfterOperators = config["extendedIndentAfterOperators"]?.toBoolean() ?: true
+    val extendedIndentAfterOperators = config[EXTENDED_INDENT_AFTER_OPERATORS]?.toBoolean() ?: true
 
     /**
      * If true, when dot qualified expression starts on a new line, this line will be indented with
      * two indentations instead of one
      */
-    val extendedIndentBeforeDot = config["extendedIndentBeforeDot"]?.toBoolean() ?: false
+    val extendedIndentBeforeDot = config[EXTENDED_INDENT_BEFORE_DOT]?.toBoolean() ?: false
 
     /**
      * The indentation size for each file
      */
-    val indentationSize = config["indentationSize"]?.toInt() ?: DEFAULT_INDENT_SIZE
+    val indentationSize = config[INDENTATION_SIZE]?.toInt() ?: DEFAULT_INDENTATION_SIZE
 
-    private companion object {
+    override fun equals(other: Any?): Boolean =
+        other is IndentationConfig && configWithExplicitDefaults == other.configWithExplicitDefaults
+
+    override fun hashCode(): Int =
+        configWithExplicitDefaults.hashCode()
+
+    override fun toString(): String =
+        "${javaClass.simpleName}$configWithExplicitDefaults"
+
+    internal companion object {
+        internal const val ALIGNED_PARAMETERS = "alignedParameters"
+
         /**
          * The default indent size (space characters), configurable via
          * `indentationSize`.
          */
-        private const val DEFAULT_INDENT_SIZE = 4
+        private const val DEFAULT_INDENTATION_SIZE = 4
+        internal const val EXTENDED_INDENT_AFTER_OPERATORS = "extendedIndentAfterOperators"
+        internal const val EXTENDED_INDENT_BEFORE_DOT = "extendedIndentBeforeDot"
+        internal const val EXTENDED_INDENT_FOR_EXPRESSION_BODIES = "extendedIndentForExpressionBodies"
+        internal const val EXTENDED_INDENT_OF_PARAMETERS = "extendedIndentOfParameters"
+        internal const val INDENTATION_SIZE = "indentationSize"
+        internal const val NEWLINE_AT_END = "newlineAtEnd"
+
+        @Suppress(
+            "CUSTOM_GETTERS_SETTERS",
+            "STRING_TEMPLATE_QUOTES",
+        )
+        private val IndentationConfig.configWithExplicitDefaults: Map<String, String>
+            get() =
+                mutableMapOf<String, String>().apply {
+                    putAll(config)
+                    putIfAbsent(ALIGNED_PARAMETERS, "$alignedParameters")
+                    putIfAbsent(EXTENDED_INDENT_AFTER_OPERATORS, "$extendedIndentAfterOperators")
+                    putIfAbsent(EXTENDED_INDENT_BEFORE_DOT, "$extendedIndentBeforeDot")
+                    putIfAbsent(EXTENDED_INDENT_FOR_EXPRESSION_BODIES, "$extendedIndentForExpressionBodies")
+                    putIfAbsent(EXTENDED_INDENT_OF_PARAMETERS, "$extendedIndentOfParameters")
+                    putIfAbsent(INDENTATION_SIZE, "$indentationSize")
+                    putIfAbsent(NEWLINE_AT_END, "$newlineAtEnd")
+                }
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationConfigAwareTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationConfigAwareTest.kt
@@ -5,6 +5,7 @@ import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationAmount.EXTENDED
 import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationAmount.NONE
 import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationAmount.SINGLE
 import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationConfigAware.Factory.withIndentationConfig
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.INDENTATION_SIZE
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.MethodOrderer.DisplayName
@@ -14,10 +15,10 @@ import org.junit.jupiter.params.provider.ValueSource
 
 @TestMethodOrder(DisplayName::class)
 class IndentationConfigAwareTest {
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun `Int + IndentationAmount`(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(42 + NONE).isEqualTo(42)
@@ -26,10 +27,10 @@ class IndentationConfigAwareTest {
         }
     }
 
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun `Int - IndentationAmount`(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(42 - NONE).isEqualTo(42)
@@ -38,10 +39,10 @@ class IndentationConfigAwareTest {
         }
     }
 
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun `IndentationAmount + Int`(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(NONE + 42).isEqualTo(42 + NONE)
@@ -52,10 +53,10 @@ class IndentationConfigAwareTest {
         }
     }
 
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun `IndentationAmount - Int`(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(NONE - 42).isEqualTo(-(42 - NONE))
@@ -66,10 +67,10 @@ class IndentationConfigAwareTest {
         }
     }
 
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun `IndentationAmount + IndentationAmount`(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(NONE + SINGLE).isEqualTo(0 + SINGLE)
@@ -80,10 +81,10 @@ class IndentationConfigAwareTest {
         }
     }
 
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun `IndentationAmount - IndentationAmount`(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(NONE - SINGLE).isEqualTo(0 - SINGLE)
@@ -95,10 +96,10 @@ class IndentationConfigAwareTest {
         }
     }
 
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun unaryPlus(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(+NONE).isEqualTo(0)
@@ -109,10 +110,10 @@ class IndentationConfigAwareTest {
         }
     }
 
-    @ParameterizedTest(name = "indentationSize = {0}")
+    @ParameterizedTest(name = "$INDENTATION_SIZE = {0}")
     @ValueSource(ints = [2, 4, 8])
     fun unaryMinus(indentationSize: Int) {
-        val config = IndentationConfig("indentationSize" to indentationSize)
+        val config = IndentationConfig(INDENTATION_SIZE to indentationSize)
 
         withIndentationConfig(config) {
             assertThat(-NONE).isEqualTo(0)

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
@@ -15,6 +15,13 @@ import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.pare
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.whitespaceInStringLiterals
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
 import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationRule
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.ALIGNED_PARAMETERS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_AFTER_OPERATORS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_BEFORE_DOT
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_FOR_EXPRESSION_BODIES
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_OF_PARAMETERS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.NEWLINE_AT_END
 import org.cqfn.diktat.util.FixTestBase
 
 import generated.WarningNames
@@ -27,6 +34,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 import java.nio.file.Path
@@ -37,12 +45,12 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
     listOf(
         RulesConfig(WRONG_INDENTATION.name, true,
             mapOf(
-                "newlineAtEnd" to "true",  // expected file should have two newlines at end in order to be read by BufferedReader correctly
-                "extendedIndentOfParameters" to "true",
-                "alignedParameters" to "true",
-                "extendedIndentForExpressionBodies" to "true",
-                "extendedIndentAfterOperators" to "true",
-                "extendedIndentBeforeDot" to "true",
+                NEWLINE_AT_END to "true",  // expected file should have two newlines at end in order to be read by BufferedReader correctly
+                EXTENDED_INDENT_OF_PARAMETERS to "true",
+                ALIGNED_PARAMETERS to "true",
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to "true",
+                EXTENDED_INDENT_AFTER_OPERATORS to "true",
+                EXTENDED_INDENT_BEFORE_DOT to "true",
             )
         )
     )
@@ -121,12 +129,12 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Expression body functions` {
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should remain unchanged if properly indented`(extendedIndentForExpressionBodies: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies)
 
             lintMultipleMethods(
                 expressionBodyFunctions[extendedIndentForExpressionBodies].assertNotNull(),
@@ -134,12 +142,12 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
                 rulesConfigList = customConfig.asRulesConfigList())
         }
 
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be reformatted if mis-indented`(extendedIndentForExpressionBodies: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies)
 
             lintMultipleMethods(
                 actualContent = expressionBodyFunctions[!extendedIndentForExpressionBodies].assertNotNull(),
@@ -159,7 +167,7 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `no whitespace should be injected (code matches settings)`(extendedIndent: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
             val customConfig = defaultConfig.withCustomParameters(*extendedIndent(enabled = extendedIndent))
 
             lintMultipleMethods(
@@ -172,7 +180,7 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `no whitespace should be injected (mis-indented code reformatted)`(extendedIndent: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
             val customConfig = defaultConfig.withCustomParameters(*extendedIndent(enabled = extendedIndent))
 
             lintMultipleMethods(
@@ -189,12 +197,12 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Expressions wrapped after operator` {
-        @ParameterizedTest(name = "extendedIndentAfterOperators = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be properly indented`(extendedIndentAfterOperators: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to extendedIndentAfterOperators)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
 
             lintMultipleMethods(
                 expressionsWrappedAfterOperator[extendedIndentAfterOperators].assertNotNull(),
@@ -202,12 +210,12 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
                 rulesConfigList = customConfig.asRulesConfigList())
         }
 
-        @ParameterizedTest(name = "extendedIndentAfterOperators = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be reformatted if mis-indented`(extendedIndentAfterOperators: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to extendedIndentAfterOperators)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
 
             lintMultipleMethods(
                 actualContent = expressionsWrappedAfterOperator[!extendedIndentAfterOperators].assertNotNull(),
@@ -223,31 +231,49 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Parentheses-surrounded infix expressions` {
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
-        @ValueSource(booleans = [false, true])
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}, $EXTENDED_INDENT_AFTER_OPERATORS = {1}")
+        @CsvSource(value = ["false,true", "true,false"])
         @Tag(WarningNames.WRONG_INDENTATION)
-        fun `should be properly indented`(extendedIndentForExpressionBodies: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+        fun `should be properly indented`(
+            extendedIndentForExpressionBodies: Boolean,
+            extendedIndentAfterOperators: Boolean,
+            @TempDir tempDir: Path,
+        ) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies,
+                EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators,
+            )
 
             lintMultipleMethods(
-                parenthesesSurroundedInfixExpressions[extendedIndentForExpressionBodies].assertNotNull(),
+                parenthesesSurroundedInfixExpressions[IndentationConfig(customConfig)].assertNotNull(),
                 tempDir = tempDir,
                 rulesConfigList = customConfig.asRulesConfigList())
         }
 
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
-        @ValueSource(booleans = [false, true])
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}, $EXTENDED_INDENT_AFTER_OPERATORS = {1}")
+        @CsvSource(value = ["false,true", "true,false"])
         @Tag(WarningNames.WRONG_INDENTATION)
-        fun `should be reformatted if mis-indented`(extendedIndentForExpressionBodies: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+        fun `should be reformatted if mis-indented`(
+            extendedIndentForExpressionBodies: Boolean,
+            extendedIndentAfterOperators: Boolean,
+            @TempDir tempDir: Path,
+        ) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val actualCodeStyle = defaultConfig.withCustomParameters(
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to !extendedIndentForExpressionBodies,
+                EXTENDED_INDENT_AFTER_OPERATORS to !extendedIndentAfterOperators,
+            )
+            val desiredCodeStyle = defaultConfig.withCustomParameters(
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies,
+                EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators,
+            )
 
             lintMultipleMethods(
-                actualContent = parenthesesSurroundedInfixExpressions[!extendedIndentForExpressionBodies].assertNotNull(),
-                expectedContent = parenthesesSurroundedInfixExpressions[extendedIndentForExpressionBodies].assertNotNull(),
+                actualContent = parenthesesSurroundedInfixExpressions[IndentationConfig(actualCodeStyle)].assertNotNull(),
+                expectedContent = parenthesesSurroundedInfixExpressions[IndentationConfig(desiredCodeStyle)].assertNotNull(),
                 tempDir = tempDir,
-                rulesConfigList = customConfig.asRulesConfigList())
+                rulesConfigList = desiredCodeStyle.asRulesConfigList())
         }
     }
 
@@ -257,12 +283,12 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Dot- and safe-qualified expressions` {
-        @ParameterizedTest(name = "extendedIndentBeforeDot = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_BEFORE_DOT = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be properly indented`(extendedIndentBeforeDot: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentBeforeDot" to extendedIndentBeforeDot)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_BEFORE_DOT to extendedIndentBeforeDot)
 
             lintMultipleMethods(
                 dotQualifiedExpressions[extendedIndentBeforeDot].assertNotNull(),
@@ -270,12 +296,12 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
                 rulesConfigList = customConfig.asRulesConfigList())
         }
 
-        @ParameterizedTest(name = "extendedIndentBeforeDot = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_BEFORE_DOT = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be reformatted if mis-indented`(extendedIndentBeforeDot: Boolean, @TempDir tempDir: Path) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentBeforeDot" to extendedIndentBeforeDot)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_BEFORE_DOT to extendedIndentBeforeDot)
 
             lintMultipleMethods(
                 actualContent = dotQualifiedExpressions[!extendedIndentBeforeDot].assertNotNull(),

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestMixin.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestMixin.kt
@@ -3,6 +3,13 @@ package org.cqfn.diktat.ruleset.chapter3.spaces
 import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
 import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.ALIGNED_PARAMETERS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_AFTER_OPERATORS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_BEFORE_DOT
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_FOR_EXPRESSION_BODIES
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_OF_PARAMETERS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.INDENTATION_SIZE
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.NEWLINE_AT_END
 
 /**
  * Code shared by [IndentationRuleWarnTest] and [IndentationRuleFixTest].
@@ -34,13 +41,13 @@ internal object IndentationRuleTestMixin {
     @Suppress("STRING_TEMPLATE_QUOTES")
     fun IndentationConfig.withCustomParameters(vararg configEntries: Pair<String, Any>): Map<String, String> =
         mutableMapOf(
-            "alignedParameters" to "$alignedParameters",
-            "indentationSize" to "$indentationSize",
-            "newlineAtEnd" to "$newlineAtEnd",
-            "extendedIndentOfParameters" to "$extendedIndentOfParameters",
-            "extendedIndentForExpressionBodies" to "$extendedIndentForExpressionBodies",
-            "extendedIndentAfterOperators" to "$extendedIndentAfterOperators",
-            "extendedIndentBeforeDot" to "$extendedIndentBeforeDot",
+            ALIGNED_PARAMETERS to "$alignedParameters",
+            INDENTATION_SIZE to "$indentationSize",
+            NEWLINE_AT_END to "$newlineAtEnd",
+            EXTENDED_INDENT_OF_PARAMETERS to "$extendedIndentOfParameters",
+            EXTENDED_INDENT_FOR_EXPRESSION_BODIES to "$extendedIndentForExpressionBodies",
+            EXTENDED_INDENT_AFTER_OPERATORS to "$extendedIndentAfterOperators",
+            EXTENDED_INDENT_BEFORE_DOT to "$extendedIndentBeforeDot",
         ).apply {
             configEntries.forEach { (key, value) ->
                 this[key] = value.toString()
@@ -70,10 +77,10 @@ internal object IndentationRuleTestMixin {
      */
     fun extendedIndent(enabled: Boolean): Array<Pair<String, Any>> =
         arrayOf(
-            "extendedIndentOfParameters" to enabled,
-            "extendedIndentForExpressionBodies" to enabled,
-            "extendedIndentAfterOperators" to enabled,
-            "extendedIndentBeforeDot" to enabled)
+            EXTENDED_INDENT_OF_PARAMETERS to enabled,
+            EXTENDED_INDENT_FOR_EXPRESSION_BODIES to enabled,
+            EXTENDED_INDENT_AFTER_OPERATORS to enabled,
+            EXTENDED_INDENT_BEFORE_DOT to enabled)
 
     /**
      * @return the concatenated content of this array (elements separated with

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
@@ -1,5 +1,10 @@
 package org.cqfn.diktat.ruleset.chapter3.spaces
 
+import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.IndentationConfig
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_AFTER_OPERATORS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_FOR_EXPRESSION_BODIES
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.NEWLINE_AT_END
+
 import org.intellij.lang.annotations.Language
 
 /**
@@ -849,8 +854,8 @@ internal object IndentationRuleTestResources {
         true to expressionsWrappedAfterOperatorContinuationIndent)
 
     /**
-     * Parenthesized expressions, single indent
-     * (`extendedIndentForExpressionBodies` is **off**).
+     * Parenthesized expressions, `extendedIndentForExpressionBodies` is **off**,
+     * `extendedIndentAfterOperators` is **on**.
      *
      * When adding new code fragments to this list, be sure to also add their
      * counterparts (preserving order) to
@@ -864,56 +869,56 @@ internal object IndentationRuleTestResources {
     private val parenthesesSurroundedInfixExpressionsSingleIndent = arrayOf(
         """
         |fun f1() = (
-        |    1 + 2
+        |        1 + 2
         |)
         """.trimMargin(),
 
         """
         |fun f2() = (
-        |    1 + 2)
+        |        1 + 2)
         """.trimMargin(),
 
         """
         |fun f3() =
         |    (
-        |        1 + 2
+        |            1 + 2
         |    )
         """.trimMargin(),
 
         """
         |fun f4() =
         |    (
-        |        1 + 2)
+        |            1 + 2)
         """.trimMargin(),
 
         """
         |const val v1 = (
-        |    1 + 2
+        |        1 + 2
         |)
         """.trimMargin(),
 
         """
         |const val v2 = (
-        |    1 + 2)
+        |        1 + 2)
         """.trimMargin(),
 
         """
         |const val v3 =
         |    (
-        |        1 + 2
+        |            1 + 2
         |    )
         """.trimMargin(),
 
         """
         |const val v4 =
         |    (
-        |        1 + 2)
+        |            1 + 2)
         """.trimMargin(),
     )
 
     /**
-     * Parenthesized expressions, continuation indent
-     * (`extendedIndentForExpressionBodies` is **on**).
+     * Parenthesized expressions, `extendedIndentForExpressionBodies` is **on**,
+     * `extendedIndentAfterOperators` is **off**.
      *
      * When adding new code fragments to this list, be sure to also add their
      * counterparts (preserving order) to
@@ -980,8 +985,16 @@ internal object IndentationRuleTestResources {
      * See [#1409](https://github.com/saveourtool/diktat/issues/1409).
      */
     val parenthesesSurroundedInfixExpressions = mapOf(
-        false to parenthesesSurroundedInfixExpressionsSingleIndent,
-        true to parenthesesSurroundedInfixExpressionsContinuationIndent)
+        IndentationConfig(
+            NEWLINE_AT_END to false,
+            EXTENDED_INDENT_FOR_EXPRESSION_BODIES to false,
+            EXTENDED_INDENT_AFTER_OPERATORS to true,
+        ) to parenthesesSurroundedInfixExpressionsSingleIndent,
+        IndentationConfig(
+            NEWLINE_AT_END to false,
+            EXTENDED_INDENT_FOR_EXPRESSION_BODIES to true,
+            EXTENDED_INDENT_AFTER_OPERATORS to false,
+        ) to parenthesesSurroundedInfixExpressionsContinuationIndent)
 
     /**
      * Dot-qualified and safe-access expressions, single indent

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
@@ -15,6 +15,14 @@ import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.ifEx
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.parenthesesSurroundedInfixExpressions
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
 import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationRule
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.ALIGNED_PARAMETERS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_AFTER_OPERATORS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_BEFORE_DOT
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_FOR_EXPRESSION_BODIES
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_OF_PARAMETERS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.INDENTATION_SIZE
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.NEWLINE_AT_END
 import org.cqfn.diktat.util.LintTestBase
 
 import com.pinterest.ktlint.core.LintError
@@ -29,6 +37,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.opentest4j.MultipleFailuresError
 
@@ -41,24 +50,24 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
     private val rulesConfigList = listOf(
         RulesConfig(WRONG_INDENTATION.name, true,
             mapOf(
-                "extendedIndentOfParameters" to "true",
-                "alignedParameters" to "true",
-                "extendedIndentForExpressionBodies" to "true",
-                "extendedIndentAfterOperators" to "true",
-                "extendedIndentBeforeDot" to "false",
-                "indentationSize" to "4"
+                EXTENDED_INDENT_OF_PARAMETERS to "true",
+                ALIGNED_PARAMETERS to "true",
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to "true",
+                EXTENDED_INDENT_AFTER_OPERATORS to "true",
+                EXTENDED_INDENT_BEFORE_DOT to "false",
+                INDENTATION_SIZE to "4"
             )
         )
     )
     private val disabledOptionsRulesConfigList = listOf(
         RulesConfig(WRONG_INDENTATION.name, true,
             mapOf(
-                "extendedIndentOfParameters" to "false",
-                "alignedParameters" to "false",
-                "extendedIndentForExpressionBodies" to "false",
-                "extendedIndentAfterOperators" to "false",
-                "extendedIndentBeforeDot" to "false",
-                "indentationSize" to "4"
+                EXTENDED_INDENT_OF_PARAMETERS to "false",
+                ALIGNED_PARAMETERS to "false",
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to "false",
+                EXTENDED_INDENT_AFTER_OPERATORS to "false",
+                EXTENDED_INDENT_BEFORE_DOT to "false",
+                INDENTATION_SIZE to "4"
             )
         )
     )
@@ -551,8 +560,8 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             rulesConfigList = listOf(
                 RulesConfig(WRONG_INDENTATION.name, true,
                     mapOf(
-                        "extendedIndentOfParameters" to "false",
-                        "extendedIndentBeforeDot" to "false"
+                        EXTENDED_INDENT_OF_PARAMETERS to "false",
+                        EXTENDED_INDENT_BEFORE_DOT to "false"
                     )
                 )
             )
@@ -822,12 +831,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Expression body functions` {
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be properly indented`(extendedIndentForExpressionBodies: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies)
 
             lintMultipleMethods(
                 expressionBodyFunctions[extendedIndentForExpressionBodies].assertNotNull(),
@@ -836,12 +845,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             )
         }
 
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be reported if mis-indented`(extendedIndentForExpressionBodies: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies)
 
             assertSoftly { softly ->
                 expressionBodyFunctions[!extendedIndentForExpressionBodies].assertNotNull().forEach { code ->
@@ -864,12 +873,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Expressions wrapped after operator` {
-        @ParameterizedTest(name = "extendedIndentAfterOperators = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be properly indented`(extendedIndentAfterOperators: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to extendedIndentAfterOperators)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
 
             lintMultipleMethods(
                 expressionsWrappedAfterOperator[extendedIndentAfterOperators].assertNotNull(),
@@ -878,12 +887,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             )
         }
 
-        @ParameterizedTest(name = "extendedIndentAfterOperators = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be reported if mis-indented`(extendedIndentAfterOperators: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to extendedIndentAfterOperators)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
 
             assertSoftly { softly ->
                 expressionsWrappedAfterOperator[!extendedIndentAfterOperators].assertNotNull().forEach { code ->
@@ -906,30 +915,42 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Parentheses-surrounded infix expressions` {
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
-        @ValueSource(booleans = [false, true])
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}, $EXTENDED_INDENT_AFTER_OPERATORS = {1}")
+        @CsvSource(value = ["false,true", "true,false"])
         @Tag(WarningNames.WRONG_INDENTATION)
-        fun `should be properly indented`(extendedIndentForExpressionBodies: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+        fun `should be properly indented`(extendedIndentForExpressionBodies: Boolean,
+                                          extendedIndentAfterOperators: Boolean) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies,
+                EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators,
+            )
 
             lintMultipleMethods(
-                parenthesesSurroundedInfixExpressions[extendedIndentForExpressionBodies].assertNotNull(),
+                parenthesesSurroundedInfixExpressions[IndentationConfig(customConfig)].assertNotNull(),
                 lintErrors = emptyArray(),
                 customConfig.asRulesConfigList()
             )
         }
 
-        @ParameterizedTest(name = "extendedIndentForExpressionBodies = {0}")
-        @ValueSource(booleans = [false, true])
+        @ParameterizedTest(name = "$EXTENDED_INDENT_FOR_EXPRESSION_BODIES = {0}, $EXTENDED_INDENT_AFTER_OPERATORS = {1}")
+        @CsvSource(value = ["false,true", "true,false"])
         @Tag(WarningNames.WRONG_INDENTATION)
-        fun `should be reported if mis-indented`(extendedIndentForExpressionBodies: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentForExpressionBodies" to extendedIndentForExpressionBodies)
+        fun `should be reported if mis-indented`(extendedIndentForExpressionBodies: Boolean,
+                                                 extendedIndentAfterOperators: Boolean) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val actualCodeStyle = defaultConfig.withCustomParameters(
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to !extendedIndentForExpressionBodies,
+                EXTENDED_INDENT_AFTER_OPERATORS to !extendedIndentAfterOperators,
+            )
+            val desiredCodeStyle = defaultConfig.withCustomParameters(
+                EXTENDED_INDENT_FOR_EXPRESSION_BODIES to extendedIndentForExpressionBodies,
+                EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators,
+            )
 
             assertSoftly { softly ->
-                parenthesesSurroundedInfixExpressions[!extendedIndentForExpressionBodies].assertNotNull().forEach { code ->
-                    softly.assertThat(lintResult(code, customConfig.asRulesConfigList()))
+                parenthesesSurroundedInfixExpressions[IndentationConfig(actualCodeStyle)].assertNotNull().forEach { code ->
+                    softly.assertThat(lintResult(code, desiredCodeStyle.asRulesConfigList()))
                         .describedAs("lint result for ${code.describe()}")
                         .hasSizeBetween(0, 3).allSatisfy(Consumer { lintError ->
                             assertThat(lintError.ruleId).describedAs("ruleId").isEqualTo(ruleId)
@@ -947,12 +968,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `Dot- and safe-qualified expressions` {
-        @ParameterizedTest(name = "extendedIndentBeforeDot = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_BEFORE_DOT = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be properly indented`(extendedIndentBeforeDot: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentBeforeDot" to extendedIndentBeforeDot)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_BEFORE_DOT to extendedIndentBeforeDot)
 
             lintMultipleMethods(
                 dotQualifiedExpressions[extendedIndentBeforeDot].assertNotNull(),
@@ -961,12 +982,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             )
         }
 
-        @ParameterizedTest(name = "extendedIndentBeforeDot = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_BEFORE_DOT = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be reported if mis-indented`(extendedIndentBeforeDot: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentBeforeDot" to extendedIndentBeforeDot)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_BEFORE_DOT to extendedIndentBeforeDot)
 
             assertSoftly { softly ->
                 dotQualifiedExpressions[!extendedIndentBeforeDot].assertNotNull().forEach { code ->
@@ -986,12 +1007,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
     @Nested
     @TestMethodOrder(DisplayName::class)
     inner class `If expressions` {
-        @ParameterizedTest(name = "extendedIndentAfterOperators = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be properly indented`(extendedIndentAfterOperators: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to extendedIndentAfterOperators)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
 
             lintMultipleMethods(
                 ifExpressions[extendedIndentAfterOperators].assertNotNull(),
@@ -1000,12 +1021,12 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             )
         }
 
-        @ParameterizedTest(name = "extendedIndentAfterOperators = {0}")
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
         @ValueSource(booleans = [false, true])
         @Tag(WarningNames.WRONG_INDENTATION)
         fun `should be reported if mis-indented`(extendedIndentAfterOperators: Boolean) {
-            val defaultConfig = IndentationConfig("newlineAtEnd" to false)
-            val customConfig = defaultConfig.withCustomParameters("extendedIndentAfterOperators" to extendedIndentAfterOperators)
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
 
             assertSoftly { softly ->
                 ifExpressions[!extendedIndentAfterOperators].assertNotNull().forEach { code ->

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -12,6 +12,7 @@ import org.cqfn.diktat.ruleset.rules.chapter2.comments.CommentsRule
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocComments
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocFormatting
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocMethods
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.NEWLINE_AT_END
 import org.cqfn.diktat.util.assertEquals
 
 import com.pinterest.ktlint.core.LintError
@@ -50,7 +51,7 @@ class DiktatSmokeTest : DiktatSmokeTestBase() {
             emptyList(),
             mapOf(
                 WRONG_INDENTATION.name to mapOf(
-                    "newlineAtEnd" to "false",
+                    NEWLINE_AT_END to "false",
                 )
             )
         )  // so that trailing newline isn't checked, because it's incorrectly read in tests and we are comparing file with itself

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
@@ -29,6 +29,9 @@ import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocFormatting
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocMethods
 import org.cqfn.diktat.ruleset.rules.chapter3.EmptyBlock
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.InlineClassesRule
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_AFTER_OPERATORS
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_BEFORE_DOT
+import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.EXTENDED_INDENT_FOR_EXPRESSION_BODIES
 import org.cqfn.diktat.util.FixTestBase
 import org.cqfn.diktat.util.assertEquals
 
@@ -128,9 +131,9 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
             rulesToDisable = emptyList(),
             rulesToOverride = mapOf(
                 WRONG_INDENTATION.name to mapOf(
-                    "extendedIndentForExpressionBodies" to "true",
-                    "extendedIndentAfterOperators" to "true",
-                    "extendedIndentBeforeDot" to "true",
+                    EXTENDED_INDENT_FOR_EXPRESSION_BODIES to "true",
+                    EXTENDED_INDENT_AFTER_OPERATORS to "true",
+                    EXTENDED_INDENT_BEFORE_DOT to "true",
                 )
             )
         )
@@ -196,8 +199,8 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
             rulesToDisable = emptyList(),
             rulesToOverride = mapOf(
                 WRONG_INDENTATION.name to mapOf(
-                    "extendedIndentAfterOperators" to "true",
-                    "extendedIndentBeforeDot" to "true",
+                    EXTENDED_INDENT_AFTER_OPERATORS to "true",
+                    EXTENDED_INDENT_BEFORE_DOT to "true",
                 )
             )
         )
@@ -221,8 +224,8 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
             rulesToDisable = emptyList(),
             rulesToOverride = mapOf(
                 WRONG_INDENTATION.name to mapOf(
-                    "extendedIndentAfterOperators" to "true",
-                    "extendedIndentForExpressionBodies" to "true",
+                    EXTENDED_INDENT_AFTER_OPERATORS to "true",
+                    EXTENDED_INDENT_FOR_EXPRESSION_BODIES to "true",
                 )
             )
         )
@@ -276,7 +279,7 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
             rulesToDisable = emptyList(),
             rulesToOverride = mapOf(
                 WRONG_INDENTATION.name to mapOf(
-                    "extendedIndentAfterOperators" to "false",
+                    EXTENDED_INDENT_AFTER_OPERATORS to "false",
                 )
             )
         )


### PR DESCRIPTION
### What's done:

 * The value of the indent is controlled with the `extendedIndentAfterOperators`
   flag.
 * Fixes #1448.