### PR TITLE
Only apply `RANGE_TO_UNTIL` rule if right-hand side of `..` contains `X-1`

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -816,12 +816,10 @@ fun ASTNode.getLineNumber(): Int =
 fun ASTNode.takeByChainOfTypes(vararg types: IElementType): ASTNode? {
     var node: ASTNode? = this
     types.forEach {
-        node = node?.findChildByType(it) ?: run {
-            while (node?.hasChildOfType(PARENTHESIZED) == true) {
-                node = node?.findChildByType(PARENTHESIZED)
-            }
-            node?.findChildByType(it)
+        while (node?.hasChildOfType(PARENTHESIZED) == true) {
+            node = node?.findChildByType(PARENTHESIZED)
         }
+        node = node?.findChildByType(it)
     }
     return node
 }

--- a/diktat-rules/src/test/resources/test/paragraph3/range/RangeToUntilExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/range/RangeToUntilExpected.kt
@@ -11,5 +11,7 @@ class A {
         for (i in 1 until (4)) print(i)
         for (i in 1 until (b)) print(i)
         for (i in ((1 until ((4))))) print(i)
+        for (i in 1..(4 - 2)) print(i)
+        for (i in 1..(b - 10)) print(i)
     }
 }

--- a/diktat-rules/src/test/resources/test/paragraph3/range/RangeToUntilTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/range/RangeToUntilTest.kt
@@ -11,5 +11,7 @@ class A {
         for (i in 1..(4 - 1)) print(i)
         for (i in 1..(b - 1)) print(i)
         for (i in ((1 .. ((4 - 1))))) print(i)
+        for (i in 1..(4 - 2)) print(i)
+        for (i in 1..(b - 10)) print(i)
     }
 }


### PR DESCRIPTION
### What's done:
* Fix logic
* Minor refactorings
* Add fix test case

This pull request closes #1502 