### PR TITLE
False positive with single expression functions that use multiple return keywords

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -405,8 +405,10 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun handleReturnStatement(node: ASTNode) {
         val blockNode = node.treeParent.takeIf { it.elementType == BLOCK && it.treeParent.elementType == FUN }
         val returnsUnit = node.children().count() == 1  // the only child is RETURN_KEYWORD
-        if (blockNode == null || returnsUnit) {
+        val hasMultipleReturn = node.findAllDescendantsWithSpecificType(RETURN_KEYWORD).count() > 1
+        if (blockNode == null || returnsUnit || hasMultipleReturn) {
             // function is either already with expression body or definitely can't be converted to it
+            // or the function has more than one keyword `return` inside it
             return
         }
         blockNode

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
@@ -599,6 +599,18 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
 
     @Test
     @Tag(WarningNames.WRONG_NEWLINES)
+    fun `shouldn't warn if function consists of a single return statement with a nested return`() {
+        lintMethod(
+            """
+                    |fun foo(): String {
+                    |    return Demo(string ?: return null)
+                    |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.WRONG_NEWLINES)
     @Suppress("TOO_LONG_FUNCTION")
     fun `should not trigger`() {
         lintMethod(


### PR DESCRIPTION
### What's done:
- added check for multiple return keywords

Closes #1588

