### PR TITLE
gradle-plugin: fix incorrect dependencies related to `SarifReportMergeTask`

### DIFF
--- a/diktat-gradle-plugin/pom.xml
+++ b/diktat-gradle-plugin/pom.xml
@@ -36,6 +36,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.github.detekt.sarif4k</groupId>
+            <artifactId>sarif4k</artifactId>
+            <version>0.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/tasks/SarifReportMergeTask.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/tasks/SarifReportMergeTask.kt
@@ -58,7 +58,7 @@ abstract class SarifReportMergeTask : DefaultTask() {
 
         if (sarifReports.isEmpty()) {
             logger.warn("Cannot perform merging of SARIF reports because no matching files were found; " +
-                    "Is SARIF reporter active?"
+                    "is SARIF reporter active?"
             )
             return
         }


### PR DESCRIPTION
### What's done:
* Added missing dependency in `diktat-gradle-plugin/pom.xml`
* Fixed typo in logging

This pull request is part of #1484. It fixes compilation of gradle scripts for projects that don't have `kotlinx-serialization-core` on their plugin classpath.