### PR TITLE
Add the retry logic and diagnostics to `DiktatSaveSmokeTest`

### DIFF
--- a/diktat-rules/pom.xml
+++ b/diktat-rules/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <apache.httpclient.version>4.5.13</apache.httpclient.version>
     </properties>
 
     <dependencies>
@@ -93,11 +92,6 @@
         <dependency>
             <groupId>com.bpodgursky</groupId>
             <artifactId>jbool_expressions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${apache.httpclient.version}</version>
         </dependency>
     </dependencies>
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
@@ -43,8 +43,10 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit.SECONDS
 
 import kotlinx.serialization.builtins.ListSerializer
 
@@ -106,6 +108,7 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `regression - should not fail if package is not set`() {
         overrideRulesConfig(listOf(Warnings.PACKAGE_NAME_MISSING, Warnings.PACKAGE_NAME_INCORRECT_PATH,
             Warnings.PACKAGE_NAME_INCORRECT_PREFIX))
@@ -114,18 +117,21 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #8 - anonymous function`() {
         fixAndCompare(configFilePath, "Example8Expected.kt", "Example8Test.kt")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #7`() {
         fixAndCompare(configFilePath, "Example7Expected.kt", "Example7Test.kt")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #6`() {
         overrideRulesConfig(
             rulesToDisable = emptyList(),
@@ -142,6 +148,7 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #5`() {
         overrideRulesConfig(emptyList(),
             mapOf(
@@ -176,24 +183,28 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #4`() {
         fixAndCompare(configFilePath, "Example4Expected.kt", "Example4Test.kt")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #3`() {
         fixAndCompare(configFilePath, "Example3Expected.kt", "Example3Test.kt")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `regression - shouldn't throw exception in cases similar to #371`() {
         fixAndCompare(configFilePath, "Bug1Expected.kt", "Bug1Test.kt")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #2`() {
         overrideRulesConfig(
             rulesToDisable = emptyList(),
@@ -219,6 +230,7 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test #1`() {
         overrideRulesConfig(
             rulesToDisable = emptyList(),
@@ -250,30 +262,35 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test with kts files #2`() {
         fixAndCompare(configFilePath, "script/SimpleRunInScriptExpected.kts", "script/SimpleRunInScriptTest.kts")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `smoke test with kts files with package name`() {
         fixAndCompare(configFilePath, "script/PackageInScriptExpected.kts", "script/PackageInScriptTest.kts")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `regression - should correctly handle tags with empty lines`() {
         fixAndCompare(configFilePath, "KdocFormattingMultilineTagsExpected.kt", "KdocFormattingMultilineTagsTest.kt")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `regression - FP of local variables rule`() {
         fixAndCompare(configFilePath, "LocalVariableWithOffsetExpected.kt", "LocalVariableWithOffsetTest.kt")
     }
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    @Timeout(TEST_TIMEOUT_SECONDS, unit = SECONDS)
     fun `fix can cause long line`() {
         overrideRulesConfig(
             rulesToDisable = emptyList(),
@@ -294,6 +311,7 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     companion object {
         const val DEFAULT_CONFIG_PATH = "../diktat-analysis.yml"
+        private const val TEST_TIMEOUT_SECONDS = 20L
         val unfixedLintErrors: MutableList<LintError> = mutableListOf()
 
         // by default using same yml config as for diktat code style check, but allow to override

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -232,9 +232,9 @@ internal fun ProcessBuilder.prependPath(pathEntry: Path) {
     val defaultWindowsPathKey = "Path"
 
     val pathKey = when {
-        /*
+        /*-
          * Keys of the Windows environment are case-insensitive ("PATH" == "Path").
-         * Keys of the Java interface to the environment is not ("PATH" != "Path").
+         * Keys of the Java interface to the environment are not ("PATH" != "Path").
          * This is an attempt to work around the inconsistency.
          */
         System.getProperty("os.name").startsWith("Windows") -> environment.keys.firstOrNull { key ->

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -2,6 +2,8 @@
  * Utility classes and methods for tests
  */
 
+@file:Suppress("TOP_LEVEL_ORDER")// False positives
+
 package org.cqfn.diktat.util
 
 import org.cqfn.diktat.common.config.rules.RulesConfig
@@ -20,8 +22,13 @@ import org.assertj.core.api.SoftAssertions
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
+import java.io.File
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
+import kotlin.io.path.absolute
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.isDirectory
 
 internal const val TEST_FILE_NAME = "TestFileName.kt"
 
@@ -137,4 +144,113 @@ internal fun applyToCode(code: String,
         .assertThat(counter.get())
         .`as`("Number of expected asserts")
         .isEqualTo(expectedAsserts)
+}
+
+/**
+ * Retries the execution of the [block].
+ *
+ * @param attempts the number of attempts (must be positive).
+ * @param delayMillis the timeout (in milliseconds) between the consecutive
+ *   attempts. The default is 0. Ignored if [attempts] is 1.
+ * @param lazyDefault allows to override the return value if none of the
+ *   attempts succeeds. By default, the last exception is thrown.
+ * @param block the block to execute.
+ * @return the result of the execution of the [block], or whatever [lazyDefault]
+ *   evaluates to if none of the attempts is successful.
+ */
+internal fun <T> retry(
+    attempts: Int,
+    delayMillis: Long = 0L,
+    lazyDefault: (Throwable) -> T = { error -> throw error },
+    block: () -> T
+): T {
+    require(attempts > 0) {
+        "The number of attempts should be positive: $attempts"
+    }
+
+    var lastError: Throwable? = null
+
+    for (i in 1..attempts) {
+        try {
+            return block()
+        } catch (error: Throwable) {
+            lastError = error
+        }
+
+        if (delayMillis > 0L) {
+            Thread.sleep(delayMillis)
+        }
+    }
+
+    return lazyDefault(lastError ?: Exception("The block was never executed"))
+}
+
+/**
+ * Deletes the file if it exists, retrying as necessary if the file is
+ * blocked by another process (on Windows).
+ *
+ * @receiver the file or empty directory.
+ * @see Path.deleteIfExists
+ */
+@Suppress(
+    "EMPTY_BLOCK_STRUCTURE_ERROR",
+    "MAGIC_NUMBER",
+)
+internal fun Path.deleteIfExistsSilently() {
+    val attempts = 10
+
+    val deleted = retry(attempts, delayMillis = 100L, lazyDefault = { false }) {
+        deleteIfExists()
+
+        /*
+         * Ignore the return code of `deleteIfExists()` (will be `false`
+         * if the file doesn't exist).
+         */
+        true
+    }
+
+    if (!deleted) {
+        log.warn {
+            "File \"${absolute()}\" not deleted after $attempts attempt(s)."
+        }
+    }
+}
+
+/**
+ * Prepends the `PATH` of this process builder with [pathEntry].
+ *
+ * @param pathEntry the entry to be prepended to the `PATH`.
+ */
+internal fun ProcessBuilder.prependPath(pathEntry: Path) {
+    require(pathEntry.isDirectory()) {
+        "$pathEntry is not a directory"
+    }
+
+    val environment = environment()
+
+    val defaultPathKey = "PATH"
+    val defaultWindowsPathKey = "Path"
+
+    val pathKey = when {
+        /*
+         * Keys of the Windows environment are case-insensitive ("PATH" == "Path").
+         * Keys of the Java interface to the environment is not ("PATH" != "Path").
+         * This is an attempt to work around the inconsistency.
+         */
+        System.getProperty("os.name").startsWith("Windows") -> environment.keys.firstOrNull { key ->
+            key.equals(defaultPathKey, ignoreCase = true)
+        } ?: defaultWindowsPathKey
+
+        else -> defaultPathKey
+    }
+
+    val pathSeparator = File.pathSeparatorChar
+    val oldPath = environment[pathKey]
+
+    val newPath = when {
+        oldPath == null || oldPath.isEmpty() -> pathEntry.toString()
+        else -> "$pathEntry$pathSeparator$oldPath"
+    }
+
+    environment[pathKey] = newPath
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -248,7 +248,7 @@ internal fun ProcessBuilder.prependPath(pathEntry: Path) {
     val oldPath = environment[pathKey]
 
     val newPath = when {
-        oldPath == null || oldPath.isEmpty() -> pathEntry.toString()
+        oldPath.isNullOrEmpty() -> pathEntry.toString()
         else -> "$pathEntry$pathSeparator$oldPath"
     }
 


### PR DESCRIPTION
### What's done:

 * `JAVA_HOME` is now correctly set for child processes (works around
   compatibility problems with Java 17).
 * Added the retry logic for download and delete operations.
 * Added test timeouts of 20s.
 * Added debug logging.
 * Dropped the dependency on Apache HttpClient (not really necessary).
 * See #1476.
