### PR TITLE
Properly format expressions wrapped *before* a binary operator

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
@@ -170,7 +170,7 @@ class KdocMethods(configRules: List<RulesConfig>) : DiktatRule(
         val isReferenceExpressionWithSameName = node.findAllDescendantsWithSpecificType(REFERENCE_EXPRESSION).map { it.text }.contains((node.psi as KtFunction).name)
         val hasReturnKdoc = kdocTags != null && kdocTags.hasKnownKdocTag(KDocKnownTag.RETURN)
         return (hasExplicitNotUnitReturnType || isFunWithExpressionBody && !hasExplicitUnitReturnType && hasNotExpressionBodyTypes)
-        && !hasReturnKdoc && !isReferenceExpressionWithSameName
+                && !hasReturnKdoc && !isReferenceExpressionWithSameName
     }
 
     private fun getExplicitlyThrownExceptions(node: ASTNode): Set<String> {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/SmartCastRule.kt
@@ -126,7 +126,7 @@ class SmartCastRule(configRules: List<RulesConfig>) : DiktatRule(
             val list: MutableList<KtNameReferenceExpression> = mutableListOf()
             asExpr.forEach { asCall ->
                 if (asCall.node.findParentNodeWithSpecificType(IF)
-                    == it.node.findParentNodeWithSpecificType(IF)) {
+                        == it.node.findParentNodeWithSpecificType(IF)) {
                     list.add(asCall)
                 }
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -930,7 +930,7 @@ private fun ASTNode.hasExplicitIt(): Boolean {
     val parameterList = findChildByType(ElementType.FUNCTION_LITERAL)
         ?.findChildByType(ElementType.VALUE_PARAMETER_LIST)
         ?.psi
-        as KtParameterList?
+            as KtParameterList?
     return parameterList?.parameters
         ?.any { it.name == "it" }
         ?: false

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleFixTest.kt
@@ -11,6 +11,7 @@ import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.withCust
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.dotQualifiedExpressions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionBodyFunctions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionsWrappedAfterOperator
+import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionsWrappedBeforeOperator
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.parenthesesSurroundedInfixExpressions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.whitespaceInStringLiterals
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
@@ -220,6 +221,40 @@ class IndentationRuleFixTest : FixTestBase("test/paragraph3/indentation",
             lintMultipleMethods(
                 actualContent = expressionsWrappedAfterOperator[!extendedIndentAfterOperators].assertNotNull(),
                 expectedContent = expressionsWrappedAfterOperator[extendedIndentAfterOperators].assertNotNull(),
+                tempDir = tempDir,
+                rulesConfigList = customConfig.asRulesConfigList())
+        }
+    }
+
+    /**
+     * See [#1340](https://github.com/saveourtool/diktat/issues/1340).
+     */
+    @Nested
+    @TestMethodOrder(DisplayName::class)
+    inner class `Expressions wrapped before operator` {
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
+        @ValueSource(booleans = [false, true])
+        @Tag(WarningNames.WRONG_INDENTATION)
+        fun `should be properly indented`(extendedIndentAfterOperators: Boolean, @TempDir tempDir: Path) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
+
+            lintMultipleMethods(
+                expressionsWrappedBeforeOperator[extendedIndentAfterOperators].assertNotNull(),
+                tempDir = tempDir,
+                rulesConfigList = customConfig.asRulesConfigList())
+        }
+
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
+        @ValueSource(booleans = [false, true])
+        @Tag(WarningNames.WRONG_INDENTATION)
+        fun `should be reformatted if mis-indented`(extendedIndentAfterOperators: Boolean, @TempDir tempDir: Path) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
+
+            lintMultipleMethods(
+                actualContent = expressionsWrappedBeforeOperator[!extendedIndentAfterOperators].assertNotNull(),
+                expectedContent = expressionsWrappedBeforeOperator[extendedIndentAfterOperators].assertNotNull(),
                 tempDir = tempDir,
                 rulesConfigList = customConfig.asRulesConfigList())
         }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleTestResources.kt
@@ -605,6 +605,29 @@ internal object IndentationRuleTestResources {
         |            2 to
         |            3))
         """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g(42 as
+        |        Integer)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g("" as?
+        |        String?)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    // The dot-qualified expression is always single-indented. 
+        |    ""
+        |        .length as
+        |        Int
+        |}
+        """.trimMargin(),
     )
 
     /**
@@ -842,6 +865,29 @@ internal object IndentationRuleTestResources {
         |                2 to
         |                3))
         """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g(42 as
+        |            Integer)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g("" as?
+        |            String?)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    // The dot-qualified expression is always single-indented. 
+        |    ""
+        |        .length as
+        |            Int
+        |}
+        """.trimMargin(),
     )
 
     /**
@@ -852,6 +898,491 @@ internal object IndentationRuleTestResources {
     val expressionsWrappedAfterOperator = mapOf(
         false to expressionsWrappedAfterOperatorSingleIndent,
         true to expressionsWrappedAfterOperatorContinuationIndent)
+
+    /**
+     * Expressions wrapped before an operator or an infix function, single
+     * indent (`extendedIndentAfterOperators` is **off**).
+     *
+     * When adding new code fragments to this list, be sure to also add their
+     * counterparts (preserving order) to [expressionsWrappedBeforeOperatorContinuationIndent].
+     *
+     * See [#1340](https://github.com/saveourtool/diktat/issues/1340).
+     *
+     * @see expressionsWrappedBeforeOperatorContinuationIndent
+     */
+    @Language("kotlin")
+    private val expressionsWrappedBeforeOperatorSingleIndent = arrayOf(
+        """
+        |fun f() {
+        |    systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
+        |        or View.SYSTEM_UI_FLAG_FULLSCREEN
+        |        or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        |        or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+        |        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+        |        or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+        |}
+        """.trimMargin(),
+
+        """
+        |val systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
+        |    or View.SYSTEM_UI_FLAG_FULLSCREEN
+        |    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        |    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+        |    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+        |    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+        """.trimMargin(),
+
+        """
+        |const val FOO = 1
+        |
+        |const val BAR = 2
+        |
+        |const val BAZ = 4
+        |
+        |fun acceptInteger(arg: Int) = Unit
+        |
+        |fun main() {
+        |    acceptInteger(FOO or BAR or BAZ or FOO or BAR or BAZ
+        |        or FOO or BAR or BAZ or FOO or BAR or BAZ or FOO or BAR or BAZ
+        |        or FOO or BAR or BAZ)
+        |}
+        """.trimMargin(),
+
+        """
+        |const val TRUE = true
+        |
+        |const val FALSE = false
+        |
+        |fun acceptBoolean(arg: Boolean) = Unit
+        |
+        |fun f() {
+        |    acceptBoolean(TRUE
+        |        || FALSE
+        |        || TRUE)
+        |}
+        """.trimMargin(),
+
+        """
+        |val c = (3
+        |    + 2)
+        """.trimMargin(),
+
+        """
+        |infix fun Int.combineWith(that: Int) = this + that
+        |
+        |fun f() {
+        |    val x = (1
+        |        combineWith 2
+        |        combineWith 3
+        |        combineWith 4
+        |        combineWith 5
+        |        combineWith 6)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f(i1: Int, i2: Int, i3: Int): Int {
+        |    if (i2 > 0
+        |        && i3 < 0) {
+        |        return 2
+        |    }
+        |    return 0
+        |}
+        """.trimMargin(),
+
+        """
+        |val value1 = (1
+        |    to 2
+        |    to 3)
+        """.trimMargin(),
+
+        """
+        |val value2 =
+        |    (1
+        |        to 2
+        |        to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value3 = identity(1
+        |    to 2
+        |    to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value4 = identity(
+        |    1
+        |        to 2
+        |        to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value5 =
+        |    identity(1
+        |        to 2
+        |        to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |/**
+        | * Line breaks:
+        | *
+        | * 1. before the expression body (`=`),
+        | * 2. before the effective function arguments, and
+        | * 3. on each infix function call ([to]).
+        | */
+        |val value6 =
+        |    identity(
+        |        1
+        |            to 2
+        |            to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value7 = identity(identity(1
+        |    to 2
+        |    to 3))
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value8 = identity(identity(
+        |    1
+        |        to 2
+        |        to 3))
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value9 =
+        |    identity(identity(1
+        |        to 2
+        |        to 3))
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value10 =
+        |    identity(identity(
+        |        1
+        |            to 2
+        |            to 3))
+        """.trimMargin(),
+
+        """
+        |// Same as above, but using a custom getter instead of an explicit initializer.
+        |val value11
+        |    get() =
+        |        (1
+        |            to 2
+        |            to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |// Same as above, but using a custom getter instead of an explicit initializer.
+        |val value12
+        |    get() =
+        |        identity(1
+        |            to 2
+        |            to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |// Same as above, but using a custom getter instead of an explicit initializer.
+        |val value13
+        |    get() =
+        |        identity(identity(1
+        |            to 2
+        |            to 3))
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g(42
+        |        as Integer)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g(""
+        |        as? String?)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    // The dot-qualified expression is always single-indented. 
+        |    ""
+        |        .length
+        |        as Int
+        |}
+        """.trimMargin(),
+    )
+
+    /**
+     * Expressions wrapped before an operator or an infix function, continuation
+     * indent (`extendedIndentAfterOperators` is **on**).
+     *
+     * When adding new code fragments to this list, be sure to also add their
+     * counterparts (preserving order) to [expressionsWrappedBeforeOperatorSingleIndent].
+     *
+     * See [#1340](https://github.com/saveourtool/diktat/issues/1340).
+     *
+     * @see expressionsWrappedBeforeOperatorSingleIndent
+     */
+    @Language("kotlin")
+    private val expressionsWrappedBeforeOperatorContinuationIndent = arrayOf(
+        """
+        |fun f() {
+        |    systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
+        |            or View.SYSTEM_UI_FLAG_FULLSCREEN
+        |            or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        |            or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+        |            or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+        |            or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+        |}
+        """.trimMargin(),
+
+        """
+        |val systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
+        |        or View.SYSTEM_UI_FLAG_FULLSCREEN
+        |        or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        |        or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+        |        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+        |        or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+        """.trimMargin(),
+
+        """
+        |const val FOO = 1
+        |
+        |const val BAR = 2
+        |
+        |const val BAZ = 4
+        |
+        |fun acceptInteger(arg: Int) = Unit
+        |
+        |fun main() {
+        |    acceptInteger(FOO or BAR or BAZ or FOO or BAR or BAZ
+        |            or FOO or BAR or BAZ or FOO or BAR or BAZ or FOO or BAR or BAZ
+        |            or FOO or BAR or BAZ)
+        |}
+        """.trimMargin(),
+
+        """
+        |const val TRUE = true
+        |
+        |const val FALSE = false
+        |
+        |fun acceptBoolean(arg: Boolean) = Unit
+        |
+        |fun f() {
+        |    acceptBoolean(TRUE
+        |            || FALSE
+        |            || TRUE)
+        |}
+        """.trimMargin(),
+
+        """
+        |val c = (3
+        |        + 2)
+        """.trimMargin(),
+
+        """
+        |infix fun Int.combineWith(that: Int) = this + that
+        |
+        |fun f() {
+        |    val x = (1
+        |            combineWith 2
+        |            combineWith 3
+        |            combineWith 4
+        |            combineWith 5
+        |            combineWith 6)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f(i1: Int, i2: Int, i3: Int): Int {
+        |    if (i2 > 0
+        |            && i3 < 0) {
+        |        return 2
+        |    }
+        |    return 0
+        |}
+        """.trimMargin(),
+
+        """
+        |val value1 = (1
+        |        to 2
+        |        to 3)
+        """.trimMargin(),
+
+        """
+        |val value2 =
+        |    (1
+        |            to 2
+        |            to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value3 = identity(1
+        |        to 2
+        |        to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value4 = identity(
+        |    1
+        |            to 2
+        |            to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value5 =
+        |    identity(1
+        |            to 2
+        |            to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |/**
+        | * Line breaks:
+        | *
+        | * 1. before the expression body (`=`),
+        | * 2. before the effective function arguments, and
+        | * 3. on each infix function call ([to]).
+        | */
+        |val value6 =
+        |    identity(
+        |        1
+        |                to 2
+        |                to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value7 = identity(identity(1
+        |        to 2
+        |        to 3))
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value8 = identity(identity(
+        |    1
+        |            to 2
+        |            to 3))
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value9 =
+        |    identity(identity(1
+        |            to 2
+        |            to 3))
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |val value10 =
+        |    identity(identity(
+        |        1
+        |                to 2
+        |                to 3))
+        """.trimMargin(),
+
+        """
+        |// Same as above, but using a custom getter instead of an explicit initializer.
+        |val value11
+        |    get() =
+        |        (1
+        |                to 2
+        |                to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |// Same as above, but using a custom getter instead of an explicit initializer.
+        |val value12
+        |    get() =
+        |        identity(1
+        |                to 2
+        |                to 3)
+        """.trimMargin(),
+
+        """
+        |fun <T : Any> identity(t: T): T = t
+        |
+        |// Same as above, but using a custom getter instead of an explicit initializer.
+        |val value13
+        |    get() =
+        |        identity(identity(1
+        |                to 2
+        |                to 3))
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g(42
+        |            as Integer)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    g(""
+        |            as? String?)
+        |}
+        """.trimMargin(),
+
+        """
+        |fun f() {
+        |    // The dot-qualified expression is always single-indented. 
+        |    ""
+        |        .length
+        |            as Int
+        |}
+        """.trimMargin(),
+    )
+
+    /**
+     * Expressions wrapped before an operator or an infix function.
+     *
+     * See [#1340](https://github.com/saveourtool/diktat/issues/1340).
+     */
+    val expressionsWrappedBeforeOperator = mapOf(
+        false to expressionsWrappedBeforeOperatorSingleIndent,
+        true to expressionsWrappedBeforeOperatorContinuationIndent)
 
     /**
      * Parenthesized expressions, `extendedIndentForExpressionBodies` is **off**,

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
@@ -11,6 +11,7 @@ import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestMixin.withCust
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.dotQualifiedExpressions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionBodyFunctions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionsWrappedAfterOperator
+import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.expressionsWrappedBeforeOperator
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.ifExpressions
 import org.cqfn.diktat.ruleset.chapter3.spaces.IndentationRuleTestResources.parenthesesSurroundedInfixExpressions
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
@@ -329,8 +330,8 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |
                     |    bar
                     |        .baz()
-                    |        as Baz
-                    |        as? Baz
+                    |            as Baz
+                    |            as? Baz
                     |}
                     |
             """.trimMargin()
@@ -896,6 +897,48 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
 
             assertSoftly { softly ->
                 expressionsWrappedAfterOperator[!extendedIndentAfterOperators].assertNotNull().forEach { code ->
+                    softly.assertThat(lintResult(code, customConfig.asRulesConfigList()))
+                        .describedAs("lint result for ${code.describe()}")
+                        .isNotEmpty
+                        .hasSizeBetween(1, 5).allSatisfy(Consumer { lintError ->
+                            assertThat(lintError.ruleId).describedAs("ruleId").isEqualTo(ruleId)
+                            assertThat(lintError.canBeAutoCorrected).describedAs("canBeAutoCorrected").isTrue
+                            assertThat(lintError.detail).matches(warnTextRegex)
+                        })
+                }
+            }
+        }
+    }
+
+    /**
+     * See [#1340](https://github.com/saveourtool/diktat/issues/1340).
+     */
+    @Nested
+    @TestMethodOrder(DisplayName::class)
+    inner class `Expressions wrapped before operator` {
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
+        @ValueSource(booleans = [false, true])
+        @Tag(WarningNames.WRONG_INDENTATION)
+        fun `should be properly indented`(extendedIndentAfterOperators: Boolean) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
+
+            lintMultipleMethods(
+                expressionsWrappedBeforeOperator[extendedIndentAfterOperators].assertNotNull(),
+                lintErrors = emptyArray(),
+                customConfig.asRulesConfigList()
+            )
+        }
+
+        @ParameterizedTest(name = "$EXTENDED_INDENT_AFTER_OPERATORS = {0}")
+        @ValueSource(booleans = [false, true])
+        @Tag(WarningNames.WRONG_INDENTATION)
+        fun `should be reported if mis-indented`(extendedIndentAfterOperators: Boolean) {
+            val defaultConfig = IndentationConfig(NEWLINE_AT_END to false)
+            val customConfig = defaultConfig.withCustomParameters(EXTENDED_INDENT_AFTER_OPERATORS to extendedIndentAfterOperators)
+
+            assertSoftly { softly ->
+                expressionsWrappedBeforeOperator[!extendedIndentAfterOperators].assertNotNull().forEach { code ->
                     softly.assertThat(lintResult(code, customConfig.asRulesConfigList()))
                         .describedAs("lint result for ${code.describe()}")
                         .isNotEmpty


### PR DESCRIPTION
### What's done:

 * Now, the indentation in binary expressions wrapped *before* a binary operator
   or an infix function is also controlled with `extendedIndentAfterOperators`.
 * The above is also true for `as` and `as?` operators.
 * The only exclusion is the Elvis operator (`?:`).
 * Fixes #1340.