### PR TITLE
Avoid overriding the deprecated `Rule#visit()` call

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
@@ -37,11 +37,8 @@ abstract class DiktatRule(
      */
     lateinit var emitWarn: EmitType
 
-    @Suppress(
-        "TooGenericExceptionThrown",
-        "OVERRIDE_DEPRECATION",
-    )
-    override fun visit(
+    @Suppress("TooGenericExceptionThrown")
+    final override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: EmitType

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/RunInScript.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/RunInScript.kt
@@ -27,8 +27,7 @@ class RunInScript(private val configRules: List<RulesConfig>) : Rule(NAME_ID.qua
     private var isFixMode: Boolean = false
     private lateinit var emitWarn: EmitType
 
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun visit(
+    override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: EmitType

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtilsTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtilsTest.kt
@@ -792,10 +792,9 @@ private class PrettyPrintingVisitor(private val elementType: IElementType,
                                     private val maxLevel: Int,
                                     private val expected: String
 ) : Rule("print-ast") {
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun visit(node: ASTNode,
-                       autoCorrect: Boolean,
-                       emit: EmitType
+    override fun beforeVisitChildNodes(node: ASTNode,
+                                       autoCorrect: Boolean,
+                                       emit: EmitType
     ) {
         if (node.elementType == elementType) {
             Assertions.assertEquals(

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -51,10 +51,9 @@ internal fun applyToCode(code: String,
             text = code,
             ruleSets = listOf(
                 RuleSet("test", object : Rule("astnode-utils-test") {
-                    @Suppress("OVERRIDE_DEPRECATION")
-                    override fun visit(node: ASTNode,
-                                       autoCorrect: Boolean,
-                                       emit: EmitType
+                    override fun beforeVisitChildNodes(node: ASTNode,
+                                                       autoCorrect: Boolean,
+                                                       emit: EmitType
                     ) {
                         applyToNode(node, counter)
                     }


### PR DESCRIPTION
### What's done:

`Rule.visit()` calls replaced with `Rule.beforeVisitChildNodes()`.
