### PR TITLE
Fix assertion failed in rule [kdoc-formatting] #1489

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
@@ -219,7 +219,6 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
                     .first()
                     .node
                     .startOffset, basicTags.first().node) {
-                val kdocSection = node.getFirstChildWithType(KDOC_SECTION)!!
                 val basicTagChildren = kdocTags
                     .filter { basicTagsOrdered.contains(it.knownTag) }
                     .map { it.node }
@@ -229,7 +228,8 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
                     .map { it.node }
 
                 basicTagChildren.mapIndexed { index, astNode ->
-                    kdocSection.treeParent.addChild(correctKdocOrder[index].clone() as CompositeElement, astNode.treeNext)
+                    val kdocSection = astNode.treeParent
+                    kdocSection.addChild(correctKdocOrder[index].clone() as CompositeElement, astNode)
                     kdocSection.removeChild(astNode)
                 }
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocFormatting.kt
@@ -229,7 +229,7 @@ class KdocFormatting(configRules: List<RulesConfig>) : DiktatRule(
                     .map { it.node }
 
                 basicTagChildren.mapIndexed { index, astNode ->
-                    kdocSection.addChild(correctKdocOrder[index].clone() as CompositeElement, astNode)
+                    kdocSection.treeParent.addChild(correctKdocOrder[index].clone() as CompositeElement, astNode.treeNext)
                     kdocSection.removeChild(astNode)
                 }
             }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocFormattingFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocFormattingFixTest.kt
@@ -22,6 +22,12 @@ class KdocFormattingFixTest : FixTestBase("test/paragraph2/kdoc/", ::KdocFormatt
     }
 
     @Test
+    @Tag(WarningNames.KDOC_WRONG_TAGS_ORDER)
+    fun `extra new line with tags ordering should not cause assert`() {
+        fixAndCompare("OrderedTagsAssertionExpected.kt", "OrderedTagsAssertionTest.kt")
+    }
+
+    @Test
     @Tag(WarningNames.KDOC_NO_NEWLINES_BETWEEN_BASIC_TAGS)
     fun `basic tags should not have empty lines between`() {
         fixAndCompare("BasicTagsEmptyLinesExpected.kt", "BasicTagsEmptyLinesTest.kt")

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocFormattingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocFormattingTest.kt
@@ -201,6 +201,31 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
     }
 
     @Test
+    @Tag(WarningNames.KDOC_WRONG_TAGS_ORDER)
+    fun `tags should be ordered assertion issue`() {
+        val invalidCode = """
+            /**
+             * Reporter that produces a JSON report as a [Report]
+             *
+             * @property out a sink for output
+             *
+             * @param builder additional configuration lambda for serializers module
+             */
+            class JsonReporter(
+                override val out: BufferedSink,
+                builder: PolymorphicModuleBuilder<Plugin.TestFiles>.() -> Unit = {}
+            ) : Reporter
+        """.trimIndent()
+
+        lintMethod(invalidCode,
+            LintError(4, 4, ruleId,
+                "${KDOC_NO_NEWLINES_BETWEEN_BASIC_TAGS.warnText()} @property", true),
+            LintError(4, 4, ruleId,
+                "${KDOC_WRONG_TAGS_ORDER.warnText()} @property, @param", true)
+        )
+    }
+
+    @Test
     @Tag(WarningNames.KDOC_NO_NEWLINES_BETWEEN_BASIC_TAGS)
     fun `newlines are not allowed between basic tags`() {
         val invalidCode = """

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/OrderedTagsAssertionExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/OrderedTagsAssertionExpected.kt
@@ -1,0 +1,12 @@
+package com.saveourtool.save.reporter.json
+
+/**
+ * Reporter that produces a JSON report as a [Report]
+ *
+ * @param builder additional configuration lambda for serializers module
+ * @property out a sink for output
+ */
+class JsonReporter(
+    override val out: BufferedSink,
+    builder: PolymorphicModuleBuilder<Plugin.TestFiles>.() -> Unit = {}
+) : Reporter

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/OrderedTagsAssertionTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/OrderedTagsAssertionTest.kt
@@ -1,0 +1,12 @@
+package com.saveourtool.save.reporter.json
+
+/**
+ * Reporter that produces a JSON report as a [Report]
+ *
+ * @property out a sink for output
+ * @param builder additional configuration lambda for serializers module
+ */
+class JsonReporter(
+    override val out: BufferedSink,
+    builder: PolymorphicModuleBuilder<Plugin.TestFiles>.() -> Unit = {}
+) : Reporter

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/OrderedTagsAssertionTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/OrderedTagsAssertionTest.kt
@@ -4,6 +4,7 @@ package com.saveourtool.save.reporter.json
  * Reporter that produces a JSON report as a [Report]
  *
  * @property out a sink for output
+ *
  * @param builder additional configuration lambda for serializers module
  */
 class JsonReporter(


### PR DESCRIPTION
Assertion failed: anchorBefore == null || anchorBefore.getTreeParent() == parent in rule [kdoc-formatting] #1489

### What's done:
- fix for KDOC_WRONG_TAGS_ORDER rule
- warning test "tags should be ordered assertion issue"
- fix test "extra new line with tags ordering should not cause assert"
