### PR TITLE
Add `experimental`, `test`, and `custom` to the list of ignored rule set ids

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run diKTat from cli
         continue-on-error: true
         run: |
-          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard 'examples/maven/src/main/kotlin/Test.kt' &>out.txt
+          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard,experimental,test,custom 'examples/maven/src/main/kotlin/Test.kt' &>out.txt
         shell: bash
 
       - name: Check output
@@ -91,14 +91,14 @@ jobs:
         continue-on-error: true
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
         run: |
-          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard "$PWD/examples/maven/src/main/kotlin/Test.kt" &>out.txt
+          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard,experimental,test,custom "$PWD/examples/maven/src/main/kotlin/Test.kt" &>out.txt
         shell: bash
 
       - name: Run diKTat from cli on windows (absolute paths)
         continue-on-error: true
         if: runner.os == 'Windows'
         run: |
-          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard "%cd%/examples/maven/src/main/kotlin/Test.kt" > out.txt 2>&1
+          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard,experimental,test,custom "%cd%/examples/maven/src/main/kotlin/Test.kt" > out.txt 2>&1
         shell: cmd
 
       - name: Check output (absolute paths)
@@ -111,7 +111,7 @@ jobs:
       - name: Run diKTat from cli (glob paths, 1 of 4)
         continue-on-error: true
         run: |
-          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard 'examples/maven/src/main/kotlin/*.kt' &>out.txt
+          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard,experimental,test,custom 'examples/maven/src/main/kotlin/*.kt' &>out.txt
         shell: bash
 
       - name: Check output (glob paths, 1 of 4)
@@ -124,7 +124,7 @@ jobs:
       - name: Run diKTat from cli (glob paths, 2 of 4)
         continue-on-error: true
         run: |
-          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard 'examples/**/main/kotlin/*.kt' &>out.txt
+          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard,experimental,test,custom 'examples/**/main/kotlin/*.kt' &>out.txt
         shell: bash
 
       - name: Check output (glob paths, 2 of 4)
@@ -137,7 +137,7 @@ jobs:
       - name: Run diKTat from cli (glob paths, 3 of 4)
         continue-on-error: true
         run: |
-          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard 'examples/**/*.kt' &>out.txt
+          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard,experimental,test,custom 'examples/**/*.kt' &>out.txt
         shell: bash
 
       - name: Check output (glob paths, 3 of 4)
@@ -150,7 +150,7 @@ jobs:
       - name: Run diKTat from cli (glob paths, 4 of 4)
         continue-on-error: true
         run: |
-          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard '**/*.kt' &>out.txt
+          java -jar ktlint -R diktat-${{ env.DIKTAT_VERSION }}.jar --disabled_rules=standard,experimental,test,custom '**/*.kt' &>out.txt
         shell: bash
 
       - name: Check output (glob paths, 4 of 4)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [ master, feature/ktlint-wrapper ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [ master, feature/ktlint-wrapper ]
   schedule:
     - cron: '0 20 * * 5'
 

--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, feature/ktlint-wrapper ]
 
 jobs:
   diktat_check:

