### PR TITLE
Added a placeholder for years

### DIFF
--- a/diktat-rules/pom.xml
+++ b/diktat-rules/pom.xml
@@ -138,7 +138,6 @@
                     <mainClass>org.cqfn.diktat.ruleset.generation.GenerationKt</mainClass>
                     <arguments>
                         <argument>${project.build.sourceDirectory}</argument>
-                        <argument>${project.basedir}/src/test/resources</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/generation/Generation.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/generation/Generation.kt
@@ -5,22 +5,13 @@
 package org.cqfn.diktat.ruleset.generation
 
 import org.cqfn.diktat.ruleset.constants.Warnings
-import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule.Companion.afterCopyrightRegex
-import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule.Companion.curYear
-import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule.Companion.hyphenRegex
 
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
-import java.nio.file.Files
 import java.nio.file.Paths
-
-import kotlin.io.path.createTempFile
-import kotlin.io.path.name
-import kotlin.io.path.readLines
-import kotlin.io.path.writeLines
 
 /**
  * The comment that will be added to the generated sources file.
@@ -32,11 +23,10 @@ private val autoGenerationComment =
     """.trimMargin()
 
 fun main(args: Array<String>) {
-    require(args.size == 2) {
-        "Only two arguments are expected: <source root> <test resource root>"
+    require(args.size == 1) {
+        "Expected only one argument: <source root>"
     }
     generateWarningNames(args[0])
-    validateYear(args[1])
 }
 
 private fun generateWarningNames(sourceDirectory: String) {
@@ -63,29 +53,4 @@ private fun generateWarningNames(sourceDirectory: String) {
         .build()
 
     kotlinFile.writeTo(Paths.get(sourceDirectory))
-}
-
-private fun validateYear(testResourcesDirectory: String) {
-    val folder = Paths.get(testResourcesDirectory, "test/paragraph2/header")
-    Files.list(folder)
-        .filter { !it.name.contains("CopyrightDifferentYearTest.kt") }
-        .forEach { file ->
-            val tempFile = createTempFile()
-            tempFile.writeLines(file.readLines()
-                .map { line ->
-                    when {
-                        line.contains(hyphenRegex) -> line.replace(hyphenRegex) {
-                            val years = it.value.split("-")
-                            "${years[0]}-$curYear"
-                        }
-                        line.contains(afterCopyrightRegex) -> line.replace(afterCopyrightRegex) {
-                            val copyrightYears = it.value.split("(c)", "(C)", "©")
-                            "${copyrightYears[0]}-$curYear"
-                        }
-                        else -> line
-                    }
-                })
-            Files.delete(file)
-            Files.move(tempFile, file)
-        }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleFixTest.kt
@@ -20,7 +20,7 @@ class HeaderCommentRuleFixTest : FixTestBase(
         RulesConfig("HEADER_MISSING_OR_WRONG_COPYRIGHT", true,
             mapOf(
                 "isCopyrightMandatory" to "true",
-                "copyrightText" to "Copyright (c) Huawei Technologies Co., Ltd. 2020-${LocalDate.now().year}. All rights reserved.")
+                "copyrightText" to "Copyright (c) Huawei Technologies Co., Ltd. 2020-$currentYear. All rights reserved.")
         ),
         RulesConfig("HEADER_WRONG_FORMAT", true, emptyMap())
     )
@@ -28,25 +28,31 @@ class HeaderCommentRuleFixTest : FixTestBase(
     @Test
     @Tag(WarningNames.HEADER_WRONG_FORMAT)
     fun `new line should be inserted after header KDoc`() {
-        fixAndCompare("NewlineAfterHeaderKdocExpected.kt", "NewlineAfterHeaderKdocTest.kt")
+        fixAndCompare("NewlineAfterHeaderKdocExpected.kt", "NewlineAfterHeaderKdocTest.kt", replacements = currentYearReplacement)
     }
 
     @Test
     @Tag(WarningNames.HEADER_MISSING_OR_WRONG_COPYRIGHT)
     fun `if no copyright is present and mandatoryCopyright=true, it is added`() {
-        fixAndCompare("AutoCopyrightExpected.kt", "AutoCopyrightTest.kt")
+        fixAndCompare("AutoCopyrightExpected.kt", "AutoCopyrightTest.kt", replacements = currentYearReplacement)
     }
 
     @Test
     @Tag(WarningNames.HEADER_MISSING_OR_WRONG_COPYRIGHT)
     fun `if no copyright is present, added it and apply pattern for current year`() {
         fixAndCompare("AutoCopyrightApplyPatternExpected.kt", "AutoCopyrightApplyPatternTest.kt",
-            listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true,
-                mapOf(
-                    "isCopyrightMandatory" to "true",
-                    "copyrightText" to "Copyright (c) Huawei Technologies Co., Ltd. 2020-;@currYear;. All rights reserved.")
+            listOf(
+                RulesConfig(
+                    HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true,
+                    mapOf(
+                        "isCopyrightMandatory" to "true",
+                        "copyrightText" to "Copyright (c) Huawei Technologies Co., Ltd. 2020-;@currYear;. All rights reserved."
+                    )
+                ),
+                RulesConfig(HEADER_WRONG_FORMAT.name, true, emptyMap())
             ),
-                RulesConfig(HEADER_WRONG_FORMAT.name, true, emptyMap())))
+            replacements = currentYearReplacement
+        )
     }
 
     /**
@@ -55,21 +61,22 @@ class HeaderCommentRuleFixTest : FixTestBase(
     @Test
     @Tag(WarningNames.HEADER_NOT_BEFORE_PACKAGE)
     fun `header KDoc should be moved before package`() {
-        fixAndCompare("MisplacedHeaderKdocExpected.kt", "MisplacedHeaderKdocTest.kt")
+        fixAndCompare("MisplacedHeaderKdocExpected.kt", "MisplacedHeaderKdocTest.kt", replacements = currentYearReplacement)
     }
 
     @Test
     @Tags(Tag(WarningNames.HEADER_MISSING_OR_WRONG_COPYRIGHT), Tag(WarningNames.HEADER_WRONG_FORMAT))
     fun `header KDoc should be moved before package - no copyright`() {
         fixAndCompare("MisplacedHeaderKdocNoCopyrightExpected.kt", "MisplacedHeaderKdocNoCopyrightTest.kt",
-            listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, false, emptyMap()), RulesConfig(HEADER_WRONG_FORMAT.name, true, emptyMap()))
+            listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, false, emptyMap()), RulesConfig(HEADER_WRONG_FORMAT.name, true, emptyMap())),
+            replacements = currentYearReplacement,
         )
     }
 
     @Test
     @Tags(Tag(WarningNames.HEADER_NOT_BEFORE_PACKAGE), Tag(WarningNames.HEADER_MISSING_OR_WRONG_COPYRIGHT))
     fun `header KDoc should be moved before package - appended copyright`() {
-        fixAndCompare("MisplacedHeaderKdocAppendedCopyrightExpected.kt", "MisplacedHeaderKdocAppendedCopyrightTest.kt")
+        fixAndCompare("MisplacedHeaderKdocAppendedCopyrightExpected.kt", "MisplacedHeaderKdocAppendedCopyrightTest.kt", replacements = currentYearReplacement)
     }
 
     @Test
@@ -79,7 +86,8 @@ class HeaderCommentRuleFixTest : FixTestBase(
             listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true, mapOf(
                 "isCopyrightMandatory" to "true",
                 "copyrightText" to "Copyright (c) My Company., Ltd. 2012-2019. All rights reserved."
-            )))
+            ))),
+            replacements = currentYearReplacement,
         )
     }
 
@@ -90,7 +98,8 @@ class HeaderCommentRuleFixTest : FixTestBase(
             listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true, mapOf(
                 "isCopyrightMandatory" to "true",
                 "copyrightText" to "Copyright (c) My Company., Ltd. 2021. All rights reserved."
-            )))
+            ))),
+            replacements = currentYearReplacement,
         )
     }
 
@@ -101,7 +110,8 @@ class HeaderCommentRuleFixTest : FixTestBase(
             listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true, mapOf(
                 "isCopyrightMandatory" to "true",
                 "copyrightText" to "Copyright (c) My Company., Ltd. 2012-2019. All rights reserved."
-            )))
+            ))),
+            replacements = currentYearReplacement,
         )
     }
 
@@ -112,7 +122,8 @@ class HeaderCommentRuleFixTest : FixTestBase(
             listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true, mapOf(
                 "isCopyrightMandatory" to "true",
                 "copyrightText" to "Copyright (c) My Company., Ltd. 2012-2019. All rights reserved."
-            )))
+            ))),
+            replacements = currentYearReplacement,
         )
     }
 
@@ -123,7 +134,8 @@ class HeaderCommentRuleFixTest : FixTestBase(
             listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true, mapOf(
                 "isCopyrightMandatory" to "true",
                 "copyrightText" to "Copyright (c) My Company., Ltd. 2012-2021. All rights reserved."
-            )))
+            ))),
+            replacements = currentYearReplacement,
         )
     }
 
@@ -134,7 +146,7 @@ class HeaderCommentRuleFixTest : FixTestBase(
             listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true, mapOf(
                 "isCopyrightMandatory" to "true",
                 "copyrightText" to """
-                |    Copyright 2018-${LocalDate.now().year} John Doe.
+                |    Copyright 2018-$currentYear John Doe.
                 |
                 |    Licensed under the Apache License, Version 2.0 (the "License");
                 |    you may not use this file except in compliance with the License.
@@ -148,7 +160,8 @@ class HeaderCommentRuleFixTest : FixTestBase(
                 |    See the License for the specific language governing permissions and
                 |    limitations under the License.
                 """.trimMargin()
-            )))
+            ))),
+            replacements = currentYearReplacement,
         )
     }
 
@@ -165,7 +178,14 @@ class HeaderCommentRuleFixTest : FixTestBase(
                     |   you may not use this file except in compliance with the License.
                     |   You may obtain a copy of the License at
             """.trimMargin()
-            )))
+            ))),
+            replacements = currentYearReplacement,
         )
+    }
+
+    companion object {
+        private const val PLACEHOLDER = "%%YEAR%%"
+        private val currentYear = LocalDate.now().year.toString()
+        private val currentYearReplacement = mapOf(PLACEHOLDER to currentYear)
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleFixTest.kt
@@ -51,7 +51,7 @@ class HeaderCommentRuleFixTest : FixTestBase(
                 ),
                 RulesConfig(HEADER_WRONG_FORMAT.name, true, emptyMap())
             ),
-            replacements = currentYearReplacement
+            replacements = currentYearReplacement,
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/FixTestBase.kt
@@ -49,6 +49,7 @@ open class FixTestBase(
      * @param overrideRulesConfigList optional override to [defaultRulesConfigList]
      * @param trimLastEmptyLine whether the last (empty) line should be
      *   discarded when reading the content of [testPath].
+     * @param replacements a map of replacements which will be applied to [expectedPath] and [testPath] before comparing.
      * @see fixAndCompareContent
      */
     protected fun fixAndCompare(
@@ -56,10 +57,11 @@ open class FixTestBase(
         testPath: String,
         overrideRulesConfigList: List<RulesConfig>? = null,
         trimLastEmptyLine: Boolean = false,
+        replacements: Map<String, String> = emptyMap(),
     ) {
         val testComparatorUnit = testComparatorUnitSupplier(overrideRulesConfigList)
         val result = testComparatorUnit
-            .compareFilesFromResources(expectedPath, testPath, trimLastEmptyLine)
+            .compareFilesFromResources(expectedPath, testPath, trimLastEmptyLine, replacements)
         Assertions.assertTrue(
             result.isSuccessful
         ) {

--- a/diktat-rules/src/test/resources/test/paragraph2/header/AutoCopyrightApplyPatternExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/AutoCopyrightApplyPatternExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2023. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-%%YEAR%%. All rights reserved.
 */
 
 package test.paragraph2.header

--- a/diktat-rules/src/test/resources/test/paragraph2/header/AutoCopyrightExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/AutoCopyrightExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2023. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-%%YEAR%%. All rights reserved.
 */
 
 package test.paragraph2.header

--- a/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightAbsentInvalidPatternExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightAbsentInvalidPatternExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) My Company., Ltd. 2012-2023. All rights reserved.
+    Copyright (c) My Company., Ltd. 2012-%%YEAR%%. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightDifferentYearExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightDifferentYearExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) My Company., Ltd. 2012-2023. All rights reserved.
+    Copyright (c) My Company., Ltd. 2012-%%YEAR%%. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightInvalidPatternValidCodeExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightInvalidPatternValidCodeExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) My Company., Ltd. 2021-2023. All rights reserved.
+    Copyright (c) My Company., Ltd. 2021-%%YEAR%%. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightInvalidPatternValidCodeTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightInvalidPatternValidCodeTest.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) My Company., Ltd. 2021-2023. All rights reserved.
+    Copyright (c) My Company., Ltd. 2021-%%YEAR%%. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightShouldNotTriggerNPEExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightShouldNotTriggerNPEExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) My Company., Ltd. 2012-2023. All rights reserved.
+    Copyright (c) My Company., Ltd. 2012-%%YEAR%%. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocAppendedCopyrightExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocAppendedCopyrightExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2023. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-%%YEAR%%. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2023. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-%%YEAR%%. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocTest.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2023. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-%%YEAR%%. All rights reserved.
 */
 
 package test.paragraph2.header

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightExample.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightExample.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018-2023 John Doe.
+    Copyright 2018-%%YEAR%% John Doe.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightNotTriggerExample.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightNotTriggerExample.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018-2023 John Doe.
+    Copyright 2018-%%YEAR%% John Doe.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightNotTriggerTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightNotTriggerTest.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018-2023 John Doe.
+    Copyright 2018-%%YEAR%% John Doe.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/diktat-rules/src/test/resources/test/paragraph2/header/NewlineAfterHeaderKdocExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/NewlineAfterHeaderKdocExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2023. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-%%YEAR%%. All rights reserved.
 */
 /**
  * This is a file used in unit test

--- a/diktat-rules/src/test/resources/test/paragraph2/header/NewlineAfterHeaderKdocTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/NewlineAfterHeaderKdocTest.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2023. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-%%YEAR%%. All rights reserved.
 */
 /**
  * This is a file used in unit test

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
@@ -9,18 +9,16 @@ import mu.KotlinLogging
 import java.io.File
 import java.io.IOException
 import java.nio.file.Path
-import kotlin.io.path.Path
-import kotlin.io.path.name
 import kotlin.io.path.readLines
 
 /**
  * A class that is capable of comparing files content
  */
 class FileComparator(
-    private val expectedResultFile: Path,
-    private val expectedResultList: List<String> = readFile(expectedResultFile),
-    private val actualResultFile: Path,
-    private val actualResultList: List<String> = readFile(actualResultFile)
+    private val expectedResultFileName: String,
+    private val expectedResultList: List<String>,
+    private val actualResultFileName: String,
+    private val actualResultList: List<String>,
 ) {
     private val diffGenerator = DiffRowGenerator(
         columnWidth = Int.MAX_VALUE,
@@ -67,17 +65,21 @@ class FileComparator(
         expectedResultFile: File,
         actualResultList: List<String>
     ) : this(
-        expectedResultFile.toPath(),
-        actualResultFile = Path("No file name.kt"),
-        actualResultList = actualResultList
+        expectedResultFileName = expectedResultFile.name,
+        expectedResultList = readFile(expectedResultFile.toPath()),
+        actualResultFileName = "No file name.kt",
+        actualResultList = actualResultList,
     )
 
     constructor(
         expectedResultFile: File,
         actualResultFile: File
     ) : this(
-        expectedResultFile.toPath(),
-        actualResultFile = actualResultFile.toPath())
+        expectedResultFileName = expectedResultFile.name,
+        expectedResultList = readFile(expectedResultFile.toPath()),
+        actualResultFileName = actualResultFile.name,
+        actualResultList = readFile(actualResultFile.toPath()),
+    )
 
     /**
      * @return true in case files are different
@@ -95,14 +97,14 @@ class FileComparator(
             }
             val joinedDeltas = delta ?: return true
             log.error("""
-                |Expected result from <${expectedResultFile.name}> and <${actualResultFile.name}> formatted are different.
+                |Expected result from <$expectedResultFileName> and <$actualResultFileName> formatted are different.
                 |See difference below:
                 |$joinedDeltas
                 """.trimMargin()
             )
             return false
         } catch (e: IllegalArgumentException) {
-            log.error("Not able to prepare diffs between <${expectedResultFile.name}> and <${actualResultFile.name}>", e)
+            log.error("Not able to prepare diffs between <$expectedResultFileName> and <$actualResultFileName>", e)
             return false
         }
     }

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestComparatorUnit.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/TestComparatorUnit.kt
@@ -9,6 +9,7 @@ import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.copyTo
 import kotlin.io.path.isRegularFile
+import kotlin.io.path.name
 import kotlin.io.path.readLines
 
 /**
@@ -33,6 +34,7 @@ class TestComparatorUnit(
      * @param testFileStr the name of the resource which has the original content.
      * @param trimLastEmptyLine whether the last (empty) line should be
      *   discarded when reading the content of [testFileStr].
+     * @param replacements a map of replacements which will be applied to [expectedResult] and [testFileStr] before comparing.
      * @return the result of file comparison by their content.
      * @see compareFilesFromFileSystem
      */
@@ -40,7 +42,8 @@ class TestComparatorUnit(
     fun compareFilesFromResources(
         expectedResult: String,
         testFileStr: String,
-        trimLastEmptyLine: Boolean = false
+        trimLastEmptyLine: Boolean = false,
+        replacements: Map<String, String> = emptyMap(),
     ): FileComparisonResult {
         val expectedPath = javaClass.classLoader.getResource("$resourceFilePath/$expectedResult")
         val testPath = javaClass.classLoader.getResource("$resourceFilePath/$testFileStr")
@@ -56,7 +59,9 @@ class TestComparatorUnit(
         return compareFilesFromFileSystem(
             Paths.get(expectedPath.toURI()),
             Paths.get(testPath.toURI()),
-            trimLastEmptyLine)
+            trimLastEmptyLine,
+            replacements,
+        )
     }
 
     /**
@@ -68,6 +73,7 @@ class TestComparatorUnit(
      * @param testFile the file which has the original content.
      * @param trimLastEmptyLine whether the last (empty) line should be
      *   discarded when reading the content of [testFile].
+     * @param replacements a map of replacements which will be applied to [expectedFile] and [testFile] before comparing.
      * @return the result of file comparison by their content.
      * @see compareFilesFromResources
      */
@@ -75,7 +81,8 @@ class TestComparatorUnit(
     fun compareFilesFromFileSystem(
         expectedFile: Path,
         testFile: Path,
-        trimLastEmptyLine: Boolean = false
+        trimLastEmptyLine: Boolean = false,
+        replacements: Map<String, String> = emptyMap(),
     ): FileComparisonResult {
         if (!testFile.isRegularFile() || !expectedFile.isRegularFile()) {
             log.error("Not able to find files for running test: $expectedFile and $testFile")
@@ -90,7 +97,7 @@ class TestComparatorUnit(
         testFile.copyTo(copyTestFile, overwrite = true)
 
         val actualResult = function(
-            readFile(copyTestFile).joinToString("\n"),
+            readFile(copyTestFile).replaceAll(replacements).joinToString("\n"),
             copyTestFile.absolutePathString()
         )
 
@@ -101,13 +108,14 @@ class TestComparatorUnit(
             actualResult.split("\n")
         }
 
-        val expectedFileContent = readFile(expectedFile)
+        val expectedFileContent = readFile(expectedFile).replaceAll(replacements)
 
         val comparator = FileComparator(
-            expectedFile,
+            expectedFile.name,
             expectedFileContent,
-            testFile,
-            actualFileContent)
+            testFile.name,
+            actualFileContent,
+        )
 
         return FileComparisonResult(
             comparator.compareFilesEqual(),
@@ -132,5 +140,12 @@ class TestComparatorUnit(
                 log.error("Not able to read file: $file")
                 emptyList()
             }
+
+        private fun List<String>.replaceAll(replacements: Map<String, String>): List<String> = map { line ->
+            replacements.entries
+                .fold(line) { result, replacement ->
+                    result.replace(replacement.key, replacement.value)
+                }
+        }
     }
 }


### PR DESCRIPTION
### What's done:
- supported replacements in comparing two files in tests
- replace current year with placeholder %%YEAR%%
- removed from Generation updating year

It can be useful for #1625
