### PR TITLE
Bugfix for fix mode of `AVOID_NULL_CHECK`

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
@@ -151,8 +151,8 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
             }
             ?.blockExpressionsOrSingle()
             ?.let { elements ->
-                elements.count() to elements.any {
-                        element -> KtPsiUtil.isAssignment(element)
+                elements.count() to elements.any { element ->
+                    KtPsiUtil.isAssignment(element)
                 }
             }
             ?: Pair(0, false)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter4/NullChecksRule.kt
@@ -149,15 +149,15 @@ class NullChecksRule(configRules: List<RulesConfig>) : DiktatRule(
 
         val text = "$thenEditedCodeLines $elseEditedCodeLines"
         val tree = KotlinParser().createNode(text)
-        condition.treeParent.treeParent.addChild(tree, condition.treeParent)
-        condition.treeParent.treeParent.removeChild(condition.treeParent)
+        val ifNode = condition.treeParent
+        ifNode.treeParent.replaceChild(ifNode, tree)
     }
 
     private fun getEditedElseCodeLines(elseCodeLines: List<String>?, numberOfStatementsInElseBlock: Int): String = when {
         // else { "null"/empty } -> ""
         elseCodeLines == null || elseCodeLines.singleOrNull() == "null" -> ""
         // else { bar() } -> ?: bar()
-        numberOfStatementsInElseBlock == 1 -> "?: ${elseCodeLines.joinToString(postfix = "\n", separator = "\n")}"
+        numberOfStatementsInElseBlock == 1 && elseCodeLines.singleOrNull()?.hasAssignment() != true -> "?: ${elseCodeLines.joinToString(postfix = "\n", separator = "\n")}"
         // else { ... } -> ?: run { ... }
         else -> getDefaultCaseElseCodeLines(elseCodeLines)
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringUtils.kt
@@ -40,6 +40,11 @@ val KOTLIN = KtTokens.KEYWORDS
 val loggerPropertyRegex = "(?iu)^log(?:ger)?$".toRegex()
 
 /**
+ * @return true if this String includes assignment operator, false otherwise
+ */
+fun String.hasAssignment(): Boolean = contains(REGEX_FOR_ASSIGNMENT_DETECTION.toRegex())
+
+/**
  * @return whether [this] string represents a Java keyword
  */
 fun String.isJavaKeyWord() = JAVA.contains(this)
@@ -131,8 +136,3 @@ internal fun String.leadingSpaceCount(): Int =
  */
 private fun isSpaceCharacter(ch: Char): Boolean =
     ch == SPACE
-
-/**
- * @return true if this String includes assignment operator, false otherwise
- */
-fun String.hasAssignment(): Boolean = contains(REGEX_FOR_ASSIGNMENT_DETECTION.toRegex())

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringUtils.kt
@@ -12,8 +12,6 @@ internal const val SPACE = ' '
 
 internal const val TAB = '\t'
 
-private const val REGEX_FOR_ASSIGNMENT_DETECTION = "[^=]+=[^=]+"
-
 @Suppress("VARIABLE_NAME_INCORRECT_FORMAT")
 val JAVA = arrayOf("abstract", "assert", "boolean",
     "break", "byte", "case", "catch", "char", "class", "const",
@@ -38,11 +36,6 @@ val KOTLIN = KtTokens.KEYWORDS
  * expression.
  */
 val loggerPropertyRegex = "(?iu)^log(?:ger)?$".toRegex()
-
-/**
- * @return true if this String includes assignment operator, false otherwise
- */
-fun String.hasAssignment(): Boolean = contains(REGEX_FOR_ASSIGNMENT_DETECTION.toRegex())
 
 /**
  * @return whether [this] string represents a Java keyword

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringUtils.kt
@@ -12,6 +12,8 @@ internal const val SPACE = ' '
 
 internal const val TAB = '\t'
 
+private const val REGEX_FOR_ASSIGNMENT_DETECTION = "[^=]+=[^=]+"
+
 @Suppress("VARIABLE_NAME_INCORRECT_FORMAT")
 val JAVA = arrayOf("abstract", "assert", "boolean",
     "break", "byte", "case", "catch", "char", "class", "const",
@@ -129,3 +131,8 @@ internal fun String.leadingSpaceCount(): Int =
  */
 private fun isSpaceCharacter(ch: Char): Boolean =
     ch == SPACE
+
+/**
+ * @return true if this String includes assignment operator, false otherwise
+ */
+fun String.hasAssignment(): Boolean = contains(REGEX_FOR_ASSIGNMENT_DETECTION.toRegex())

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
@@ -311,7 +311,7 @@ abstract class DiktatSmokeTestBase : FixTestBase("test/smoke/src/main/kotlin",
 
     companion object {
         const val DEFAULT_CONFIG_PATH = "../diktat-analysis.yml"
-        private const val TEST_TIMEOUT_SECONDS = 20L
+        private const val TEST_TIMEOUT_SECONDS = 25L
         val unfixedLintErrors: MutableList<LintError> = mutableListOf()
 
         // by default using same yml config as for diktat code style check, but allow to override

--- a/diktat-rules/src/test/resources/test/paragraph4/null_checks/IfConditionNullCheckExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph4/null_checks/IfConditionNullCheckExpected.kt
@@ -79,3 +79,25 @@ foo()
 } ?: boo()
 }
 
+fun nullCheckWithAssumption() {
+    val a: Int? = 5
+    a?.let {
+foo()
+} ?: run {
+a = 5
+}
+    a?.let {
+foo()
+} ?: run {
+a = 5
+}
+    a?.let {
+a = 5
+} ?: foo()
+    a?.let {
+a = 5
+} ?: foo()
+    a?.let {
+foo()
+} ?: a == 5
+}

--- a/diktat-rules/src/test/resources/test/paragraph4/null_checks/IfConditionNullCheckTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph4/null_checks/IfConditionNullCheckTest.kt
@@ -111,3 +111,31 @@ fun reversedCheckSmartCases() {
     }
 }
 
+fun nullCheckWithAssumption() {
+    val a: Int? = 5
+    if (a != null) {
+        foo()
+    } else {
+        a = 5
+    }
+    if (a == null) {
+        a = 5
+    } else {
+        foo()
+    }
+    if (a != null) {
+        a = 5
+    } else {
+        foo()
+    }
+    if (a == null) {
+        foo()
+    } else {
+        a = 5
+    }
+    if (a != null) {
+        foo()
+    } else {
+        a == 5
+    }
+}


### PR DESCRIPTION
This PR closes #1293
### What's done:
 - [x] Added isAssignment utility function to check if a line has assignment operator ('=') using simple regex
 - [x] Added a check for assignment operator when deciding if to put run block or not
 - [x] Added tests