### PR TITLE
Fix the build status badge to show status from the `master` branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,7 +2,10 @@
 name: Build and test
 
 on:
-  pull_request
+  pull_request:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   build_and_test_with_code_coverage:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="/logo.svg" width="64px"/>
 
-![Build and test](https://github.com/saveourtool/diKTat/workflows/Build%20and%20test/badge.svg)
+![Build and test](https://github.com/saveourtool/diKTat/workflows/Build%20and%20test/badge.svg?branch=master)
 ![deteKT static analysis](https://github.com/saveourtool/diKTat/workflows/Run%20deteKT/badge.svg)
 ![diKTat code style](https://github.com/saveourtool/diKTat/workflows/Run%20diKTat%20from%20release%20version/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/saveourtool/diKTat/branch/master/graph/badge.svg)](https://codecov.io/gh/saveourtool/diKTat)


### PR DESCRIPTION
### What's done:

 - The build status badge included from `README.md` now is showing status from the `master` branch.
