### PR TITLE
Silently overwrite `diktat.jar` if the previous copy already exists

### DIFF
--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSaveSmokeTest.kt
@@ -186,7 +186,7 @@ class DiktatSaveSmokeTest : DiktatSmokeTestBase() {
             downloadFile(URL("https://github.com/saveourtool/save-cli/releases/download/v$SAVE_VERSION/${getSaveForCurrentOs()}"), save)
             downloadFile(URL("https://github.com/pinterest/ktlint/releases/download/$KTLINT_VERSION/ktlint"), ktlint)
 
-            diktatFrom?.copyTo(diktat)
+            diktatFrom?.copyTo(diktat, overwrite = true)
         }
 
         @AfterAll


### PR DESCRIPTION
### What's done:

 * A smoke test will no longer fail if `diktat.jar` from the previous run was
   not deleted (e.g.: due to an abnormal test termination).