### PR TITLE
Remove the circular dependency between `diktat-rules` and `diktat-ruleset`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,9 +24,7 @@ jobs:
           restore-keys: |
             maven-build-
       - name: Maven Install
-        run: mvn -B clean install -DskipTests
-      - name: Maven run test
-        run: mvn verify
+        run: mvn -B clean install
       - name: Code coverage report
         uses: codecov/codecov-action@v3
         with:
@@ -152,25 +150,13 @@ jobs:
       - name: Maven Install
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
         run: |
-          mvn -B -T1C clean install -DskipTests
-        shell: bash
-
-      - name: Maven run test
-        if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
-        run: |
-          mvn verify
+          mvn -B -T1C clean install
         shell: bash
 
       - name: Maven Install on windows
         if: runner.os == 'Windows'
         run: |
-          mvn -B -T1C clean install -DskipTests
-        shell: cmd
-
-      - name: Maven run test
-        if: runner.os == 'Windows'
-        run: |
-          mvn verify
+          mvn -B -T1C clean install
         shell: cmd
 
         # This step needs a Git repository, so it's impossible to extract it

--- a/.github/workflows/metrics_for_master.yml
+++ b/.github/workflows/metrics_for_master.yml
@@ -28,11 +28,9 @@ jobs:
           key: maven-build-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-build-
-      - name: Maven Install
-        # we need to run `install` goal here so that gradle will be able to resolve dependencies and run tests on diktat-gradle-plugin
-        run: mvn -B install -DskipPluginMarker -DskipTests
       - name: Run tests
-        run: mvn verify
+        # we need to run `install` goal here so that gradle will be able to resolve dependencies and run tests on diktat-gradle-plugin
+        run: mvn -B install -DskipPluginMarker
       - name: Generate code coverage report
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,16 +49,10 @@ jobs:
               { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
               { "id": "kotlin-maven-plugin-tools", "username": "${{github.actor}}", "password": "${{ secrets.GITHUB_TOKEN }}" }
             ]
-        # Runs tests, incl. smoke tests (using a fat JAR built from the
-        # "diktat-ruleset" module). The fat JAR is also used later during the
-        # "upload-release-asset" step (see below).
-      - name: Run tests
-        run: mvn -B clean install
-        # "diktat-ruleset" is a module that creates a fat JAR, which is,
-        # obviously, never released. Since we *do need* this fat JAR in order to
-        # run smoke tests, we *skip tests entirely* in this step.
-      - name: Deploy artifacts (skipping the clean, test, and verify phases)
-        run: mvn -B deploy -Prelease --projects "!diktat-ruleset" -DskipTests=true
+      - name: Deploy artifacts
+        run: mvn -B clean deploy -Prelease --projects '!diktat-ruleset'
+      - name: Build diktat.jar
+        run: mvn -B package --projects diktat-ruleset
       - name: Create Github Release
         id: create_release
         uses: actions/create-release@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
-target
-.gradle
-build
+target/
+.gradle/
+build/
 !ktlint/src/main/resources/config/.idea
-/.idea
+/.idea/
 *.iml
-out
+out/
 .DS_Store
+
+# Vim swap files
+*.swp

--- a/diktat-rules/pom.xml
+++ b/diktat-rules/pom.xml
@@ -161,6 +161,73 @@
                     </arguments>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <!-- Don't produce the JAR during the `package` phase. -->
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Instead, create it immediately before the `test` phase
+                         so that the shade plug-in may use it. -->
+                    <execution>
+                        <id>fat-jar-for-smoke-tests</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Create a fat JAR to be used in smoke tests, removing the
+                 circular dependency between `diktat-rules` and `diktat-ruleset`. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <!-- Suppress the generation of `dependency-reduced-pom.xml`,
+                         because it will also get installed under `~/.m2`,
+                         resulting in the `diktat-maven-plugin` build failure
+                         (the plug-in depends on `diktat-rules`). -->
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <!-- Should be `false`: otherwise, the generated JAR, even
+                         with a custom classifier, will still be installed/deployed. -->
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <!-- Necessary: otherwise, the artifact produced by the JAR
+                         plug-in will be overwritten by the fat JAR. -->
+                    <finalName>${project.name}-${project.version}-fat-jar-for-smoke-tests</finalName>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>com.squareup:kotlinpoet</exclude>
+                            <exclude>net.java.dev.jna:jna</exclude>
+                            <exclude>org.jetbrains.intellij.deps:trove4j</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-compiler-embeddable</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-daemon-embeddable</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-reflect</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-script-runtime</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-stdlib-common</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk7</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk8</exclude>
+                            <exclude>org.jetbrains.kotlin:kotlin-stdlib</exclude>
+                            <exclude>org.jetbrains:annotations</exclude>
+                        </excludes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>fat-jar-for-smoke-tests</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
@@ -98,9 +98,9 @@ class DiktatSaveSmokeTest : DiktatSmokeTestBase() {
 
     @Suppress("WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES")  // False positives
     companion object {
-        private const val KTLINT_VERSION = "0.46.1"
         private const val BUILD_DIRECTORY = "target"
         private const val FAT_JAR_GLOB = "diktat-rules-*-fat-jar-for-smoke-tests.jar"
+        private const val KTLINT_VERSION = "0.46.1"
 
         @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR")
         private val logger = KotlinLogging.loggerWithKtlintConfig { }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
@@ -101,9 +101,7 @@ class DiktatSaveSmokeTest : DiktatSmokeTestBase() {
     @Suppress("WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES")  // False positives
     companion object {
         private const val KTLINT_VERSION = "0.46.1"
-
         private const val BUILD_DIRECTORY = "target"
-
         private const val FAT_JAR_GLOB = "diktat-rules-*-fat-jar-for-smoke-tests.jar"
 
         @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR")

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
@@ -25,9 +25,7 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.div
 import kotlin.io.path.exists
 import kotlin.io.path.listDirectoryEntries
-import kotlin.io.path.name
 import kotlin.io.path.outputStream
-import kotlin.io.path.pathString
 import kotlin.io.path.readText
 import kotlin.io.path.relativeTo
 import kotlin.system.measureNanoTime

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
@@ -69,8 +69,8 @@ open class FixTestBase(
         val systemName = System.getProperty("os.name")
         val result = when {
             systemName.startsWith("Linux", ignoreCase = true) || systemName.startsWith("Mac", ignoreCase = true) ->
-                ProcessBuilder("sh", "-c", "chmod 777 $savePath ; ./$savePath src/test/resources/test/smoke/src/main/kotlin $testPath --log all")
-            else -> ProcessBuilder(savePath, "src/test/resources/test/smoke/src/main/kotlin", testPath)
+                ProcessBuilder("sh", "-c", "chmod 777 $savePath ; ./$savePath $filesDir/src/main/kotlin $testPath --log all")
+            else -> ProcessBuilder(savePath, "$filesDir/src/main/kotlin", testPath)
         }
         return result
     }


### PR DESCRIPTION
### What's done:

 * Now it's possible to run `mvn clean install` w/o skipping tests.
 * Reverted ad66a04da79f66db5c452197ece937f666ed14c9 (was useless in the 1st
   place).
 * Reverted a67811df0a6dcb27e047fdd35f09ae4478fc0a41 (no longer necessary).
 * Partially reverted 54c8ccefc3009b8dd2a493c30590168318765b89 (no longer
   necessary).
 * See #1478.