--- a/.github/workflows/diktat_snapshot.yml
+++ b/.github/workflows/diktat_snapshot.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, feature/ktlint-wrapper ]
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Main features of diktat are the following:
 Finally, run KTlint (with diKTat injected) to check your '*.kt' files in 'dir/your/dir':
 
 ```console
-$ ./ktlint -R diktat.jar --disabled_rules=standard "dir/your/dir/**/*.kt"
+$ ./ktlint -R diktat.jar --disabled_rules=standard,experimental,test,custom "dir/your/dir/**/*.kt"
 ```
 
 To **autofix** all code style violations, use `-F` option.

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePlugin.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePlugin.kt
@@ -17,6 +17,7 @@ class DiktatGradlePlugin : Plugin<Project> {
     /**
      * @param project a gradle [Project] that the plugin is applied to
      */
+    @Suppress("TOO_LONG_FUNCTION")
     override fun apply(project: Project) {
         val patternSet = PatternSet()
         val diktatExtension = project.extensions.create(
@@ -31,12 +32,25 @@ class DiktatGradlePlugin : Plugin<Project> {
         val diktatConfiguration = project.configurations.create(DIKTAT_CONFIGURATION) { configuration ->
             configuration.isVisible = false
             configuration.dependencies.add(project.dependencies.create("com.pinterest:ktlint:$KTLINT_VERSION", closureOf<ExternalModuleDependency> {
-                exclude(
-                    mutableMapOf(
-                        "group" to "com.pinterest.ktlint",
-                        "module" to "ktlint-ruleset-standard"
-                    )
+                /*
+                 * Prevent the discovery of standard rules by excluding them as
+                 * dependencies.
+                 */
+                val ktlintRuleSets = sequenceOf(
+                    "standard",
+                    "experimental",
+                    "test",
+                    "template"
                 )
+                ktlintRuleSets.forEach { ktlintRuleSet ->
+                    exclude(
+                        mutableMapOf(
+                            "group" to "com.pinterest.ktlint",
+                            "module" to "ktlint-ruleset-$ktlintRuleSet"
+                        )
+                    )
+                }
+
                 attributes {
                     it.attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling::class.java, Bundling.EXTERNAL))
                 }

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -92,6 +92,17 @@ open class DiktatJavaExecTaskBase @Inject constructor(
             project.logger.info("Setting system property for diktat config to $it")
         })
         args = additionalFlags.toMutableList().apply {
+            /*
+             * Disable the standard rules via the command line.
+             */
+            run {
+                val ktlintRuleSetIds = sequenceOf("standard", "experimental", "test", "custom")
+                ktlintRuleSetIds.joinToString(
+                    prefix = "--disabled_rules=",
+                    separator = ","
+                )
+            }.let(::add)
+
             if (diktatExtension.debug) {
                 add("--debug")
             }

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -92,8 +92,11 @@ open class DiktatJavaExecTaskBase @Inject constructor(
             project.logger.info("Setting system property for diktat config to $it")
         })
         args = additionalFlags.toMutableList().apply {
-            /*
+            /*-
              * Disable the standard rules via the command line.
+             *
+             * Classpath exclusion (see `DiktatGradlePlugin`) is enough, but
+             * this is better left enabled as a safety net.
              */
             run {
                 val ktlintRuleSetIds = sequenceOf("standard", "experimental", "test", "custom")

--- a/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskTest.kt
+++ b/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskTest.kt
@@ -33,7 +33,12 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `check command line for various inputs`() {
         assertCommandLineEquals(
-            listOf(null, combinePathParts("src", "main", "kotlin", "Test.kt"), "--reporter=plain")
+            listOf(
+                null,
+                DISABLED_RULES,
+                combinePathParts("src", "main", "kotlin", "Test.kt"),
+                "--reporter=plain"
+            )
         ) {
             inputs { include("src/**/*.kt") }
         }
@@ -42,7 +47,13 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `check command line in debug mode`() {
         assertCommandLineEquals(
-            listOf(null, "--debug", combinePathParts("src", "main", "kotlin", "Test.kt"), "--reporter=plain")
+            listOf(
+                null,
+                DISABLED_RULES,
+                "--debug",
+                combinePathParts("src", "main", "kotlin", "Test.kt"),
+                "--reporter=plain"
+            )
         ) {
             inputs { include("src/**/*.kt") }
             debug = true
@@ -54,7 +65,12 @@ class DiktatJavaExecTaskTest {
         project.file("src/main/kotlin/generated").mkdirs()
         project.file("src/main/kotlin/generated/Generated.kt").createNewFile()
         assertCommandLineEquals(
-            listOf(null, combinePathParts("src", "main", "kotlin", "Test.kt"), "--reporter=plain")
+            listOf(
+                null,
+                DISABLED_RULES,
+                combinePathParts("src", "main", "kotlin", "Test.kt"),
+                "--reporter=plain"
+            )
         ) {
             inputs {
                 include("src/**/*.kt")
@@ -91,7 +107,11 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `check command line has reporter type and output`() {
         assertCommandLineEquals(
-            listOf(null, "--reporter=json,output=${project.projectDir.resolve("some.txt")}")
+            listOf(
+                null,
+                DISABLED_RULES,
+                "--reporter=json,output=${project.projectDir.resolve("some.txt")}"
+            )
         ) {
             inputs { exclude("*") }
             diktatConfigFile = project.file("../diktat-analysis.yml")
@@ -103,7 +123,11 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `check command line has reporter type without output`() {
         assertCommandLineEquals(
-            listOf(null, "--reporter=json")
+            listOf(
+                null,
+                DISABLED_RULES,
+                "--reporter=json"
+            )
         ) {
             inputs { exclude("*") }
             diktatConfigFile = project.file("../diktat-analysis.yml")
@@ -115,7 +139,11 @@ class DiktatJavaExecTaskTest {
     fun `check command line in githubActions mode`() {
         val path = project.file("${project.buildDir}/reports/diktat/diktat.sarif")
         assertCommandLineEquals(
-            listOf(null, "--reporter=sarif,output=$path")
+            listOf(
+                null,
+                DISABLED_RULES,
+                "--reporter=sarif,output=$path"
+            )
         ) {
             inputs { exclude("*") }
             diktatConfigFile = project.file("../diktat-analysis.yml")
@@ -132,7 +160,11 @@ class DiktatJavaExecTaskTest {
     fun `githubActions mode should have higher precedence over explicit reporter`() {
         val path = project.file("${project.buildDir}/reports/diktat/diktat.sarif")
         assertCommandLineEquals(
-            listOf(null, "--reporter=sarif,output=$path")
+            listOf(
+                null,
+                DISABLED_RULES,
+                "--reporter=sarif,output=$path"
+            )
         ) {
             inputs { exclude("*") }
             diktatConfigFile = project.file("../diktat-analysis.yml")
@@ -145,7 +177,11 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `should set system property with SARIF reporter`() {
         assertCommandLineEquals(
-            listOf(null, "--reporter=sarif")
+            listOf(
+                null,
+                DISABLED_RULES,
+                "--reporter=sarif"
+            )
         ) {
             inputs { exclude("*") }
             diktatConfigFile = project.file("../diktat-analysis.yml")
@@ -232,5 +268,6 @@ class DiktatJavaExecTaskTest {
 
     companion object {
         private const val DIKTAT_CHECK_TASK = "diktatCheck"
+        private const val DISABLED_RULES = "--disabled_rules=standard,experimental,test,custom"
     }
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
@@ -98,11 +98,16 @@ import java.io.File
 /**
  * [RuleSetProvider] that provides diKTat ruleset.
  * By default, it is expected to have diktat-analysis.yml configuration in the root folder where 'ktlint' is run
- * otherwise it will use default configuration where some rules are disabled
+ * otherwise it will use default configuration where some rules are disabled.
+ *
+ * The no-argument constructor is used by the Java SPI interface; that's why
+ * it's explicitly annotated with [JvmOverloads].
  *
  * @param diktatConfigFile - configuration file where all configurations for inspections and rules are stored
  */
-class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYSIS_CONF) : RuleSetProvider {
+class DiktatRuleSetProvider
+@JvmOverloads
+constructor(private var diktatConfigFile: String = DIKTAT_ANALYSIS_CONF) : RuleSetProvider {
     private val possibleConfigs: Sequence<String?> = sequence {
         yield(resolveDefaultConfig())
         yield(resolveConfigFileFromJarLocation())

--- a/diktat-ruleset/src/test/resources/test/smoke/save.toml
+++ b/diktat-ruleset/src/test/resources/test/smoke/save.toml
@@ -9,7 +9,7 @@ timeOutMillis = 3600000
 
 ["fix and warn"]
     ["fix and warn".fix]
-        execFlags="--disabled_rules=standard -F"
+        execFlags="--disabled_rules=standard,experimental,test,custom -F"
     ["fix and warn".warn]
         lineCaptureGroup = 1
         columnCaptureGroup = 2

--- a/diktat-ruleset/src/test/resources/test/smoke/src/main/kotlin/save.toml
+++ b/diktat-ruleset/src/test/resources/test/smoke/src/main/kotlin/save.toml
@@ -8,7 +8,7 @@ expectedWarningsPattern = "// ;warn:?(.*):(\\d*): (.+)"
 
 ["fix and warn"]
     ["fix and warn".fix]
-        execFlags="--disabled_rules=standard -F"
+        execFlags="--disabled_rules=standard,experimental,test,custom -F"
     ["fix and warn".warn]
         actualWarningsPattern = "(\\w+\\..+):(\\d+):(\\d+): (\\[.*\\].*)$"
         exactWarningsMatch = false


### PR DESCRIPTION
### What's done:

Additional rule set ids (available since KtLint 0.47) are now ignored, both via the `--disabled_rules` command-line argument, and via class path exclusions (Gradle plug-in).

This change fixes behaviour described in #1559 with KtLint 0.47+.