### PR TITLE
Handling a package directive when nodes are moved

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
@@ -71,7 +71,7 @@ abstract class DiktatRule(
                 // we are very sorry for throwing common Error here, but unfortunately we are not able to throw
                 // any existing Exception, as they will be caught in ktlint framework and the logging will be confusing:
                 // in this case it will incorrectly ask you to report issues in diktat to ktlint repository
-                throw Error("Internal error in diktat application")
+                throw Error("Internal error in diktat application", internalError)
             }
         }
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
@@ -166,7 +166,8 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
         val otherNodesBeforeCode = firstCodeNode.siblings(forward = false)
             .filterNot {
                 it.isWhiteSpace() ||
-                        it == copyrightComment || it == headerKdoc || it == fileAnnotations
+                        it == copyrightComment || it == headerKdoc || it == fileAnnotations ||
+                        it.elementType == PACKAGE_DIRECTIVE
             }
             .toList()
             .reversed()

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -586,8 +586,8 @@ fun ASTNode.moveChildBefore(
     beforeThisNode: ASTNode?,
     withNextNode: Boolean = false
 ): ReplacementResult {
-    require(childToMove in children()) { "can only move child of this node" }
-    require(beforeThisNode == null || beforeThisNode in children()) { "can only place node before another child of this node" }
+    require(childToMove in children()) { "can only move child ($childToMove) of this node $this" }
+    require(beforeThisNode == null || beforeThisNode in children()) { "can only place node before another child ($beforeThisNode) of this node $this" }
     val movedChild = childToMove.clone() as ASTNode
     val nextMovedChild = childToMove.treeNext?.takeIf { withNextNode }?.let { it.clone() as ASTNode }
     val nextOldChild = childToMove.treeNext.takeIf { withNextNode && it != null }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleFixTest.kt
@@ -90,4 +90,10 @@ class FileStructureRuleFixTest : FixTestBase("test/paragraph3/file_structure", :
     fun `should move other comments before package node`() {
         fixAndCompare("OtherCommentsExpected.kt", "OtherCommentsTest.kt")
     }
+
+    @Test
+    @Tag(WarningNames.FILE_INCORRECT_BLOCKS_ORDER)
+    fun `invalid move in kts files`() {
+        fixAndCompare("ScriptPackageDirectiveExpected.kts", "ScriptPackageDirectiveTest.kts")
+    }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
@@ -561,4 +561,22 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
             """.trimMargin(),
         )
     }
+
+
+    @Test
+    @Tag(WarningNames.FILE_INCORRECT_BLOCKS_ORDER)
+    fun `error in moving blocking at the first place`() {
+        lintMethod(
+            """
+                // Without suppressing these, version catalog usage in `plugins` is marked as an error in IntelliJ:
+                // https://youtrack.jetbrains.com/issue/KTIJ-19369
+                @file:Suppress("DSL_SCOPE_VIOLATION")
+                plugins {
+                    id(libs.plugins.kotlinJvm.get().pluginId)
+                }
+            """.trimIndent(),
+            expectedLintErrors = arrayOf(LintError(3, 1, ruleId, "${Warnings.FILE_INCORRECT_BLOCKS_ORDER.warnText()} @file:Suppress(\"DSL_SCOPE_VIOLATION\")", true)),
+            fileName = "build.gradle.kts",
+        )
+    }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
@@ -562,7 +562,6 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
         )
     }
 
-
     @Test
     @Tag(WarningNames.FILE_INCORRECT_BLOCKS_ORDER)
     fun `error in moving blocking at the first place`() {

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
@@ -58,11 +58,13 @@ open class FixTestBase(
         trimLastEmptyLine: Boolean = false,
     ) {
         val testComparatorUnit = testComparatorUnitSupplier(overrideRulesConfigList)
+        val result = testComparatorUnit
+            .compareFilesFromResources(expectedPath, testPath, trimLastEmptyLine)
         Assertions.assertTrue(
-            testComparatorUnit
-                .compareFilesFromResources(expectedPath, testPath, trimLastEmptyLine)
-                .isSuccessful
-        )
+            result.isSuccessful
+        ) {
+            "Detected delta: ${result.delta}"
+        }
     }
 
     /**

--- a/diktat-rules/src/test/resources/test/paragraph3/file_structure/ScriptPackageDirectiveExpected.kts
+++ b/diktat-rules/src/test/resources/test/paragraph3/file_structure/ScriptPackageDirectiveExpected.kts
@@ -1,0 +1,7 @@
+@file:Suppress("DSL_SCOPE_VIOLATION")// Without suppressing these, version catalog usage in `plugins` is marked as an error in IntelliJ:
+// https://youtrack.jetbrains.com/issue/KTIJ-19369
+
+
+plugins {
+    id(libs.plugins.kotlinJvm.get().pluginId)
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/file_structure/ScriptPackageDirectiveTest.kts
+++ b/diktat-rules/src/test/resources/test/paragraph3/file_structure/ScriptPackageDirectiveTest.kts
@@ -1,0 +1,7 @@
+// Without suppressing these, version catalog usage in `plugins` is marked as an error in IntelliJ:
+// https://youtrack.jetbrains.com/issue/KTIJ-19369
+@file:Suppress("DSL_SCOPE_VIOLATION")
+
+plugins {
+    id(libs.plugins.kotlinJvm.get().pluginId)
+}

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
@@ -31,22 +31,6 @@ class FileComparator(
         newTag = { _, start -> if (start) "<" else ">" },
     )
 
-    constructor(
-        expectedResultFile: File,
-        actualResultList: List<String>
-    ) : this(
-        expectedResultFile.toPath(),
-        actualResultFile = Path("No file name.kt"),
-        actualResultList = actualResultList
-    )
-
-    constructor(
-        expectedResultFile: File,
-        actualResultFile: File
-    ) : this(
-        expectedResultFile.toPath(),
-        actualResultFile = actualResultFile.toPath())
-
     /**
      * delta in files
      */
@@ -78,6 +62,22 @@ class FileComparator(
             }
         }
     }
+
+    constructor(
+        expectedResultFile: File,
+        actualResultList: List<String>
+    ) : this(
+        expectedResultFile.toPath(),
+        actualResultFile = Path("No file name.kt"),
+        actualResultList = actualResultList
+    )
+
+    constructor(
+        expectedResultFile: File,
+        actualResultFile: File
+    ) : this(
+        expectedResultFile.toPath(),
+        actualResultFile = actualResultFile.toPath())
 
     /**
      * @return true in case files are different

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparisonResult.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparisonResult.kt
@@ -12,12 +12,14 @@ import org.intellij.lang.annotations.Language
  *   Similarly, if [isSuccessful] is `false`, [actualContent] and
  *   [expectedContent] are not necessarily different (consider the case when
  *   both files are missing).
+ * @property delta a delta between compared files.
  * @property actualContent the actual file content (possibly slightly different
  *   from the original after `diktat:check` is run).
  * @property expectedContent the expected file content.
  */
 data class FileComparisonResult(
     val isSuccessful: Boolean,
+    val delta: String?,
     @Language("kotlin") val actualContent: String,
     @Language("kotlin") val expectedContent: String
 )

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestComparatorUnit.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestComparatorUnit.kt
@@ -48,6 +48,7 @@ class TestComparatorUnit(
             log.error("Not able to find files for running test: $expectedResult and $testFileStr")
             return FileComparisonResult(
                 isSuccessful = false,
+                delta = null,
                 actualContent = "// $resourceFilePath/$expectedResult is found: ${testPath != null}",
                 expectedContent = "// $resourceFilePath/$testFileStr is found: ${expectedPath != null}")
         }
@@ -80,6 +81,7 @@ class TestComparatorUnit(
             log.error("Not able to find files for running test: $expectedFile and $testFile")
             return FileComparisonResult(
                 isSuccessful = false,
+                delta = null,
                 actualContent = "// $testFile is a regular file: ${testFile.isRegularFile()}",
                 expectedContent = "// $expectedFile is a regular file: ${expectedFile.isRegularFile()}")
         }
@@ -101,14 +103,15 @@ class TestComparatorUnit(
 
         val expectedFileContent = readFile(expectedFile)
 
-        val isSuccessful = FileComparator(
+        val comparator = FileComparator(
             expectedFile,
             expectedFileContent,
             testFile,
-            actualFileContent).compareFilesEqual()
+            actualFileContent)
 
         return FileComparisonResult(
-            isSuccessful,
+            comparator.compareFilesEqual(),
+            comparator.delta,
             actualFileContent.joinToString("\n"),
             expectedFileContent.joinToString("\n"))
     }


### PR DESCRIPTION
### What's done:
- excluded `PACKAGE_DIRECTIVE` from `otherNodesBeforeCode`
- added delta to error message of test
- added two tests expired by provided repro repo

It closes #1612

