### PR TITLE
Improve `JAVA_HOME` comparison for forked tests

### DIFF
--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
@@ -3,6 +3,7 @@ package org.cqfn.diktat.ruleset.smoke
 import org.cqfn.diktat.common.utils.loggerWithKtlintConfig
 import org.cqfn.diktat.util.SAVE_VERSION
 import org.cqfn.diktat.util.deleteIfExistsSilently
+import org.cqfn.diktat.util.isSameJavaHomeAs
 import org.cqfn.diktat.util.prependPath
 import org.cqfn.diktat.util.retry
 
@@ -22,7 +23,6 @@ import kotlin.io.path.copyTo
 import kotlin.io.path.createDirectories
 import kotlin.io.path.div
 import kotlin.io.path.exists
-import kotlin.io.path.isSameFileAs
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.name
 import kotlin.io.path.outputStream
@@ -150,7 +150,7 @@ class DiktatSaveSmokeTest : DiktatSmokeTestBase() {
             val forkedJavaHome = System.getenv("JAVA_HOME")
             if (forkedJavaHome != null) {
                 val javaHome = System.getProperty("java.home")
-                if (javaHome != null && !Path(javaHome).isSameFileAs(Path(forkedJavaHome))) {
+                if (javaHome != null && !Path(javaHome).isSameJavaHomeAs(Path(forkedJavaHome))) {
                     logger.warn {
                         "Current JDK home is $javaHome. Forked tests may use a different JDK at $forkedJavaHome."
                     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -221,7 +221,7 @@ internal fun Path.deleteIfExistsSilently() {
 /**
  * @receiver the 1st operand.
  * @param other the 2nd operand.
- * @return `true` if, and only if, the two paths locate the same file.
+ * @return `true` if, and only if, the two paths locate the same `JAVA_HOME`.
  */
 internal fun Path.isSameJavaHomeAs(other: Path): Boolean =
     isDirectory() &&

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -23,12 +23,14 @@ import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 import java.io.File
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
 import kotlin.io.path.absolute
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.isDirectory
+import kotlin.io.path.isSameFileAs
 
 internal const val TEST_FILE_NAME = "TestFileName.kt"
 
@@ -215,6 +217,33 @@ internal fun Path.deleteIfExistsSilently() {
         }
     }
 }
+
+/**
+ * @receiver the 1st operand.
+ * @param other the 2nd operand.
+ * @return `true` if, and only if, the two paths locate the same file.
+ */
+internal fun Path.isSameJavaHomeAs(other: Path): Boolean =
+    isDirectory() &&
+            (isSameFileAsSafe(other) ||
+                    resolve("jre").isSameFileAsSafe(other) ||
+                    other.resolve("jre").isSameFileAsSafe(this))
+
+/**
+ * The same as [Path.isSameFileAs], but doesn't throw any [NoSuchFileException]
+ * if either of the operands doesn't exist.
+ *
+ * @receiver the 1st operand.
+ * @param other the 2nd operand.
+ * @return `true` if, and only if, the two paths locate the same file.
+ * @see Path.isSameFileAs
+ */
+internal fun Path.isSameFileAsSafe(other: Path): Boolean =
+    try {
+        isSameFileAs(other)
+    } catch (_: NoSuchFileException) {
+        false
+    }
 
 /**
  * Prepends the `PATH` of this process builder with [pathEntry].


### PR DESCRIPTION
### What's done:

 * Now, `/path/to/jdk` and `/path/to/jdk/jre` are considered the same
   `JAVA_HOME`.
