### PR TITLE
Maven: enable the Surefire tree reporter & color output

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             maven-build-
       - name: Maven Install
-        run: mvn -B clean install
+        run: mvn -B -Dstyle.color=always clean install
       - name: Code coverage report
         uses: codecov/codecov-action@v3
         with:
@@ -150,13 +150,13 @@ jobs:
       - name: Maven Install
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
         run: |
-          mvn -B -T1C clean install
+          mvn -B -Dstyle.color=always -T1C clean install
         shell: bash
 
       - name: Maven Install on windows
         if: runner.os == 'Windows'
         run: |
-          mvn -B -T1C clean install
+          mvn -B -Dstyle.color=always -T1C clean install
         shell: cmd
 
         # This step needs a Git repository, so it's impossible to extract it

--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -35,4 +35,4 @@ jobs:
           DIKTAT_CONFIG=diktat-analysis.yml
           wget -O $DIKTAT_CONFIG https://raw.githubusercontent.com/saveourtool/diKTat/$LATEST_TAG/$DIKTAT_CONFIG
       - name: Run diktat via maven plugin
-        run: mvn -B diktat:check@diktat -DskipPluginMarker
+        run: mvn -B -Dstyle.color=always diktat:check@diktat -DskipPluginMarker

--- a/.github/workflows/diktat_snapshot.yml
+++ b/.github/workflows/diktat_snapshot.yml
@@ -37,7 +37,7 @@ jobs:
           mvn -B versions:set -DnewVersion=$base_version-pre
       - name: Build and install
         # install diktat with version 'base_version-pre' to local maven repo
-        run: mvn -B clean install -DskipTests=true --projects diktat-maven-plugin --also-make
+        run: mvn -B -Dstyle.color=always clean install -DskipTests=true --projects diktat-maven-plugin --also-make
       - name: Revert project version and set proper version for diktat check
         # revert project version to avoid cycle dependency
         # set diktat version in plugin dependencies to the version which was built in the previous step
@@ -46,7 +46,7 @@ jobs:
           mvn -B versions:set-property -Dproperty=diktat-check.version -DnewVersion=${{ env.BASE_VERSION }}-pre
       - name: Run diktat snapshot via maven plugin
         run: |
-          mvn -B diktat:check@diktat -Ddiktat.debug=true -Ddiktat.githubActions=true
+          mvn -B -Dstyle.color=always diktat:check@diktat -Ddiktat.debug=true -Ddiktat.githubActions=true
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v2
         if: ${{ always() }}

--- a/.github/workflows/metrics_for_master.yml
+++ b/.github/workflows/metrics_for_master.yml
@@ -30,7 +30,7 @@ jobs:
             maven-build-
       - name: Run tests
         # we need to run `install` goal here so that gradle will be able to resolve dependencies and run tests on diktat-gradle-plugin
-        run: mvn -B install -DskipPluginMarker
+        run: mvn -B -Dstyle.color=always install -DskipPluginMarker
       - name: Generate code coverage report
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
               { "id": "kotlin-maven-plugin-tools", "username": "${{github.actor}}", "password": "${{ secrets.GITHUB_TOKEN }}" }
             ]
       - name: Deploy artifacts
-        run: mvn -B clean deploy -Prelease --projects '!diktat-ruleset'
+        run: mvn -B -Dstyle.color=always clean deploy -Prelease --projects '!diktat-ruleset'
       - name: Build diktat.jar
-        run: mvn -B package --projects diktat-ruleset
+        run: mvn -B -Dstyle.color=always package --projects diktat-ruleset
       - name: Create Github Release
         id: create_release
         uses: actions/create-release@v1

--- a/diktat-rules/pom.xml
+++ b/diktat-rules/pom.xml
@@ -165,10 +165,37 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>me.fabriciorby</groupId>
+                        <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                        <version>1.1.0</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <excludes>
                         <exclude>**/DiktatSaveSmokeTest.*</exclude>
                     </excludes>
+                    <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                        <!-- Prefer @DisplayName & friends, if any. -->
+                        <usePhrasedFileName>true</usePhrasedFileName>
+                        <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                        <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                        <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                    </statelessTestsetReporter>
+                    <!-- For the console output, use the tree reporter from
+                         https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter. -->
+                    <reportFormat>plain</reportFormat>
+                    <consoleOutputReporter>
+                        <disable>true</disable>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                        <!-- Prefer @DisplayName & friends, if any. -->
+                        <usePhrasedFileName>true</usePhrasedFileName>
+                        <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+                        <!-- Avoid null's in *.txt summary -->
+                        <usePhrasedClassNameInTestCaseSummary>false</usePhrasedClassNameInTestCaseSummary>
+                    </statelessTestsetInfoReporter>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
### What's done:

 * Surefire tree reporter enabled (see
   https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter).
 * Maven color output turned on even in batch mode (`-B`).