### PR TITLE
update README.md for JDK 16+ issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ $ ./ktlint -R diktat.jar --disabled_rules=standard "dir/your/dir/**/*.kt"
 To **autofix** all code style violations, use `-F` option.
 
 ## Run with Maven using diktat-maven-plugin
-:heavy_exclamation_mark: If you are using **Java 16+**, you need to add `--add-opens java.base/java.util=ALL-UNNAMED` flag to the JVM. For more information, see: https://github.com/pinterest/ktlint/issues/1195
+:heavy_exclamation_mark: If you are using **Java 16+**, you need to add `--add-opens java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED` flag to the JVM. For more information, see: https://github.com/pinterest/ktlint/issues/1195
 This can be done by setting `MAVEN_OPTS` variable:
 
 ```
-export MAVEN_OPTS="--add-opens java.base/java.util=ALL-UNNAMED"
+export MAVEN_OPTS="--add-opens java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
 ```
 
 This plugin is available since version 0.1.3. You can see how it is configured in our project for self-checks: [pom.xml](pom.xml).


### PR DESCRIPTION
```
…
[ERROR] Internal error has occurred in rule [diktat-ruleset:function-length]. Please make an issue on this bug at https://github.com/saveourtool/diKTat/.
                       As a workaround you can disable these inspections in yml config: <[TOO_LONG_FUNCTION]>.
                       Root cause of the problem is in […] file.
java.lang.ExceptionInInitializerError
…
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private transient java.lang.Object java.lang.Throwable.backtrace accessible: module java.base does not "opens java.lang" to unnamed module @6dd93a21
    at java.lang.reflect.AccessibleObject.checkCanSetAccessible (AccessibleObject.java:354)
    at java.lang.reflect.AccessibleObject.checkCanSetAccessible (AccessibleObject.java:297)
    at java.lang.reflect.Field.checkCanSetAccessible (Field.java:178)
    at java.lang.reflect.Field.setAccessible (Field.java:172)
    at org.jetbrains.kotlin.com.intellij.util.ReflectionUtil.findFieldInHierarchy (ReflectionUtil.java:154)
…
```