### PR TITLE
Limit the maximum Maven Plug-in API version to be at most 3.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,10 @@
         <detekt.version>1.22.0</detekt.version>
         <dokka.version>1.8.10</dokka.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <maven-plugin-tools.version>3.8.1</maven-plugin-tools.version>
+        <!-- Don't upgrade before checking compatibility with `kotlin-maven-plugin-tools`.
+             See also `renovate.json`.
+             See https://github.com/saveourtool/diktat/issues/1632 for details. -->
+        <maven-plugin-tools.version>3.6.4</maven-plugin-tools.version>
         <jbool.version>1.24</jbool.version>
         <!-- downgraded to be compliance with ktlint -->
         <mu-logging.version>2.1.23</mu-logging.version>

--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,20 @@
       "allowedVersions": "<= 0.47.0"
     },
     {
+      "managers": ["maven"],
+      "matchPackageNames": [
+        "org.apache.maven.plugins:maven-plugin-plugin"
+      ],
+      "allowedVersions": "< 3.7.0"
+    },
+    {
+      "managers": ["maven"],
+      "matchPackageNames": [
+        "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      ],
+      "allowedVersions": "< 3.7.0"
+    },
+    {
       "managers": ["gradle"],
       "matchPackagePatterns": [
         "*"


### PR DESCRIPTION
### What's done:

 - Versions 3.7.0+ are incompatible.
 - Fixes #1632.
