### PR TITLE
Inlined typealias for legacy LintError

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,6 +75,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   run_diktat_from_CLI:
     name: Run diktat via CLI
@@ -302,6 +303,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   report:
     name: Publish JUnit test results

--- a/diktat-rules/src/test/kotlin/com/pinterest/ktlint/core/KtLintTestUtils.kt
+++ b/diktat-rules/src/test/kotlin/com/pinterest/ktlint/core/KtLintTestUtils.kt
@@ -1,7 +1,0 @@
-/**
- * This class contains util methods for KtLint
- */
-
-package com.pinterest.ktlint.core
-
-typealias LintError = org.cqfn.diktat.api.DiktatError

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -18,7 +18,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.VARIABLE_NAME_INCORRECT_FORMAT
 import org.cqfn.diktat.ruleset.rules.chapter1.IdentifierNaming
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Tags
@@ -82,7 +82,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 class TreeNode<a>(val value: T?, val next: TreeNode<T>? = null)
 
             """.trimIndent()
-        lintMethod(code, LintError(
+        lintMethod(code, DiktatError(
             3, 15, ruleId, "${GENERIC_NAME.warnText()} <a>", true)
         )
     }
@@ -97,7 +97,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 class TreeNode<TBBB>(val value: T?, val next: TreeNode<T>? = null)
 
             """.trimIndent()
-        lintMethod(code, LintError(
+        lintMethod(code, DiktatError(
             3, 15, ruleId, "${GENERIC_NAME.warnText()} <TBBB>", true)
         )
     }
@@ -130,8 +130,8 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 class IncorrectNAME {}
             """
         lintMethod(code,
-            LintError(2, 23, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrectNAME", true),
-            LintError(3, 23, ruleId, "${CLASS_NAME_INCORRECT.warnText()} IncorrectNAME", true)
+            DiktatError(2, 23, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrectNAME", true),
+            DiktatError(3, 23, ruleId, "${CLASS_NAME_INCORRECT.warnText()} IncorrectNAME", true)
         )
     }
 
@@ -171,16 +171,16 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
             """.trimIndent()
 
         lintMethod(code,
-            LintError(1, 5, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SOMEtest", true),
-            LintError(2, 11, ruleId, "${CONSTANT_UPPERCASE.warnText()} thisConstantShouldBeUpper", true),
-            LintError(3, 7, ruleId, "${CLASS_NAME_INCORRECT.warnText()} className", true),
-            LintError(4, 16, ruleId, "${CLASS_NAME_INCORRECT.warnText()} badClassName", true),
-            LintError(4, 33, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} FIRST", true),
-            LintError(4, 52, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SECOND", true),
-            LintError(7, 19, ruleId, "${CONSTANT_UPPERCASE.warnText()} incorrect_case", true),
-            LintError(9, 13, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} INCORRECT", true),
-            LintError(12, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} check_me", true),
-            LintError(13, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} CHECK_ME", true)
+            DiktatError(1, 5, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SOMEtest", true),
+            DiktatError(2, 11, ruleId, "${CONSTANT_UPPERCASE.warnText()} thisConstantShouldBeUpper", true),
+            DiktatError(3, 7, ruleId, "${CLASS_NAME_INCORRECT.warnText()} className", true),
+            DiktatError(4, 16, ruleId, "${CLASS_NAME_INCORRECT.warnText()} badClassName", true),
+            DiktatError(4, 33, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} FIRST", true),
+            DiktatError(4, 52, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SECOND", true),
+            DiktatError(7, 19, ruleId, "${CONSTANT_UPPERCASE.warnText()} incorrect_case", true),
+            DiktatError(9, 13, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} INCORRECT", true),
+            DiktatError(12, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} check_me", true),
+            DiktatError(13, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} CHECK_ME", true)
         )
     }
 
@@ -197,10 +197,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 5, ruleId, "${IDENTIFIER_LENGTH.warnText()} r"),
-            LintError(2, 5, ruleId, "${VARIABLE_NAME_INCORRECT.warnText()} x256"),
-            LintError(4, 7, ruleId, "${IDENTIFIER_LENGTH.warnText()} LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName"),
-            LintError(5, 9, ruleId, "${IDENTIFIER_LENGTH.warnText()} veryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongName")
+            DiktatError(1, 5, ruleId, "${IDENTIFIER_LENGTH.warnText()} r"),
+            DiktatError(2, 5, ruleId, "${VARIABLE_NAME_INCORRECT.warnText()} x256"),
+            DiktatError(4, 7, ruleId, "${IDENTIFIER_LENGTH.warnText()} LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName"),
+            DiktatError(5, 9, ruleId, "${IDENTIFIER_LENGTH.warnText()} veryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongveryLongName")
         )
     }
 
@@ -212,8 +212,8 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 data class ClassName(val FIRST: String, var SECOND: String)
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 26, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} FIRST", true),
-            LintError(1, 45, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SECOND", true)
+            DiktatError(1, 26, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} FIRST", true),
+            DiktatError(1, 45, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SECOND", true)
         )
     }
 
@@ -226,7 +226,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SOMENAME", true)
+            DiktatError(1, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} SOMENAME", true)
         )
     }
 
@@ -240,11 +240,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
-            LintError(2, 5, ruleId, "${ENUM_VALUE.warnText()} first_value (should be in UPPER_SNAKE_CASE)", true),
-            LintError(2, 18, ruleId, "${ENUM_VALUE.warnText()} secondValue (should be in UPPER_SNAKE_CASE)", true),
-            LintError(2, 31, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE (should be in UPPER_SNAKE_CASE)", true),
-            LintError(2, 43, ruleId, "${ENUM_VALUE.warnText()} FourthValue (should be in UPPER_SNAKE_CASE)", true)
+            DiktatError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
+            DiktatError(2, 5, ruleId, "${ENUM_VALUE.warnText()} first_value (should be in UPPER_SNAKE_CASE)", true),
+            DiktatError(2, 18, ruleId, "${ENUM_VALUE.warnText()} secondValue (should be in UPPER_SNAKE_CASE)", true),
+            DiktatError(2, 31, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE (should be in UPPER_SNAKE_CASE)", true),
+            DiktatError(2, 43, ruleId, "${ENUM_VALUE.warnText()} FourthValue (should be in UPPER_SNAKE_CASE)", true)
         )
     }
 
@@ -262,11 +262,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
-            LintError(2, 5, ruleId, "${ENUM_VALUE.warnText()} first_value (should be in PascalCase)", true),
-            LintError(2, 18, ruleId, "${ENUM_VALUE.warnText()} secondValue (should be in PascalCase)", true),
-            LintError(2, 31, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE (should be in PascalCase)", true),
-            LintError(2, 43, ruleId, "${ENUM_VALUE.warnText()} FOURTH_VALUE (should be in PascalCase)", true),
+            DiktatError(1, 12, ruleId, "${CLASS_NAME_INCORRECT.warnText()} TEST_ONE", true),
+            DiktatError(2, 5, ruleId, "${ENUM_VALUE.warnText()} first_value (should be in PascalCase)", true),
+            DiktatError(2, 18, ruleId, "${ENUM_VALUE.warnText()} secondValue (should be in PascalCase)", true),
+            DiktatError(2, 31, ruleId, "${ENUM_VALUE.warnText()} thirdVALUE (should be in PascalCase)", true),
+            DiktatError(2, 43, ruleId, "${ENUM_VALUE.warnText()} FOURTH_VALUE (should be in PascalCase)", true),
             rulesConfigList = rulesConfigPascalCaseEnum
         )
     }
@@ -280,7 +280,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 8, ruleId, "${OBJECT_NAME_INCORRECT.warnText()} TEST_ONE", true)
+            DiktatError(1, 8, ruleId, "${OBJECT_NAME_INCORRECT.warnText()} TEST_ONE", true)
         )
     }
 
@@ -293,7 +293,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 class incorrect_case_Exception(message: String) : Exception(message)
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 7, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrect_case_Exception", true)
+            DiktatError(1, 7, ruleId, "${CLASS_NAME_INCORRECT.warnText()} incorrect_case_Exception", true)
         )
     }
 
@@ -305,7 +305,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 class Custom(message: String) : Exception(message)
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 7, ruleId, "${EXCEPTION_SUFFIX.warnText()} Custom", true)
+            DiktatError(1, 7, ruleId, "${EXCEPTION_SUFFIX.warnText()} Custom", true)
         )
     }
 
@@ -319,7 +319,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 7, ruleId, "${EXCEPTION_SUFFIX.warnText()} Custom", true)
+            DiktatError(1, 7, ruleId, "${EXCEPTION_SUFFIX.warnText()} Custom", true)
         )
     }
 
@@ -332,8 +332,8 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 val aPrefix = ""
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 11, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} M_GLOB", true),
-            LintError(2, 5, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} aPrefix", true)
+            DiktatError(1, 11, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} M_GLOB", true),
+            DiktatError(2, 5, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} aPrefix", true)
         )
     }
 
@@ -346,9 +346,9 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 const val I_AM_CONSTANT2  = ""
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 5, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} I_AM_CONSTANT1", true),
-            LintError(1, 5, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} I_AM_CONSTANT1", true),
-            LintError(2, 11, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} I_AM_CONSTANT2", true)
+            DiktatError(1, 5, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} I_AM_CONSTANT1", true),
+            DiktatError(1, 5, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} I_AM_CONSTANT1", true),
+            DiktatError(2, 11, ruleId, "${VARIABLE_HAS_PREFIX.warnText()} I_AM_CONSTANT2", true)
         )
     }
 
@@ -367,7 +367,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(5, 13, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} STRANGECASE", true)
+            DiktatError(5, 13, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} STRANGECASE", true)
         )
     }
 
@@ -384,7 +384,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(3, 35, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} STRANGECASE", true)
+            DiktatError(3, 35, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} STRANGECASE", true)
         )
     }
 
@@ -413,10 +413,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     fun ASTNode.empty(): Boolean { }
                     fun empty(): Boolean { }
             """.trimIndent(),
-            LintError(1, 13, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} emptyLineAfter", true),
-            LintError(2, 5, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} emptyLineAfter", true),
-            LintError(3, 13, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} empty", true),
-            LintError(4, 5, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} empty", true)
+            DiktatError(1, 13, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} emptyLineAfter", true),
+            DiktatError(2, 5, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} emptyLineAfter", true),
+            DiktatError(3, 13, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} empty", true),
+            DiktatError(4, 5, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} empty", true)
         )
     }
 
@@ -462,7 +462,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
             """
                     fun foo(predicate: (a: Int) -> Boolean) = Unit
             """.trimIndent(),
-            LintError(1, 21, ruleId, "${IDENTIFIER_LENGTH.warnText()} a", false)
+            DiktatError(1, 21, ruleId, "${IDENTIFIER_LENGTH.warnText()} a", false)
         )
     }
 
@@ -505,7 +505,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(4, 17, ruleId, "${IDENTIFIER_LENGTH.warnText()} e", false))
+        lintMethod(code, DiktatError(4, 17, ruleId, "${IDENTIFIER_LENGTH.warnText()} e", false))
     }
 
     @Test
@@ -532,9 +532,9 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 5, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `foo function`"),
-            LintError(1, 20, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `argument with backstick`"),
-            LintError(2, 9, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `foo variable`")
+            DiktatError(1, 5, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `foo function`"),
+            DiktatError(1, 20, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `argument with backstick`"),
+            DiktatError(2, 9, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `foo variable`")
         )
     }
 
@@ -561,7 +561,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
 
                 }
             """.trimIndent()
-        lintMethod(code, LintError(3, 9, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `should not be used`"))
+        lintMethod(code, DiktatError(3, 9, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `should not be used`"))
     }
 
     @Test
@@ -571,7 +571,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
             """
                 class `my class name` {}
             """.trimIndent()
-        lintMethod(code, LintError(1, 7, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `my class name`"))
+        lintMethod(code, DiktatError(1, 7, ruleId, "${BACKTICKS_PROHIBITED.warnText()} `my class name`"))
     }
 
     @Test
@@ -630,14 +630,14 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(2, 9, ruleId, "${CONFUSING_IDENTIFIER_NAMING.warnText()} better name is: obj, dgt", false),
-            LintError(2, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} D", true),
-            LintError(2, 9, ruleId, "${IDENTIFIER_LENGTH.warnText()} D", false),
-            LintError(3, 9, ruleId, "${CONFUSING_IDENTIFIER_NAMING.warnText()} better name is: n1, n2", false),
-            LintError(3, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} Z", true),
-            LintError(3, 9, ruleId, "${IDENTIFIER_LENGTH.warnText()} Z", false),
-            LintError(7, 5, ruleId, "${CONFUSING_IDENTIFIER_NAMING.warnText()} better name is: bt, nxt", false),
-            LintError(7, 5, ruleId, "${IDENTIFIER_LENGTH.warnText()} B", false))
+            DiktatError(2, 9, ruleId, "${CONFUSING_IDENTIFIER_NAMING.warnText()} better name is: obj, dgt", false),
+            DiktatError(2, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} D", true),
+            DiktatError(2, 9, ruleId, "${IDENTIFIER_LENGTH.warnText()} D", false),
+            DiktatError(3, 9, ruleId, "${CONFUSING_IDENTIFIER_NAMING.warnText()} better name is: n1, n2", false),
+            DiktatError(3, 9, ruleId, "${VARIABLE_NAME_INCORRECT_FORMAT.warnText()} Z", true),
+            DiktatError(3, 9, ruleId, "${IDENTIFIER_LENGTH.warnText()} Z", false),
+            DiktatError(7, 5, ruleId, "${CONFUSING_IDENTIFIER_NAMING.warnText()} better name is: bt, nxt", false),
+            DiktatError(7, 5, ruleId, "${IDENTIFIER_LENGTH.warnText()} B", false))
     }
 
     @Test
@@ -656,10 +656,10 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 interface Test6<Tr: String>
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 15, ruleId, "${GENERIC_NAME.warnText()} <String>", true),
-            LintError(7, 16, ruleId, "${GENERIC_NAME.warnText()} <in T, A, Br>", true),
-            LintError(8, 16, ruleId, "${GENERIC_NAME.warnText()} <in Tr>", true),
-            LintError(9, 16, ruleId, "${GENERIC_NAME.warnText()} <Tr: String>", true),
+            DiktatError(1, 15, ruleId, "${GENERIC_NAME.warnText()} <String>", true),
+            DiktatError(7, 16, ruleId, "${GENERIC_NAME.warnText()} <in T, A, Br>", true),
+            DiktatError(8, 16, ruleId, "${GENERIC_NAME.warnText()} <in Tr>", true),
+            DiktatError(9, 16, ruleId, "${GENERIC_NAME.warnText()} <Tr: String>", true),
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/MethodNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/MethodNamingWarnTest.kt
@@ -7,7 +7,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TYPEALIAS_NAME_INCORRECT_CASE
 import org.cqfn.diktat.ruleset.rules.chapter1.IdentifierNaming
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 15, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
+        lintMethod(code, DiktatError(2, 15, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
     @Test
@@ -40,7 +40,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} method_two", true))
+        lintMethod(code, DiktatError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} method_two", true))
     }
 
     @Test
@@ -55,8 +55,8 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(1, 12, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true),
-            LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} TEST", true)
+            DiktatError(1, 12, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true),
+            DiktatError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} TEST", true)
         )
     }
 
@@ -70,7 +70,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
+        lintMethod(code, DiktatError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
     @Test
@@ -83,7 +83,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     }
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
+        lintMethod(code, DiktatError(2, 9, ruleId, "${FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 
     @Test
@@ -95,7 +95,7 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     typealias relatedClasses = List<Pair<String, String>>
                 }
             """.trimIndent()
-        lintMethod(code, LintError(2, 15, ruleId, "${TYPEALIAS_NAME_INCORRECT_CASE.warnText()} relatedClasses", true))
+        lintMethod(code, DiktatError(2, 15, ruleId, "${TYPEALIAS_NAME_INCORRECT_CASE.warnText()} relatedClasses", true))
     }
 
     @Test
@@ -119,6 +119,6 @@ class MethodNamingWarnTest : LintTestBase(::IdentifierNaming) {
                     return false
                 }
             """.trimIndent()
-        lintMethod(code, LintError(1, 5, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} someBooleanCheck", true))
+        lintMethod(code, DiktatError(1, 5, ruleId, "${FUNCTION_BOOLEAN_PREFIX.warnText()} someBooleanCheck", true))
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
@@ -12,7 +12,7 @@ import org.cqfn.diktat.ruleset.rules.chapter1.PackageNaming
 import org.cqfn.diktat.util.LintTestBase
 import org.cqfn.diktat.util.TEST_FILE_NAME
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -50,7 +50,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             """.trimIndent(),
             tempDir = tempDir,
             fileName = TEST_FILE_NAME,
-            LintError(1, 1, ruleId, "${PACKAGE_NAME_MISSING.warnText()} $TEST_FILE_NAME", true),
+            DiktatError(1, 1, ruleId, "${PACKAGE_NAME_MISSING.warnText()} $TEST_FILE_NAME", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -72,7 +72,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             """.trimIndent(),
             tempDir = tempDir,
             fileName = TEST_FILE_NAME,
-            LintError(1, 37, ruleId, "${PACKAGE_NAME_MISSING.warnText()} $TEST_FILE_NAME", true),
+            DiktatError(1, 37, ruleId, "${PACKAGE_NAME_MISSING.warnText()} $TEST_FILE_NAME", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -111,7 +111,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
                 class TestPackageName {  }
 
             """.trimIndent(),
-            LintError(1, 35, ruleId, "${PACKAGE_NAME_INCORRECT_CASE.warnText()} SPECIALTEST", true),
+            DiktatError(1, 35, ruleId, "${PACKAGE_NAME_INCORRECT_CASE.warnText()} SPECIALTEST", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -132,7 +132,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
                 class TestPackageName {  }
 
             """.trimIndent(),
-            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PREFIX.warnText()} org.cqfn.diktat", true),
+            DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PREFIX.warnText()} org.cqfn.diktat", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -153,7 +153,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
                 class TestPackageName {  }
 
             """.trimIndent(),
-            LintError(1, 32, ruleId, "${INCORRECT_PACKAGE_SEPARATOR.warnText()} test_", true),
+            DiktatError(1, 32, ruleId, "${INCORRECT_PACKAGE_SEPARATOR.warnText()} test_", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -174,7 +174,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
                 class TestPackageName {  }
 
             """.trimIndent(),
-            LintError(1, 32, ruleId, "${PACKAGE_NAME_INCORRECT_SYMBOLS.warnText()} testш"),
+            DiktatError(1, 32, ruleId, "${PACKAGE_NAME_INCORRECT_SYMBOLS.warnText()} testш"),
             rulesConfigList = rulesConfigList
         )
     }
@@ -235,7 +235,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             """.trimIndent(),
             tempDir = tempDir,
             fileName = "diktat/diktat-rules/src/main/kotlin/org/cqfn/diktat/domain/BlaBla.kt",
-            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.main.kotlin.org.cqfn.diktat.domain", true),
+            DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.main.kotlin.org.cqfn.diktat.domain", true),
             rulesConfigList = rulesConfigSourceDirectories
         )
     }
@@ -276,7 +276,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             """.trimIndent(),
             tempDir = tempDir,
             fileName = "diktat/diktat-rules/src/test/kotlin/org/cqfn/diktat/domain/BlaBla.kt",
-            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.test.kotlin.org.cqfn.diktat.domain", true),
+            DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.test.kotlin.org.cqfn.diktat.domain", true),
             rulesConfigList = rulesConfigSourceDirectories
         )
     }
@@ -299,7 +299,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             """.trimIndent(),
             tempDir = tempDir,
             fileName = "diktat/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/EnumValueCaseTest.kt",
-            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.ruleset.chapter1", true),
+            DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.ruleset.chapter1", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -353,7 +353,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
                 """.trimMargin(),
                 tempDir = tempDir,
                 fileName = "project/src/$it/kotlin/org/cqfn/diktat/example/Example.kt",
-                LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.example", true),
+                DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.example", true),
                 rulesConfigList = rulesConfigList
             )
         }
@@ -368,7 +368,7 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = "project/src/myProjectMain/kotlin/org/cqfn/diktat/example/Example.kt",
-            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.myProjectMain.kotlin.org.cqfn.diktat.example", true),
+            DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.myProjectMain.kotlin.org.cqfn.diktat.example", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -382,8 +382,8 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = "project/src/main/kotlin/org/cqfn/diktat/example/Example.kt",
-            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PREFIX.warnText()} ", true),
-            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.example", true),
+            DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PREFIX.warnText()} ", true),
+            DiktatError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.example", true),
             rulesConfigList = rulesConfigListEmptyDomainName
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/CommentsFormattingTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.IF_ELSE_COMMENTS
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.CommentsFormatting
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Tag
@@ -51,7 +51,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(6, 51, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but there are too many in // comment", true))
+            DiktatError(6, 51, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but there are too many in // comment", true))
     }
 
     @Test
@@ -68,7 +68,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(3, 22, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but there are too many in // asdasd", true))
+            DiktatError(3, 22, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but there are too many in // asdasd", true))
     }
 
     @Test
@@ -138,8 +138,8 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(4, 5, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 1 space(s) before comment token in //First Comment", true),
-            LintError(11, 5, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 1 space(s) before comment token in /*     Comment */", true))
+            DiktatError(4, 5, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 1 space(s) before comment token in //First Comment", true),
+            DiktatError(11, 5, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 1 space(s) before comment token in /*     Comment */", true))
     }
 
     @Test
@@ -220,7 +220,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(2, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} // Some comment", true))
+            DiktatError(2, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} // Some comment", true))
     }
 
     @Test
@@ -243,9 +243,9 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(2, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} /* Some comment */", true),
-            LintError(6, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} /**...", true),
-            LintError(8, 3, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} redundant blank line after /**...", true))
+            DiktatError(2, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} /* Some comment */", true),
+            DiktatError(6, 1, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} /**...", true),
+            DiktatError(8, 3, ruleId, "${Warnings.WRONG_NEWLINES_AROUND_KDOC.warnText()} redundant blank line after /**...", true))
     }
 
     @Test
@@ -278,7 +278,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(5, 13, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but are none in // This is a comment", true))
+            DiktatError(5, 13, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 2 space(s) before comment text, but are none in // This is a comment", true))
     }
 
     @Test
@@ -349,7 +349,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} // Bad Comment", true))
+            DiktatError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} // Bad Comment", true))
     }
 
     @Test
@@ -372,7 +372,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} /* Some comment */", true))
+            DiktatError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} /* Some comment */", true))
     }
 
     @Test
@@ -394,7 +394,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} /* Some comment */", true))
+            DiktatError(6, 8, ruleId, "${IF_ELSE_COMMENTS.warnText()} /* Some comment */", true))
     }
 
     @Test
@@ -439,7 +439,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(8, 18, ruleId, "${Warnings.FIRST_COMMENT_NO_BLANK_LINE.warnText()} // Bad Comment", true))
+            DiktatError(8, 18, ruleId, "${Warnings.FIRST_COMMENT_NO_BLANK_LINE.warnText()} // Bad Comment", true))
     }
 
     @Test
@@ -473,7 +473,7 @@ class CommentsFormattingTest : LintTestBase(::CommentsFormatting) {
             """.trimMargin()
 
         lintMethod(code,
-            LintError(1, 2, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 0 space(s) before comment text, but are 1 in /*...", true))
+            DiktatError(1, 2, ruleId, "${Warnings.COMMENT_WHITE_SPACE.warnText()} There should be 0 space(s) before comment text, but are 1 in /*...", true))
     }
 
     @Test

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleTest.kt
@@ -10,7 +10,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.HEADER_WRONG_FORMAT
 import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -120,7 +120,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
 
                 class Example2 { }
             """.trimIndent(),
-            LintError(1, 1, ruleId, "${HEADER_MISSING_OR_WRONG_COPYRIGHT.warnText()} copyright is placed inside KDoc, but should be inside a block comment", true),
+            DiktatError(1, 1, ruleId, "${HEADER_MISSING_OR_WRONG_COPYRIGHT.warnText()} copyright is placed inside KDoc, but should be inside a block comment", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -144,7 +144,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
 
                 class Example2 { }
             """.trimIndent(),
-            LintError(1, 1, ruleId, "${HEADER_MISSING_OR_WRONG_COPYRIGHT.warnText()} copyright is placed inside KDoc, but should be inside a block comment", true),
+            DiktatError(1, 1, ruleId, "${HEADER_MISSING_OR_WRONG_COPYRIGHT.warnText()} copyright is placed inside KDoc, but should be inside a block comment", true),
             rulesConfigList = rulesConfigListCn
         )
     }
@@ -166,7 +166,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
 
                 class Example2 { }
             """.trimIndent(),
-            LintError(1, 1, ruleId, "${HEADER_MISSING_OR_WRONG_COPYRIGHT.warnText()} copyright is placed inside KDoc, but should be inside a block comment", true),
+            DiktatError(1, 1, ruleId, "${HEADER_MISSING_OR_WRONG_COPYRIGHT.warnText()} copyright is placed inside KDoc, but should be inside a block comment", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -328,7 +328,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
 
                 class Example2 { }
             """.trimIndent(),
-            LintError(1, 1, ruleId, """${Warnings.WRONG_COPYRIGHT_YEAR.warnText()} year should be ${LocalDate.now().year}""", true),
+            DiktatError(1, 1, ruleId, """${Warnings.WRONG_COPYRIGHT_YEAR.warnText()} year should be ${LocalDate.now().year}""", true),
             rulesConfigList = rulesConfigListInvalidYear
         )
     }
@@ -352,7 +352,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
 
                 class Example2 { }
             """.trimIndent(),
-            LintError(1, 1, ruleId, """${Warnings.WRONG_COPYRIGHT_YEAR.warnText()} year should be ${LocalDate.now().year}""", true),
+            DiktatError(1, 1, ruleId, """${Warnings.WRONG_COPYRIGHT_YEAR.warnText()} year should be ${LocalDate.now().year}""", true),
             rulesConfigList = rulesConfigListInvalidYearBeforeCopyright
         )
     }
@@ -368,7 +368,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
 
                 fun foo(): Int = 42
             """.trimIndent(),
-            LintError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 0 declared classes and/or objects", false),
+            DiktatError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 0 declared classes and/or objects", false),
             rulesConfigList = rulesConfigList
         )
     }
@@ -384,7 +384,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
 
                 class Example2 { }
             """.trimIndent(),
-            LintError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 2 declared classes and/or objects", false),
+            DiktatError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 2 declared classes and/or objects", false),
             rulesConfigList = rulesConfigList
         )
     }
@@ -403,7 +403,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
                |
                |class Example { }
             """.trimMargin(),
-            LintError(4, 1, ruleId, "${HEADER_WRONG_FORMAT.warnText()} header KDoc should have a new line after", true),
+            DiktatError(4, 1, ruleId, "${HEADER_WRONG_FORMAT.warnText()} header KDoc should have a new line after", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -426,7 +426,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
                 | */
                 |class Example { }
             """.trimMargin(),
-            LintError(5, 1, ruleId, "${HEADER_NOT_BEFORE_PACKAGE.warnText()} header KDoc is located after package or imports", true),
+            DiktatError(5, 1, ruleId, "${HEADER_NOT_BEFORE_PACKAGE.warnText()} header KDoc is located after package or imports", true),
             rulesConfigList = emptyList()
         )
     }
@@ -471,7 +471,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
                 |
                 |class Some {}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 2 declared classes and/or objects"),
+            DiktatError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 2 declared classes and/or objects"),
             rulesConfigList = rulesConfigList
         )
     }
@@ -499,7 +499,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = "src/main/kotlin/org/cqfn/diktat/Example.kts",
-            LintError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 0 declared classes and/or objects")
+            DiktatError(1, 1, ruleId, "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 0 declared classes and/or objects")
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocCommentsWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocCommentsWarnTest.kt
@@ -12,7 +12,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.MISSING_KDOC_TOP_LEVEL
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocComments
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Tags
@@ -52,7 +52,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
             """.trimMargin()
         lintMethod(
             code,
-            LintError(
+            DiktatError(
                 11, 9, ruleId, "${Warnings.COMMENTED_BY_KDOC.warnText()} Redundant asterisk in block comment: \\**", true
             )
         )
@@ -80,10 +80,10 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
             """.trimIndent()
         lintMethod(
             code,
-            LintError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeGoodName"),
-            LintError(6, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeOtherGoodName"),
-            LintError(9, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeNewGoodName"),
-            LintError(12, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeOtherNewGoodName")
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeGoodName"),
+            DiktatError(6, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeOtherGoodName"),
+            DiktatError(9, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeNewGoodName"),
+            DiktatError(12, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeOtherNewGoodName")
         )
     }
 
@@ -96,7 +96,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 }
             """.trimIndent()
         lintMethod(
-            code, LintError(
+            code, DiktatError(
                 1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} SomeGoodName"
             )
         )
@@ -118,8 +118,8 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
             """.trimIndent()
         lintMethod(
             code,
-            LintError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} someGoodName"),
-            LintError(4, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} someGoodNameNew")
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} someGoodName"),
+            DiktatError(4, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} someGoodNameNew")
         )
     }
 
@@ -173,9 +173,9 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
             """.trimIndent()
         lintMethod(
             code,
-            LintError(5, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} variable"),
-            LintError(7, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} perfectFunction"),
-            LintError(13, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} InternalClass")
+            DiktatError(5, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} variable"),
+            DiktatError(7, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} perfectFunction"),
+            DiktatError(13, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} InternalClass")
         )
     }
 
@@ -208,9 +208,9 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
             """.trimIndent()
         lintMethod(
             code,
-            LintError(5, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} variable"),
-            LintError(8, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} perfectFunction"),
-            LintError(14, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} InternalClass")
+            DiktatError(5, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} variable"),
+            DiktatError(8, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} perfectFunction"),
+            DiktatError(14, 5, ruleId, "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} InternalClass")
         )
     }
 
@@ -311,7 +311,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |) {
                     |}
             """.trimMargin(),
-            LintError(7, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY_WITH_COMMENT.warnText()} name", true)
+            DiktatError(7, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY_WITH_COMMENT.warnText()} name", true)
         )
     }
 
@@ -365,7 +365,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |   ) {
                     |}
             """.trimMargin(),
-            LintError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY_WITH_COMMENT.warnText()} name", true)
+            DiktatError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY_WITH_COMMENT.warnText()} name", true)
         )
     }
 
@@ -384,7 +384,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |   ) {
                     |}
             """.trimMargin(),
-            LintError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} /*some descriptions*/", true)
+            DiktatError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} /*some descriptions*/", true)
         )
     }
 
@@ -427,7 +427,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |   ) {
                     |}
             """.trimMargin(),
-            LintError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} /**...", true)
+            DiktatError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} /**...", true)
         )
     }
 
@@ -448,7 +448,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |   ) {
                     |}
             """.trimMargin(),
-            LintError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} /**...", false)
+            DiktatError(5, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} /**...", false)
         )
     }
 
@@ -482,8 +482,8 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |   ) {
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${KDOC_EXTRA_PROPERTY.warnText()} @property Name text", false),
-            LintError(6, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} add <name> to KDoc", true)
+            DiktatError(2, 4, ruleId, "${KDOC_EXTRA_PROPERTY.warnText()} @property Name text", false),
+            DiktatError(6, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} add <name> to KDoc", true)
         )
     }
 
@@ -498,8 +498,8 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |   ) {
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} Example"),
-            LintError(2, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} add <name> to KDoc", true)
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} Example"),
+            DiktatError(2, 4, ruleId, "${KDOC_NO_CONSTRUCTOR_PROPERTY.warnText()} add <name> to KDoc", true)
         )
     }
 
@@ -518,7 +518,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                     |   ) {
                     |}
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${KDOC_EXTRA_PROPERTY.warnText()} @property kek", false)
+            DiktatError(3, 4, ruleId, "${KDOC_EXTRA_PROPERTY.warnText()} @property kek", false)
         )
     }
 
@@ -534,7 +534,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 |    val foo: Any
                 |}
             """.trimMargin(),
-            LintError(5, 5, ruleId, "${KDOC_NO_CLASS_BODY_PROPERTIES_IN_HEADER.warnText()} val foo: Any")
+            DiktatError(5, 5, ruleId, "${KDOC_NO_CLASS_BODY_PROPERTIES_IN_HEADER.warnText()} val foo: Any")
         )
     }
 
@@ -552,7 +552,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 |    val foo: Any
                 |}
             """.trimMargin(),
-            LintError(5, 5, ruleId, "${KDOC_NO_CLASS_BODY_PROPERTIES_IN_HEADER.warnText()} /**...")
+            DiktatError(5, 5, ruleId, "${KDOC_NO_CLASS_BODY_PROPERTIES_IN_HEADER.warnText()} /**...")
         )
     }
 
@@ -569,9 +569,9 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 |
                 |actual class A{}
             """.trimMargin(),
-            LintError(2, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} fo"),
-            LintError(4, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} foo"),
-            LintError(6, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} B")
+            DiktatError(2, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} fo"),
+            DiktatError(4, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} foo"),
+            DiktatError(6, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} B")
         )
     }
 
@@ -635,7 +635,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 |    //
                 |}
             """.trimMargin(),
-            LintError(4, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @param field2"),
+            DiktatError(4, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @param field2"),
         )
     }
 
@@ -654,7 +654,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 |    val field2: String,
                 |)
             """.trimMargin(),
-            LintError(4, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @property field2"),
+            DiktatError(4, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @property field2"),
         )
     }
 
@@ -673,7 +673,7 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 |    val field2: String,
                 |)
             """.trimMargin(),
-            LintError(4, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @param field2"),
+            DiktatError(4, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @param field2"),
         )
     }
 
@@ -693,8 +693,8 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
                 |    val field2: String,
                 |)
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @property field1"),
-            LintError(5, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @param field2"),
+            DiktatError(3, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @property field1"),
+            DiktatError(5, 4, ruleId, "${KDOC_DUPLICATE_PROPERTY.warnText()} @param field2"),
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocFormattingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocFormattingTest.kt
@@ -14,7 +14,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.KDOC_WRONG_TAGS_ORDER
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocFormatting
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -37,7 +37,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                | */
                |fun foo() = Unit
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${KDOC_EMPTY_KDOC.warnText()} foo", false)
+            DiktatError(1, 1, ruleId, "${KDOC_EMPTY_KDOC.warnText()} foo", false)
         )
     }
 
@@ -49,7 +49,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                | */
                |fun foo() = Unit
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${KDOC_EMPTY_KDOC.warnText()} foo", false)
+            DiktatError(1, 1, ruleId, "${KDOC_EMPTY_KDOC.warnText()} foo", false)
         )
     }
 
@@ -61,7 +61,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                | *
                | */
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${KDOC_EMPTY_KDOC.warnText()} /**...", false)
+            DiktatError(1, 1, ruleId, "${KDOC_EMPTY_KDOC.warnText()} /**...", false)
         )
     }
 
@@ -76,7 +76,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                |    companion object { }
                |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${KDOC_EMPTY_KDOC.warnText()} object", false)
+            DiktatError(2, 5, ruleId, "${KDOC_EMPTY_KDOC.warnText()} object", false)
         )
     }
 
@@ -91,7 +91,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(2, 4, ruleId, "${KDOC_NO_DEPRECATED_TAG.warnText()} @deprecated use foo instead", true)
+            DiktatError(2, 4, ruleId, "${KDOC_NO_DEPRECATED_TAG.warnText()} @deprecated use foo instead", true)
         )
     }
 
@@ -108,7 +108,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(3, 16, ruleId,
+            DiktatError(3, 16, ruleId,
                 "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false))
     }
 
@@ -140,13 +140,13 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(2, 16, ruleId,
+            DiktatError(2, 16, ruleId,
                 "${KDOC_WRONG_SPACES_AFTER_TAG.warnText()} @param", true),
-            LintError(3, 16, ruleId,
+            DiktatError(3, 16, ruleId,
                 "${KDOC_WRONG_SPACES_AFTER_TAG.warnText()} @param", true),
-            LintError(4, 16, ruleId,
+            DiktatError(4, 16, ruleId,
                 "${KDOC_WRONG_SPACES_AFTER_TAG.warnText()} @return", true),
-            LintError(5, 16, ruleId,
+            DiktatError(5, 16, ruleId,
                 "${KDOC_WRONG_SPACES_AFTER_TAG.warnText()} @throws", true))
     }
 
@@ -196,7 +196,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(2, 16, ruleId,
+            DiktatError(2, 16, ruleId,
                 "${KDOC_WRONG_TAGS_ORDER.warnText()} @return, @throws, @param", true))
     }
 
@@ -218,9 +218,9 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(4, 4, ruleId,
+            DiktatError(4, 4, ruleId,
                 "${KDOC_NO_NEWLINES_BETWEEN_BASIC_TAGS.warnText()} @property", true),
-            LintError(4, 4, ruleId,
+            DiktatError(4, 4, ruleId,
                 "${KDOC_WRONG_TAGS_ORDER.warnText()} @property, @param", true)
         )
     }
@@ -240,9 +240,9 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(2, 16, ruleId,
+            DiktatError(2, 16, ruleId,
                 "${KDOC_NO_NEWLINES_BETWEEN_BASIC_TAGS.warnText()} @param", true),
-            LintError(4, 16, ruleId,
+            DiktatError(4, 16, ruleId,
                 "${KDOC_NO_NEWLINES_BETWEEN_BASIC_TAGS.warnText()} @return", true))
     }
 
@@ -271,7 +271,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                | */
                |fun test(a: Int): Unit = Unit
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${KDOC_NEWLINES_BEFORE_BASIC_TAGS.warnText()} @param", true)
+            DiktatError(3, 4, ruleId, "${KDOC_NEWLINES_BEFORE_BASIC_TAGS.warnText()} @param", true)
         )
     }
 
@@ -286,7 +286,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                | */
                |fun test(a: Int): Unit = Unit
             """.trimMargin(),
-            LintError(4, 4, ruleId, "${KDOC_NEWLINES_BEFORE_BASIC_TAGS.warnText()} @param", true)
+            DiktatError(4, 4, ruleId, "${KDOC_NEWLINES_BEFORE_BASIC_TAGS.warnText()} @param", true)
         )
     }
 
@@ -322,7 +322,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(2, 16, ruleId,
+            DiktatError(2, 16, ruleId,
                 "${KDOC_NO_NEWLINE_AFTER_SPECIAL_TAGS.warnText()} @implSpec, @apiNote, @implNote", true))
     }
 
@@ -345,7 +345,7 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(2, 16, ruleId,
+            DiktatError(2, 16, ruleId,
                 "${KDOC_NO_NEWLINE_AFTER_SPECIAL_TAGS.warnText()} @implSpec, @apiNote, @implNote", true))
     }
 
@@ -367,8 +367,8 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                 | */
                 |class Example { }
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @author anonymous"),
-            LintError(10, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @author anonymous"),
+            DiktatError(3, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @author anonymous"),
+            DiktatError(10, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @author anonymous"),
         )
     }
 
@@ -400,12 +400,12 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                 | */
                 |class Example { }
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
-            LintError(4, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 19-10-11"),
-            LintError(5, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019.10.11"),
-            LintError(6, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019/10/11"),
-            LintError(7, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 11 Oct 2019"),
-            LintError(19, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
+            DiktatError(3, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
+            DiktatError(4, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 19-10-11"),
+            DiktatError(5, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019.10.11"),
+            DiktatError(6, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019/10/11"),
+            DiktatError(7, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 11 Oct 2019"),
+            DiktatError(19, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
             rulesConfigList = emptyList()
         )
     }
@@ -431,9 +431,9 @@ class KdocFormattingTest : LintTestBase(::KdocFormatting) {
                 | */
                 |class Example { }
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
-            LintError(5, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 1.2.3.RELEASE"),
-            LintError(12, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
+            DiktatError(3, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
+            DiktatError(5, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 1.2.3.RELEASE"),
+            DiktatError(12, 4, ruleId, "${Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.warnText()} @since 2019-10-11"),
             rulesConfigList = listOf(
                 RulesConfig(
                     Warnings.KDOC_CONTAINS_DATE_OR_AUTHOR.name, true, mapOf(

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocMethodsTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocMethodsTest.kt
@@ -11,7 +11,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.MISSING_KDOC_ON_FUNCTION
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocMethods
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Tags
@@ -68,7 +68,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
 
         """.trimIndent()
         lintMethod(code,
-            LintError(3, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
+            DiktatError(3, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
         )
     }
 
@@ -89,13 +89,13 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
         lintMethodWithFile(complexAnnotationCode,
             tempDir = tempDir,
             fileName = "src/main/kotlin/org/cqfn/diktat/Example.kt",
-            LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", true)
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", true)
         )
         // should check all .kt files unless both conditions on location and name are true
         lintMethodWithFile(funCode,
             tempDir = tempDir,
             fileName = "src/test/kotlin/org/cqfn/diktat/Example.kt",
-            LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", true)
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", true)
         )
         // should allow to set custom test dirs
         lintMethodWithFile(funCode,
@@ -138,7 +138,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(1, 13, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)", true)
+            DiktatError(1, 13, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)", true)
         )
     }
 
@@ -159,7 +159,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(1, 12, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} addInts (b)", true)
+            DiktatError(1, 12, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} addInts (b)", true)
         )
     }
 
@@ -179,7 +179,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(1, 13, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt", true)
+            DiktatError(1, 13, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt", true)
         )
     }
 
@@ -205,7 +205,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(1, 12, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} foo", true)
+            DiktatError(1, 12, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} foo", true)
         )
     }
 
@@ -225,7 +225,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(1, 13, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)", true)
+            DiktatError(1, 13, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)", true)
         )
     }
 
@@ -268,7 +268,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
         """.trimIndent()
 
         lintMethod(invalidCode,
-            LintError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalAccessException)", true)
+            DiktatError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalAccessException)", true)
         )
     }
 
@@ -331,8 +331,8 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(12, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} setY", true),
-            LintError(17, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} getZ", true)
+            DiktatError(12, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} setY", true),
+            DiktatError(17, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} getZ", true)
         )
     }
 
@@ -343,7 +343,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
             """
                     |fun foo() { }
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false)
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false)
         )
     }
 
@@ -357,7 +357,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
                     | */
                     |fun getX(): TypeX { return x }
             """.trimMargin(),
-            LintError(2, 3, ruleId, "${KDOC_TRIVIAL_KDOC_ON_FUNCTION.warnText()} Returns X", false)
+            DiktatError(2, 3, ruleId, "${KDOC_TRIVIAL_KDOC_ON_FUNCTION.warnText()} Returns X", false)
         )
     }
 
@@ -386,7 +386,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
                     |   return qwe
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", true)
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", true)
         )
     }
 
@@ -398,8 +398,8 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
                     |fun hasNoChildren() = children.size == 0
                     |fun getFirstChild() = children.elementAtOrNull(0)
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} hasNoChildren", true),
-            LintError(2, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} getFirstChild", true)
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} hasNoChildren", true),
+            DiktatError(2, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} getFirstChild", true)
         )
     }
 
@@ -422,7 +422,7 @@ class KdocMethodsTest : LintTestBase(::KdocMethods) {
                     |actual fun writeToConsoleAc(msg: String, outputType: OutputStreamType) {}
                     |expect fun writeToConsoleEx(msg: String, outputType: OutputStreamType) {}
             """.trimMargin(),
-            LintError(2, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} writeToConsoleEx", true),
+            DiktatError(2, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} writeToConsoleEx", true),
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocParamPresentWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocParamPresentWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.MISSING_KDOC_ON_FUNCTION
 import org.cqfn.diktat.ruleset.rules.chapter2.kdoc.KdocMethods
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Tags
@@ -39,9 +39,9 @@ class KdocParamPresentWarnTest : LintTestBase(::KdocMethods) {
                     |*/
                     |fun foo(a: Int, B: Int) {}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} foo (a, B)", true),
-            LintError(2, 3, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} A param isn't present in argument list"),
-            LintError(3, 3, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} В param isn't present in argument list")
+            DiktatError(1, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} foo (a, B)", true),
+            DiktatError(2, 3, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} A param isn't present in argument list"),
+            DiktatError(3, 3, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} В param isn't present in argument list")
         )
     }
 
@@ -55,7 +55,7 @@ class KdocParamPresentWarnTest : LintTestBase(::KdocMethods) {
                     |*/
                     |fun foo() {}
             """.trimMargin(),
-            LintError(2, 3, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} A param isn't present in argument list")
+            DiktatError(2, 3, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} A param isn't present in argument list")
         )
     }
 
@@ -74,7 +74,7 @@ class KdocParamPresentWarnTest : LintTestBase(::KdocMethods) {
                     |*/
                     |fun foo (a: Int) {}
             """.trimMargin(),
-            LintError(6, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} foo (a)", true)
+            DiktatError(6, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} foo (a)", true)
         )
     }
 
@@ -103,7 +103,7 @@ class KdocParamPresentWarnTest : LintTestBase(::KdocMethods) {
                     |* @param a - qwe
                     |*/
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", true)
+            DiktatError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/comments/CommentedCodeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/comments/CommentedCodeTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.COMMENTED_OUT_CODE
 import org.cqfn.diktat.ruleset.rules.chapter2.comments.CommentsRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -24,8 +24,8 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 |// this is an actual comment
                 |//import org.junit.Ignore
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} package org.cqfn.diktat.example", false),
-            LintError(5, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false)
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} package org.cqfn.diktat.example", false),
+            DiktatError(5, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false)
         )
     }
 
@@ -37,8 +37,8 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                |/*import org.junit.Test
                |import org.junit.Ignore*/
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Test", false),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false)
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Test", false),
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false)
         )
     }
 
@@ -57,7 +57,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                |    return 0
                |}
             """.trimMargin(),
-            LintError(4, 5, ruleId, "${COMMENTED_OUT_CODE.warnText()} println(a + 42)", false)
+            DiktatError(4, 5, ruleId, "${COMMENTED_OUT_CODE.warnText()} println(a + 42)", false)
         )
     }
 
@@ -89,7 +89,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                |//    return 0
                |//}
             """.trimMargin(),
-            LintError(3, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
+            DiktatError(3, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
         )
     }
 
@@ -107,7 +107,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                |//    return 0
                |//}
             """.trimMargin(),
-            LintError(4, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
+            DiktatError(4, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
         )
     }
 
@@ -124,7 +124,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                |    return 0
                |}*/
             """.trimMargin(),
-            LintError(3, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
+            DiktatError(3, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
         )
     }
 
@@ -145,8 +145,8 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 |    //}
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false),
-            LintError(6, 5, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false),
+            DiktatError(6, 5, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
         )
     }
 
@@ -214,7 +214,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 |   */
                 |}
             """.trimMargin(),
-            LintError(2, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun clickFilters_showFilters() {", false)
+            DiktatError(2, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun clickFilters_showFilters() {", false)
         )
     }
 
@@ -235,8 +235,8 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 |//    }
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false),
-            LintError(6, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import org.junit.Ignore", false),
+            DiktatError(6, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo(a: Int): Int {", false)
         )
     }
 
@@ -256,7 +256,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
             """
                 |// public data class Test(val some: Int): Exception()
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} public data class Test(val some: Int): Exception()", false))
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} public data class Test(val some: Int): Exception()", false))
     }
 
     @Test
@@ -266,7 +266,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
             """
                 |// var foo: Int = 1
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} var foo: Int = 1", false))
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} var foo: Int = 1", false))
     }
 
     @Test
@@ -278,7 +278,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 | //     varfoo adda foofoo
                 | // }
             """.trimMargin(),
-            LintError(1, 2, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo() {", false))
+            DiktatError(1, 2, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun foo() {", false))
     }
 
     @Test
@@ -288,7 +288,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
             """
                 | // class A { val a = 2 }
             """.trimMargin(),
-            LintError(1, 2, ruleId, "${COMMENTED_OUT_CODE.warnText()} class A { val a = 2 }", false))
+            DiktatError(1, 2, ruleId, "${COMMENTED_OUT_CODE.warnText()} class A { val a = 2 }", false))
     }
 
     @Test
@@ -298,7 +298,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
             """
                 | /* class A { val a = 2 } */
             """.trimMargin(),
-            LintError(1, 2, ruleId, "${COMMENTED_OUT_CODE.warnText()} class A { val a = 2 }", false))
+            DiktatError(1, 2, ruleId, "${COMMENTED_OUT_CODE.warnText()} class A { val a = 2 }", false))
     }
 
     @Test
@@ -317,7 +317,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
             """
                 |// import some.org
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import some.org", false))
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} import some.org", false))
     }
 
     @Test
@@ -327,7 +327,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
             """
                 |// package some.org
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} package some.org", false))
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} package some.org", false))
     }
 
     @Test
@@ -339,7 +339,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 |//     val a = 5
                 |// }
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun someFunc(name: String): Boolean {", false))
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun someFunc(name: String): Boolean {", false))
     }
 
     @Test
@@ -350,7 +350,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 |// fun someFunc(name: String): Boolean =
                 |//     name.contains("a")
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun someFunc(name: String): Boolean =", false))
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} fun someFunc(name: String): Boolean =", false))
     }
 
     @Test
@@ -361,7 +361,7 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
                 |// public fun someFunc(name: String): Boolean =
                 |//     name.contains("a")
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} public fun someFunc(name: String): Boolean =", false))
+            DiktatError(1, 1, ruleId, "${COMMENTED_OUT_CODE.warnText()} public fun someFunc(name: String): Boolean =", false))
     }
 
     @Test
@@ -428,8 +428,8 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
 
             */
             """.trimMargin(),
-            LintError(7, 13, ruleId, "${COMMENTED_OUT_CODE.warnText()} x = 2 + 4 + 1", false),
-            LintError(14, 13, ruleId, "${COMMENTED_OUT_CODE.warnText()} class A {", false)
+            DiktatError(7, 13, ruleId, "${COMMENTED_OUT_CODE.warnText()} x = 2 + 4 + 1", false),
+            DiktatError(14, 13, ruleId, "${COMMENTED_OUT_CODE.warnText()} class A {", false)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/AnnotationNewLineRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/AnnotationNewLineRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.AnnotationNewLineRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -49,8 +49,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |   val a = 5
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
-            LintError(1, 17, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
+            DiktatError(1, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
+            DiktatError(1, 17, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
         )
     }
 
@@ -63,8 +63,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |   val a = 5
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
-            LintError(1, 17, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
+            DiktatError(1, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
+            DiktatError(1, 17, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
         )
     }
 
@@ -115,8 +115,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |  }
                     |}
             """.trimMargin(),
-            LintError(4, 3, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
-            LintError(4, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
+            DiktatError(4, 3, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
+            DiktatError(4, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
         )
     }
 
@@ -134,8 +134,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |  }
                     |}
             """.trimMargin(),
-            LintError(4, 3, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
-            LintError(4, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
+            DiktatError(4, 3, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true),
+            DiktatError(4, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
         )
     }
 
@@ -205,8 +205,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @FirstAnnotation not on a single line", true),
-            LintError(2, 21, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
+            DiktatError(2, 4, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @FirstAnnotation not on a single line", true),
+            DiktatError(2, 21, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SecondAnnotation not on a single line", true)
         )
     }
 
@@ -219,8 +219,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @Inject not on a single line", true),
-            LintError(1, 27, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true)
+            DiktatError(1, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @Inject not on a single line", true),
+            DiktatError(1, 27, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true)
         )
     }
 
@@ -234,8 +234,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @Inject not on a single line", true),
-            LintError(2, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true)
+            DiktatError(1, 19, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @Inject not on a single line", true),
+            DiktatError(2, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @SomeAnnotation not on a single line", true)
         )
     }
 
@@ -306,8 +306,8 @@ class AnnotationNewLineRuleWarnTest : LintTestBase(::AnnotationNewLineRule) {
                     |@Foo
                     |@goo val loader: DataLoader
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @ExperimentalStdlibApi not on a single line", true),
-            LintError(1, 32, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @Hello not on a single line", true),
+            DiktatError(1, 1, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @ExperimentalStdlibApi not on a single line", true),
+            DiktatError(1, 32, ruleId, "${Warnings.ANNOTATION_NEW_LINE.warnText()} @Hello not on a single line", true),
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BlockStructureBracesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BlockStructureBracesWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.BRACES_BLOCK_STRUCTURE_ERROR
 import org.cqfn.diktat.ruleset.rules.chapter3.BlockStructureBraces
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -39,8 +39,8 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |       koo()}
                     |}
             """.trimMargin(),
-            LintError(4, 6, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
-            LintError(6, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
+            DiktatError(4, 6, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
+            DiktatError(6, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
         )
     }
 
@@ -127,8 +127,8 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |    } else {}
                     |}
             """.trimMargin(),
-            LintError(4, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect same line after opening brace", true),
-            LintError(4, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
+            DiktatError(4, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect same line after opening brace", true),
+            DiktatError(4, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
         )
     }
 
@@ -145,8 +145,8 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 16, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true),
-            LintError(5, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect same line after opening brace", true)
+            DiktatError(2, 16, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true),
+            DiktatError(5, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect same line after opening brace", true)
         )
     }
 
@@ -162,9 +162,9 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |       f() }
                     |}
             """.trimMargin(),
-            LintError(3, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true),
-            LintError(3, 14, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
-            LintError(5, 12, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
+            DiktatError(3, 13, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true),
+            DiktatError(3, 14, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
+            DiktatError(5, 12, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
         )
     }
 
@@ -182,7 +182,7 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |       hoo() }
                     |}
             """.trimMargin(),
-            LintError(4, 15, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
+            DiktatError(4, 15, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -239,7 +239,7 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |fun foo() {
                     |   pyu() }
             """.trimMargin(),
-            LintError(2, 10, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
+            DiktatError(2, 10, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
         )
     }
 
@@ -256,7 +256,7 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 12, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true)
+            DiktatError(2, 12, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true)
         )
     }
 
@@ -310,7 +310,7 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |   } while (x != 0)
                     |}
             """.trimMargin(),
-            LintError(2, 6, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true)
+            DiktatError(2, 6, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true)
         )
     }
 
@@ -333,8 +333,8 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(6, 5, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
-            LintError(9, 5, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true)
+            DiktatError(6, 5, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true),
+            DiktatError(9, 5, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect new line after closing brace", true)
         )
     }
 
@@ -351,8 +351,8 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |       return 1 }
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect same line after opening brace", true),
-            LintError(6, 17, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
+            DiktatError(2, 9, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect same line after opening brace", true),
+            DiktatError(6, 17, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
         )
     }
 
@@ -413,7 +413,7 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |   val x: Int = 10
                     |}
             """.trimMargin(),
-            LintError(1, 9, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true)
+            DiktatError(1, 9, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true)
         )
     }
 
@@ -432,8 +432,8 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 8, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true),
-            LintError(4, 14, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
+            DiktatError(2, 8, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} incorrect newline before opening brace", true),
+            DiktatError(4, 14, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
         )
     }
 
@@ -499,7 +499,7 @@ class BlockStructureBracesWarnTest : LintTestBase(::BlockStructureBraces) {
                     |               it.text == "sdc" }
                     |}
             """.trimMargin(),
-            LintError(9, 33, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
+            DiktatError(9, 33, ruleId, "${BRACES_BLOCK_STRUCTURE_ERROR.warnText()} no newline before closing brace", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BooleanExpressionsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BooleanExpressionsRuleWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.rules.chapter3.BooleanExpressionsRule
 import org.cqfn.diktat.ruleset.utils.KotlinParser
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
@@ -40,9 +40,9 @@ class BooleanExpressionsRuleWarnTest : LintTestBase(::BooleanExpressionsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} some != null && some != null && some == null", true),
-            LintError(10, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 3 && b > 3 && a > 3", true),
-            LintError(14, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a && a && b > 4", true)
+            DiktatError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} some != null && some != null && some == null", true),
+            DiktatError(10, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 3 && b > 3 && a > 3", true),
+            DiktatError(14, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a && a && b > 4", true)
         )
     }
 
@@ -73,11 +73,11 @@ class BooleanExpressionsRuleWarnTest : LintTestBase(::BooleanExpressionsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} some != null && (some != null || a > 5)", true),
-            LintError(6, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 || (a > 5 && b > 6)", true),
-            LintError(10, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} !!(a > 5 && q > 6)", true),
-            LintError(14, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 && false", true),
-            LintError(18, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 || (!(a > 5) && b > 5)", true)
+            DiktatError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} some != null && (some != null || a > 5)", true),
+            DiktatError(6, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 || (a > 5 && b > 6)", true),
+            DiktatError(10, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} !!(a > 5 && q > 6)", true),
+            DiktatError(14, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 && false", true),
+            DiktatError(18, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 || (!(a > 5) && b > 5)", true)
         )
     }
 
@@ -96,8 +96,8 @@ class BooleanExpressionsRuleWarnTest : LintTestBase(::BooleanExpressionsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} (a > 5 || b > 5) && (a > 5 || c > 5)", true),
-            LintError(6, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 && b > 5 || a > 5 && c > 5", true)
+            DiktatError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} (a > 5 || b > 5) && (a > 5 || c > 5)", true),
+            DiktatError(6, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 && b > 5 || a > 5 && c > 5", true)
         )
     }
 
@@ -116,8 +116,8 @@ class BooleanExpressionsRuleWarnTest : LintTestBase(::BooleanExpressionsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} (a > 5 || b > 5) && (a > 5 || c > 5) && (a > 5 || d > 5)", true),
-            LintError(6, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 && b > 5 || a > 5 && c > 5 || a > 5 || d > 5", true)
+            DiktatError(2, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} (a > 5 || b > 5) && (a > 5 || c > 5) && (a > 5 || d > 5)", true),
+            DiktatError(6, 9, ruleId, "${Warnings.COMPLEX_BOOLEAN_EXPRESSION.warnText()} a > 5 && b > 5 || a > 5 && c > 5 || a > 5 || d > 5", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BracesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/BracesRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.NO_BRACES_IN_CONDITIONALS_AND_
 import org.cqfn.diktat.ruleset.rules.chapter3.BracesInConditionalsAndLoopsRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -39,8 +39,8 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |    if (y < 0) baz()
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
-            LintError(5, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true)
+            DiktatError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
+            DiktatError(5, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true)
         )
     }
 
@@ -76,9 +76,9 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |        baz()
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
-            LintError(4, 10, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
-            LintError(6, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
+            DiktatError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
+            DiktatError(4, 10, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
+            DiktatError(6, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
         )
     }
 
@@ -172,7 +172,7 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
             |    } else baz(b.apply { id = 5 })
             |}
             """.trimMargin(),
-            LintError(4, 7, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
+            DiktatError(4, 7, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
         )
     }
 
@@ -188,7 +188,7 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
             |        c.baz(b.apply {id = 5})
             |}
             """.trimMargin(),
-            LintError(4, 7, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
+            DiktatError(4, 7, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
         )
     }
 
@@ -203,8 +203,8 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |    } else if (x == 0) bar() else baz()
                     |}
             """.trimMargin(),
-            LintError(4, 12, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
-            LintError(4, 30, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
+            DiktatError(4, 12, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
+            DiktatError(4, 30, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
         )
     }
 
@@ -219,9 +219,9 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |    else foo()
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
-            LintError(3, 10, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
-            LintError(4, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
+            DiktatError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
+            DiktatError(3, 10, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} IF", true),
+            DiktatError(4, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} ELSE", true)
         )
     }
 
@@ -247,8 +247,8 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(7, 21, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} WHEN", true),
-            LintError(8, 21, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} WHEN", true)
+            DiktatError(7, 21, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} WHEN", true),
+            DiktatError(8, 21, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} WHEN", true)
         )
     }
 
@@ -276,7 +276,7 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |        println(i)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} FOR", true)
+            DiktatError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} FOR", true)
         )
     }
 
@@ -304,7 +304,7 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |        println("")
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} WHILE", true)
+            DiktatError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} WHILE", true)
         )
     }
 
@@ -331,7 +331,7 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |    do println(i) while (condition)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} DO_WHILE", true)
+            DiktatError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} DO_WHILE", true)
         )
     }
 
@@ -344,7 +344,7 @@ class BracesRuleWarnTest : LintTestBase(::BracesInConditionalsAndLoopsRule) {
                     |    do while (condition)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} DO_WHILE", true)
+            DiktatError(2, 5, ruleId, "${NO_BRACES_IN_CONDITIONALS_AND_LOOPS.warnText()} DO_WHILE", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ClassLikeStructuresOrderRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ClassLikeStructuresOrderRuleWarnTest.kt
@@ -7,7 +7,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_ORDER_IN_CLASS_LIKE_STRU
 import org.cqfn.diktat.ruleset.rules.chapter3.ClassLikeStructuresOrderRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
@@ -61,8 +61,8 @@ class ClassLikeStructuresOrderRuleWarnTest : LintTestBase(::ClassLikeStructuresO
                     |    private val log = LoggerFactory.getLogger(Example.javaClass)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: FOO", true),
-            LintError(3, 5, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: log", true)
+            DiktatError(2, 5, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: FOO", true),
+            DiktatError(3, 5, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: log", true)
         )
     }
 
@@ -119,10 +119,10 @@ class ClassLikeStructuresOrderRuleWarnTest : LintTestBase(::ClassLikeStructuresO
                     |    private lateinit var lateFoo: Int
                     |}
             """.trimMargin(),
-            LintError(4, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} BAR", true),
-            LintError(6, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} qux", true),
-            LintError(8, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} quux", true),
-            LintError(11, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} BAZ", true)
+            DiktatError(4, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} BAR", true),
+            DiktatError(6, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} qux", true),
+            DiktatError(8, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} quux", true),
+            DiktatError(11, 5, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} BAZ", true)
         )
     }
 
@@ -210,8 +210,8 @@ class ClassLikeStructuresOrderRuleWarnTest : LintTestBase(::ClassLikeStructuresO
                         }
                     }
             """.trimMargin(),
-            LintError(3, 29, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: b", true),
-            LintError(5, 29, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: a", true)
+            DiktatError(3, 29, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: b", true),
+            DiktatError(5, 29, ruleId, "${WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES.warnText()} PROPERTY: a", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.COLLAPSE_IF_STATEMENTS
 import org.cqfn.diktat.ruleset.rules.chapter3.CollapseIfStatementsRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -32,7 +32,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -53,7 +53,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -71,7 +71,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(4, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(4, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -86,7 +86,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -105,7 +105,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(5, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(5, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -125,7 +125,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(6, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(6, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -169,7 +169,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(7, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(7, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -191,7 +191,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(8, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(8, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -208,7 +208,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -225,7 +225,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -246,7 +246,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(7, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(7, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -267,8 +267,8 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(4, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
-            LintError(6, 14, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(4, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(6, 14, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -386,7 +386,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |   }
             |}
             """.trimMargin(),
-            LintError(5, 12, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(5, 12, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
         )
     }
 
@@ -405,8 +405,8 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
-            LintError(4, 14, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(4, 14, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -431,11 +431,11 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
-            LintError(4, 14, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
-            LintError(5, 18, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
-            LintError(6, 22, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
-            LintError(7, 26, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(4, 14, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(5, 18, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(6, 22, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(7, 26, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
@@ -480,7 +480,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |    }
             |}
             """.trimMargin(),
-            LintError(7, 12, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(7, 12, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
         )
     }
 
@@ -501,7 +501,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |}
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ConsecutiveSpacesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ConsecutiveSpacesRuleWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TOO_MANY_CONSECUTIVE_SPACES
 import org.cqfn.diktat.ruleset.rules.chapter3.ConsecutiveSpacesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class ConsecutiveSpacesRuleWarnTest : LintTestBase(::ConsecutiveSpacesRule) {
                     |    PLUS, ASD
                     |}
             """.trimMargin(),
-            LintError(1, 5, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 7. need to be: 1", true)
+            DiktatError(1, 5, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 7. need to be: 1", true)
         )
     }
 
@@ -66,8 +66,8 @@ class ConsecutiveSpacesRuleWarnTest : LintTestBase(::ConsecutiveSpacesRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 7, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 6. need to be: 1", true),
-            LintError(2, 33, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
+            DiktatError(2, 7, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 6. need to be: 1", true),
+            DiktatError(2, 33, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
         )
     }
 
@@ -81,8 +81,8 @@ class ConsecutiveSpacesRuleWarnTest : LintTestBase(::ConsecutiveSpacesRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(1, 6, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true),
-            LintError(2, 9, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
+            DiktatError(1, 6, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true),
+            DiktatError(2, 9, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
         )
     }
 
@@ -128,9 +128,9 @@ class ConsecutiveSpacesRuleWarnTest : LintTestBase(::ConsecutiveSpacesRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(3, 15, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 4. need to be: 1", true),
-            LintError(4, 18, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true),
-            LintError(5, 14, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
+            DiktatError(3, 15, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 4. need to be: 1", true),
+            DiktatError(4, 18, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true),
+            DiktatError(5, 14, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
 
         )
     }
@@ -156,8 +156,8 @@ class ConsecutiveSpacesRuleWarnTest : LintTestBase(::ConsecutiveSpacesRule) {
                     |   var value = t
                     |}
             """.trimMargin(),
-            LintError(1, 11, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 3. need to be: 1", true),
-            LintError(1, 19, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 4. need to be: 1", true)
+            DiktatError(1, 11, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 3. need to be: 1", true),
+            DiktatError(1, 19, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 4. need to be: 1", true)
         )
     }
 
@@ -184,7 +184,7 @@ class ConsecutiveSpacesRuleWarnTest : LintTestBase(::ConsecutiveSpacesRule) {
                     |   fun bar()
                     |}
             """.trimMargin(),
-            LintError(1, 10, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 7. need to be: 1", true)
+            DiktatError(1, 10, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 7. need to be: 1", true)
         )
     }
 
@@ -199,7 +199,7 @@ class ConsecutiveSpacesRuleWarnTest : LintTestBase(::ConsecutiveSpacesRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 8, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
+            DiktatError(2, 8, ruleId, "${TOO_MANY_CONSECUTIVE_SPACES.warnText()} found: 5. need to be: 1", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/DebugPrintRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/DebugPrintRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.DebugPrintRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class DebugPrintRuleWarnTest : LintTestBase(::DebugPrintRule) {
                 |    print("test print")
                 |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found print()", false)
+            DiktatError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found print()", false)
         )
     }
 
@@ -35,7 +35,7 @@ class DebugPrintRuleWarnTest : LintTestBase(::DebugPrintRule) {
                 |    println("test println")
                 |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found println()", false)
+            DiktatError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found println()", false)
         )
     }
 
@@ -48,7 +48,7 @@ class DebugPrintRuleWarnTest : LintTestBase(::DebugPrintRule) {
                 |    println()
                 |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found println()", false)
+            DiktatError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found println()", false)
         )
     }
 
@@ -102,10 +102,10 @@ class DebugPrintRuleWarnTest : LintTestBase(::DebugPrintRule) {
                 |    console.warn("1", "2", "3", "4")
                 |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.error()", false),
-            LintError(3, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.info()", false),
-            LintError(4, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.log()", false),
-            LintError(5, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.warn()", false)
+            DiktatError(2, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.error()", false),
+            DiktatError(3, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.info()", false),
+            DiktatError(4, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.log()", false),
+            DiktatError(5, 5, ruleId, "${Warnings.DEBUG_PRINT.warnText()} found console.warn()", false)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/EmptyBlockWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/EmptyBlockWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.EMPTY_BLOCK_STRUCTURE_ERROR
 import org.cqfn.diktat.ruleset.rules.chapter3.EmptyBlock
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -35,7 +35,7 @@ class EmptyBlockWarnTest : LintTestBase(::EmptyBlock) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(5, 10, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false)
+            DiktatError(5, 10, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false)
         )
     }
 
@@ -49,7 +49,7 @@ class EmptyBlockWarnTest : LintTestBase(::EmptyBlock) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false)
+            DiktatError(2, 5, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false)
         )
     }
 
@@ -65,7 +65,7 @@ class EmptyBlockWarnTest : LintTestBase(::EmptyBlock) {
                     |    else {}
                     |}
             """.trimMargin(),
-            LintError(5, 10, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false),
+            DiktatError(5, 10, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false),
             rulesConfigList = rulesConfigListIgnoreEmptyBlock
         )
     }
@@ -157,7 +157,7 @@ class EmptyBlockWarnTest : LintTestBase(::EmptyBlock) {
                 |   }
                 |}
             """.trimMargin(),
-            LintError(2, 30, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} do not put newlines in empty lambda", true),
+            DiktatError(2, 30, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} do not put newlines in empty lambda", true),
             rulesConfigList = rulesConfigListEmptyBlockExist
         )
     }
@@ -170,7 +170,7 @@ class EmptyBlockWarnTest : LintTestBase(::EmptyBlock) {
                     |   val y = listOf<Int>().map { }
                     |}
             """.trimMargin(),
-            LintError(2, 30, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false)
+            DiktatError(2, 30, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false)
         )
     }
 
@@ -214,7 +214,7 @@ class EmptyBlockWarnTest : LintTestBase(::EmptyBlock) {
                 |
                 |val some = object : A{}
             """.trimMargin(),
-            LintError(3, 22, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} different style for empty block", true),
+            DiktatError(3, 22, ruleId, "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} different style for empty block", true),
             rulesConfigList = rulesConfigListEmptyBlockExist
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/EnumsSeparatedWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/EnumsSeparatedWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.ENUMS_SEPARATED
 import org.cqfn.diktat.ruleset.rules.chapter3.EnumsSeparated
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -53,10 +53,10 @@ class EnumsSeparatedWarnTest : LintTestBase(::EnumsSeparated) {
                     |   fun foo() {}
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
-            LintError(2, 7, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
-            LintError(2, 10, ruleId, "${ENUMS_SEPARATED.warnText()} semicolon must be on a new line", true),
-            LintError(2, 10, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
+            DiktatError(2, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
+            DiktatError(2, 7, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
+            DiktatError(2, 10, ruleId, "${ENUMS_SEPARATED.warnText()} semicolon must be on a new line", true),
+            DiktatError(2, 10, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
         )
     }
 
@@ -82,9 +82,9 @@ class EnumsSeparatedWarnTest : LintTestBase(::EnumsSeparated) {
                     |   C
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
-            LintError(3, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enums must end with semicolon", true),
-            LintError(3, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
+            DiktatError(2, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
+            DiktatError(3, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enums must end with semicolon", true),
+            DiktatError(3, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
         )
     }
 
@@ -98,8 +98,8 @@ class EnumsSeparatedWarnTest : LintTestBase(::EnumsSeparated) {
                     |   C, ;
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
-            LintError(3, 4, ruleId, "${ENUMS_SEPARATED.warnText()} semicolon must be on a new line", true)
+            DiktatError(2, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enum entries must end with a line break", true),
+            DiktatError(3, 4, ruleId, "${ENUMS_SEPARATED.warnText()} semicolon must be on a new line", true)
         )
     }
 
@@ -130,7 +130,7 @@ class EnumsSeparatedWarnTest : LintTestBase(::EnumsSeparated) {
                     |   ;
                     |}
             """.trimMargin(),
-            LintError(4, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
+            DiktatError(4, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
         )
     }
 
@@ -168,8 +168,8 @@ class EnumsSeparatedWarnTest : LintTestBase(::EnumsSeparated) {
                     |   abstract fun signal(): ProtocolState
                     |}
             """.trimMargin(),
-            LintError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} semicolon must be on a new line", true),
-            LintError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
+            DiktatError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} semicolon must be on a new line", true),
+            DiktatError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
         )
     }
 
@@ -187,8 +187,8 @@ class EnumsSeparatedWarnTest : LintTestBase(::EnumsSeparated) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enums must end with semicolon", true),
-            LintError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
+            DiktatError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} enums must end with semicolon", true),
+            DiktatError(5, 4, ruleId, "${ENUMS_SEPARATED.warnText()} last enum entry must end with a comma", true)
 
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileSizeWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileSizeWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.files.FileSize
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -46,7 +46,7 @@ class FileSizeWarnTest : LintTestBase(::FileSize) {
             .split("\n")
             .size
         lintMethodWithFile(file.toPath(),
-            LintError(1, 1, ruleId,
+            DiktatError(1, 1, ruleId,
                 "${Warnings.FILE_IS_TOO_LONG.warnText()} $size", false),
             rulesConfigList = rulesConfigListLarge)
     }
@@ -66,7 +66,7 @@ class FileSizeWarnTest : LintTestBase(::FileSize) {
         val file = File(path!!.file)
         val size = generate2000lines() + 1
         lintMethodWithFile(file.toPath(),
-            LintError(1, 1, ruleId,
+            DiktatError(1, 1, ruleId,
                 "${Warnings.FILE_IS_TOO_LONG.warnText()} $size", false),
             rulesConfigList = rulesConfigListLarge)
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
@@ -11,7 +11,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.FILE_WILDCARD_IMPORTS
 import org.cqfn.diktat.ruleset.rules.chapter3.files.FileStructureRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
@@ -47,7 +47,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |
                 |// lorem ipsum
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${FILE_CONTAINS_ONLY_COMMENTS.warnText()} file contains no code", false)
+            DiktatError(1, 1, ruleId, "${FILE_CONTAINS_ONLY_COMMENTS.warnText()} file contains no code", false)
         )
     }
 
@@ -66,8 +66,8 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |
                 |class Example { }
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} @file:JvmName(\"Foo\")", true),
-            LintError(3, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} /**", true)
+            DiktatError(1, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} @file:JvmName(\"Foo\")", true),
+            DiktatError(3, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} /**", true)
         )
     }
 
@@ -86,7 +86,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |val y: Foo = null
                 |}
             """.trimMargin(),
-            LintError(3, 1, ruleId, "${FILE_UNORDERED_IMPORTS.warnText()} import org.cqfn.diktat.Foo...", true)
+            DiktatError(3, 1, ruleId, "${FILE_UNORDERED_IMPORTS.warnText()} import org.cqfn.diktat.Foo...", true)
         )
     }
 
@@ -101,7 +101,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |
                 |class Example { }
             """.trimMargin(),
-            LintError(3, 1, ruleId, "${FILE_WILDCARD_IMPORTS.warnText()} import org.cqfn.diktat.*", false),
+            DiktatError(3, 1, ruleId, "${FILE_WILDCARD_IMPORTS.warnText()} import org.cqfn.diktat.*", false),
         )
     }
 
@@ -122,10 +122,10 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |val x: Foo = null
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} /**", true),
-            LintError(4, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} @file:JvmName(\"Foo\")", true),
-            LintError(7, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} package org.cqfn.diktat.example", true),
-            LintError(8, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} import org.cqfn.diktat.Foo", true)
+            DiktatError(1, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} /**", true),
+            DiktatError(4, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} @file:JvmName(\"Foo\")", true),
+            DiktatError(7, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} package org.cqfn.diktat.example", true),
+            DiktatError(8, 1, ruleId, "${FILE_NO_BLANK_LINE_BETWEEN_BLOCKS.warnText()} import org.cqfn.diktat.Foo", true)
         )
     }
 
@@ -197,8 +197,8 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |val x: Foo = null
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} // some notes on this file", true),
-            LintError(2, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} /**", true),
+            DiktatError(1, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} // some notes on this file", true),
+            DiktatError(2, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} /**", true),
         )
     }
 
@@ -242,7 +242,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |val x: Foo = null
                 |}
             """.trimMargin(),
-            LintError(4, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} @file:Annotation", true)
+            DiktatError(4, 1, ruleId, "${FILE_INCORRECT_BLOCKS_ORDER.warnText()} @file:Annotation", true)
         )
     }
 
@@ -261,7 +261,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |val x: Foo = null
                 |}
             """.trimMargin(),
-            LintError(3, 1, ruleId, "${FILE_UNORDERED_IMPORTS.warnText()} import com.pinterest.ktlint.core.LintError...", true),
+            DiktatError(3, 1, ruleId, "${FILE_UNORDERED_IMPORTS.warnText()} import com.pinterest.ktlint.core.LintError...", true),
             rulesConfigList = rulesConfigListEmptyDomainName
         )
     }
@@ -278,7 +278,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |class Example {
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} org.cqfn.diktat.example.Foo - unused import", true)
+            DiktatError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} org.cqfn.diktat.example.Foo - unused import", true)
         )
     }
 
@@ -294,7 +294,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |class Example {
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} org.cqfn.diktat.Foo - unused import", true)
+            DiktatError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} org.cqfn.diktat.Foo - unused import", true)
         )
     }
 
@@ -360,7 +360,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |println("Type is not supported yet")
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} org.cqfn.diktat.utils.logAndExit - unused import", true)
+            DiktatError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} org.cqfn.diktat.utils.logAndExit - unused import", true)
         )
     }
 
@@ -458,8 +458,8 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |   val a: Foo
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} Delegate - unused import", true),
-            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} com.example.equals - unused import", true)
+            DiktatError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} Delegate - unused import", true),
+            DiktatError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} com.example.equals - unused import", true)
         )
     }
 
@@ -481,7 +481,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |   val a
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} tasks.getValue - unused import", true)
+            DiktatError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} tasks.getValue - unused import", true)
         )
     }
 
@@ -578,7 +578,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
             """.trimIndent(),
             fileName = "build.gradle.kts",
             tempDir = tempDir,
-            expectedLintErrors = arrayOf(LintError(3, 1, ruleId, "${Warnings.FILE_INCORRECT_BLOCKS_ORDER.warnText()} @file:Suppress(\"DSL_SCOPE_VIOLATION\")", true)),
+            expectedLintErrors = arrayOf(DiktatError(3, 1, ruleId, "${Warnings.FILE_INCORRECT_BLOCKS_ORDER.warnText()} @file:Suppress(\"DSL_SCOPE_VIOLATION\")", true)),
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
@@ -8,7 +8,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.LONG_LINE
 import org.cqfn.diktat.ruleset.rules.chapter3.LineLength
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -83,7 +83,7 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(8, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 163", false)
+            DiktatError(8, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 163", false)
         )
     }
 
@@ -141,8 +141,8 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(14, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 143", true),
-            LintError(18, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 142", true)
+            DiktatError(14, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 143", true),
+            DiktatError(18, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 142", true)
         )
     }
 
@@ -172,7 +172,7 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(9, 1, ruleId, "${LONG_LINE.warnText()} max line length 163, but was 195", false),
+            DiktatError(9, 1, ruleId, "${LONG_LINE.warnText()} max line length 163, but was 195", false),
             rulesConfigList = rulesConfigListLineLength
         )
     }
@@ -222,8 +222,8 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(8, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 130", false),
-            LintError(9, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 123", true)
+            DiktatError(8, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 130", false),
+            DiktatError(9, 1, ruleId, "${LONG_LINE.warnText()} max line length 120, but was 123", true)
 
         )
     }
@@ -236,8 +236,8 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
                     |@Query(value = "ASDAASDASDASDASDASDASDASDAASDASDASDASDASDASDASDAASDASDASDASDASDASD")
                     |fun foo() = println("ASDAASDASDASDASDASDASDASDAASDASDASDASDASDASDASDAASDASDASDASDASDASD")
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${LONG_LINE.warnText()} max line length 40, but was 84", true),
-            LintError(2, 1, ruleId, "${LONG_LINE.warnText()} max line length 40, but was 89", true),
+            DiktatError(1, 1, ruleId, "${LONG_LINE.warnText()} max line length 40, but was 84", true),
+            DiktatError(2, 1, ruleId, "${LONG_LINE.warnText()} max line length 40, but was 89", true),
             rulesConfigList = shortLineLength
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LocalVariablesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LocalVariablesWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.identifiers.LocalVariablesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.LOCAL_VARIABLE_EARLY_DECLARATION
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
@@ -125,7 +125,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    baz(bar)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 4)}", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 4)}", false)
         )
     }
 
@@ -155,7 +155,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    baz(bar)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 5)}", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 5)}", false)
         )
     }
 
@@ -171,7 +171,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    baz(bar)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 5)}", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 5)}", false)
         )
     }
 
@@ -187,7 +187,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    baz(bar)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 5)}", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("bar", 2, 5)}", false)
         )
     }
 
@@ -206,7 +206,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} val bar = 0", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} val bar = 0", false)
         )
     }
 
@@ -248,7 +248,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} val bar = 0", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} val bar = 0", false)
         )
     }
 
@@ -400,7 +400,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("x", 2, 5)}", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("x", 2, 5)}", false)
         )
     }
 
@@ -418,7 +418,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("x", 2, 6)}", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("x", 2, 6)}", false)
         )
     }
 
@@ -435,7 +435,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(3, 9, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("foo", 3, 5)}", false)
+            DiktatError(3, 9, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("foo", 3, 5)}", false)
         )
     }
 
@@ -514,7 +514,7 @@ class LocalVariablesWarnTest : LintTestBase(::LocalVariablesRule) {
                     |    bar(list)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("list", 2, 4)}", false)
+            DiktatError(2, 5, ruleId, "${Warnings.LOCAL_VARIABLE_EARLY_DECLARATION.warnText()} ${warnMessage("list", 2, 4)}", false)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LongNumericalValuesSeparatedWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LongNumericalValuesSeparatedWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.LongNumericalValuesSeparatedRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.LONG_NUMERICAL_VALUES_SEPARATED
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -35,17 +35,17 @@ class LongNumericalValuesSeparatedWarnTest : LintTestBase(::LongNumericalValuesS
                     |   val hundred = 100
                     |}
             """.trimMargin(),
-            LintError(2, 21, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 100000000000", true),
-            LintError(3, 27, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 1234567890123456L", true),
-            LintError(4, 31, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 999999999L", true),
-            LintError(5, 19, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 0xFFECDE5E", true),
-            LintError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 110100110", false),
-            LintError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 01101001", false),
-            LintError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 10010100", false),
-            LintError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 10010010", false),
-            LintError(8, 14, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 192.312341341344355345", true),
-            LintError(9, 15, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 31234134134435", false),
-            LintError(9, 15, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 5345", false)
+            DiktatError(2, 21, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 100000000000", true),
+            DiktatError(3, 27, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 1234567890123456L", true),
+            DiktatError(4, 31, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 999999999L", true),
+            DiktatError(5, 19, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 0xFFECDE5E", true),
+            DiktatError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 110100110", false),
+            DiktatError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 01101001", false),
+            DiktatError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 10010100", false),
+            DiktatError(7, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 10010010", false),
+            DiktatError(8, 14, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 192.312341341344355345", true),
+            DiktatError(9, 15, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 31234134134435", false),
+            DiktatError(9, 15, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} this block is too long 5345", false)
 
         )
     }
@@ -82,12 +82,12 @@ class LongNumericalValuesSeparatedWarnTest : LintTestBase(::LongNumericalValuesS
                     |   val flo = 192.312
                     |}
             """.trimMargin(),
-            LintError(2, 21, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 100", true),
-            LintError(3, 27, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 1234566L", true),
-            LintError(4, 31, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 999L", true),
-            LintError(5, 19, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 0xFFE", true),
-            LintError(6, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 0b110100", true),
-            LintError(7, 14, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 192.312", true),
+            DiktatError(2, 21, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 100", true),
+            DiktatError(3, 27, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 1234566L", true),
+            DiktatError(4, 31, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 999L", true),
+            DiktatError(5, 19, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 0xFFE", true),
+            DiktatError(6, 16, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 0b110100", true),
+            DiktatError(7, 14, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 192.312", true),
             rulesConfigList = rulesConfig
         )
     }
@@ -113,7 +113,7 @@ class LongNumericalValuesSeparatedWarnTest : LintTestBase(::LongNumericalValuesS
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 19, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 100000000", true)
+            DiktatError(1, 19, ruleId, "${Warnings.LONG_NUMERICAL_VALUES_SEPARATED.warnText()} 100000000", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/MagicNumberRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/MagicNumberRuleWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.MAGIC_NUMBER
 import org.cqfn.diktat.ruleset.rules.chapter3.MagicNumberRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -62,11 +62,11 @@ class MagicNumberRuleWarnTest : LintTestBase(::MagicNumberRule) {
                 |   }
                 |}
             """.trimMargin(),
-            LintError(2, 18, ruleId, "${MAGIC_NUMBER.warnText()} 4", false),
-            LintError(3, 12, ruleId, "${MAGIC_NUMBER.warnText()} 128L", false),
-            LintError(4, 12, ruleId, "${MAGIC_NUMBER.warnText()} 3.4f", false),
-            LintError(5, 12, ruleId, "${MAGIC_NUMBER.warnText()} 4", false),
-            LintError(5, 14, ruleId, "${MAGIC_NUMBER.warnText()} 3", false)
+            DiktatError(2, 18, ruleId, "${MAGIC_NUMBER.warnText()} 4", false),
+            DiktatError(3, 12, ruleId, "${MAGIC_NUMBER.warnText()} 128L", false),
+            DiktatError(4, 12, ruleId, "${MAGIC_NUMBER.warnText()} 3.4f", false),
+            DiktatError(5, 12, ruleId, "${MAGIC_NUMBER.warnText()} 4", false),
+            DiktatError(5, 14, ruleId, "${MAGIC_NUMBER.warnText()} 3", false)
         )
     }
 
@@ -91,10 +91,10 @@ class MagicNumberRuleWarnTest : LintTestBase(::MagicNumberRule) {
                 |   return 32
                 |}
             """.trimMargin(),
-            LintError(2, 13, ruleId, "${MAGIC_NUMBER.warnText()} -1", false),
-            LintError(3, 18, ruleId, "${MAGIC_NUMBER.warnText()} 4", false),
-            LintError(4, 12, ruleId, "${MAGIC_NUMBER.warnText()} 0xff", false),
-            LintError(10, 6, ruleId, "${MAGIC_NUMBER.warnText()} 3", false),
+            DiktatError(2, 13, ruleId, "${MAGIC_NUMBER.warnText()} -1", false),
+            DiktatError(3, 18, ruleId, "${MAGIC_NUMBER.warnText()} 4", false),
+            DiktatError(4, 12, ruleId, "${MAGIC_NUMBER.warnText()} 0xff", false),
+            DiktatError(10, 6, ruleId, "${MAGIC_NUMBER.warnText()} 3", false),
             rulesConfigList = rulesConfigIgnoreNumbersMagicNumber
         )
     }
@@ -112,7 +112,7 @@ class MagicNumberRuleWarnTest : LintTestBase(::MagicNumberRule) {
                 |
                 |}
             """.trimMargin(),
-            LintError(3, 21, ruleId, "${MAGIC_NUMBER.warnText()} 32", false),
+            DiktatError(3, 21, ruleId, "${MAGIC_NUMBER.warnText()} 32", false),
         )
     }
 
@@ -169,7 +169,7 @@ class MagicNumberRuleWarnTest : LintTestBase(::MagicNumberRule) {
                     var elementsCount: Int = 100
                 )
             """.trimMargin(),
-            LintError(2, 46, ruleId, "${MAGIC_NUMBER.warnText()} 100", false),
+            DiktatError(2, 46, ruleId, "${MAGIC_NUMBER.warnText()} 100", false),
             rulesConfigList = rulesConfigMagicNumber
         )
     }
@@ -181,7 +181,7 @@ class MagicNumberRuleWarnTest : LintTestBase(::MagicNumberRule) {
             """
                 fun TomlDecoder(elementsCount: Int = 100) {}
             """.trimMargin(),
-            LintError(1, 54, ruleId, "${MAGIC_NUMBER.warnText()} 100", false),
+            DiktatError(1, 54, ruleId, "${MAGIC_NUMBER.warnText()} 100", false),
             rulesConfigList = rulesConfigMagicNumber
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/MultipleModifiersSequenceWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/MultipleModifiersSequenceWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_MULTIPLE_MODIFIERS_ORDER
 import org.cqfn.diktat.ruleset.rules.chapter3.MultipleModifiersSequence
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -23,10 +23,10 @@ class MultipleModifiersSequenceWarnTest : LintTestBase(::MultipleModifiersSequen
                     |   lateinit open protected var a: List<ASTNode>
                     |}
             """.trimMargin(),
-            LintError(2, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} final should be on position 2, but is on position 1", true),
-            LintError(2, 7, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} public should be on position 1, but is on position 2", true),
-            LintError(3, 4, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} lateinit should be on position 3, but is on position 1", true),
-            LintError(3, 18, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} protected should be on position 1, but is on position 3", true)
+            DiktatError(2, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} final should be on position 2, but is on position 1", true),
+            DiktatError(2, 7, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} public should be on position 1, but is on position 2", true),
+            DiktatError(3, 4, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} lateinit should be on position 3, but is on position 1", true),
+            DiktatError(3, 18, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} protected should be on position 1, but is on position 3", true)
         )
     }
 
@@ -57,10 +57,10 @@ class MultipleModifiersSequenceWarnTest : LintTestBase(::MultipleModifiersSequen
                     |
                     |inline  fun < reified T> membersOf() = T::class.members
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} inline should be on position 3, but is on position 1", true),
-            LintError(1, 16, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} public should be on position 1, but is on position 3", true),
-            LintError(3, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} inline should be on position 2, but is on position 1", true),
-            LintError(3, 8, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} suspend should be on position 1, but is on position 2", true)
+            DiktatError(1, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} inline should be on position 3, but is on position 1", true),
+            DiktatError(1, 16, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} public should be on position 1, but is on position 3", true),
+            DiktatError(3, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} inline should be on position 2, but is on position 1", true),
+            DiktatError(3, 8, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} suspend should be on position 1, but is on position 2", true)
         )
     }
 
@@ -77,12 +77,12 @@ class MultipleModifiersSequenceWarnTest : LintTestBase(::MultipleModifiersSequen
                     |      }
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} enum should be on position 2, but is on position 1", true),
-            LintError(1, 6, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} public should be on position 1, but is on position 2", true),
-            LintError(3, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} data should be on position 2, but is on position 1", true),
-            LintError(3, 6, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} protected should be on position 1, but is on position 2", true),
-            LintError(4, 4, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} operator should be on position 2, but is on position 1", true),
-            LintError(4, 13, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} suspend should be on position 1, but is on position 2", true)
+            DiktatError(1, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} enum should be on position 2, but is on position 1", true),
+            DiktatError(1, 6, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} public should be on position 1, but is on position 2", true),
+            DiktatError(3, 1, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} data should be on position 2, but is on position 1", true),
+            DiktatError(3, 6, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} protected should be on position 1, but is on position 2", true),
+            DiktatError(4, 4, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} operator should be on position 2, but is on position 1", true),
+            DiktatError(4, 13, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} suspend should be on position 1, but is on position 2", true)
         )
     }
 
@@ -94,7 +94,7 @@ class MultipleModifiersSequenceWarnTest : LintTestBase(::MultipleModifiersSequen
                     |public @Annotation final fun foo() {
                     |}
             """.trimMargin(),
-            LintError(1, 8, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} @Annotation annotation should be before all modifiers", true)
+            DiktatError(1, 8, ruleId, "${WRONG_MULTIPLE_MODIFIERS_ORDER.warnText()} @Annotation annotation should be before all modifiers", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/NullableTypeRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/NullableTypeRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.NULLABLE_PROPERTY_TYPE
 import org.cqfn.diktat.ruleset.rules.chapter3.NullableTypeRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -24,11 +24,11 @@ class NullableTypeRuleWarnTest : LintTestBase(::NullableTypeRule) {
                     |val c: String? = null
                     |val a: MutableList<Int>? = null
             """.trimMargin(),
-            LintError(1, 21, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
-            LintError(2, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
-            LintError(3, 18, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
-            LintError(4, 18, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
-            LintError(5, 28, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true)
+            DiktatError(1, 21, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
+            DiktatError(2, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
+            DiktatError(3, 18, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
+            DiktatError(4, 18, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
+            DiktatError(5, 28, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true)
         )
     }
 
@@ -45,9 +45,9 @@ class NullableTypeRuleWarnTest : LintTestBase(::NullableTypeRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(3, 22, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
-            LintError(4, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false),
-            LintError(5, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false)
+            DiktatError(3, 22, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
+            DiktatError(4, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false),
+            DiktatError(5, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false)
         )
     }
 
@@ -64,9 +64,9 @@ class NullableTypeRuleWarnTest : LintTestBase(::NullableTypeRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(3, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false),
-            LintError(4, 22, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
-            LintError(5, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false)
+            DiktatError(3, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false),
+            DiktatError(4, 22, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", true),
+            DiktatError(5, 15, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false)
         )
     }
 
@@ -81,7 +81,7 @@ class NullableTypeRuleWarnTest : LintTestBase(::NullableTypeRule) {
                     |   val e: A.Q? = null
                     |}
             """.trimMargin(),
-            LintError(4, 18, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", false)
+            DiktatError(4, 18, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} initialize explicitly", false)
         )
     }
 
@@ -95,8 +95,8 @@ class NullableTypeRuleWarnTest : LintTestBase(::NullableTypeRule) {
                     | val c: Set<Int>? = setOf()
                     | val d: List<Int?> = emptyList()
             """.trimMargin(),
-            LintError(1, 9, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false),
-            LintError(3, 9, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false)
+            DiktatError(1, 9, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false),
+            DiktatError(3, 9, ruleId, "${NULLABLE_PROPERTY_TYPE.warnText()} don't use nullable type", false)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/RangeConventionalRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/RangeConventionalRuleWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.RangeConventionalRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import org.junit.jupiter.api.Test
 
 class RangeConventionalRuleWarnTest : LintTestBase(::RangeConventionalRule) {
@@ -33,10 +33,10 @@ class RangeConventionalRuleWarnTest : LintTestBase(::RangeConventionalRule) {
                     |    for (i in 1..(4 - 1) step 3) print(i)
                     |}
             """.trimMargin(),
-            LintError(2, 15, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1..(4 - 1)", true),
-            LintError(3, 15, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1..(b - 1)", true),
-            LintError(4, 17, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1 .. ((4 - 1))", true),
-            LintError(10, 15, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1..(4 - 1)", true)
+            DiktatError(2, 15, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1..(4 - 1)", true),
+            DiktatError(3, 15, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1..(b - 1)", true),
+            DiktatError(4, 17, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1 .. ((4 - 1))", true),
+            DiktatError(10, 15, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `..` with `until`: 1..(4 - 1)", true)
         )
     }
 
@@ -51,7 +51,7 @@ class RangeConventionalRuleWarnTest : LintTestBase(::RangeConventionalRule) {
                     |    val w = num.rangeTo(num)
                     |}
             """.trimMargin(),
-            LintError(5, 13, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `rangeTo` with `..`: num.rangeTo(num)", true)
+            DiktatError(5, 13, ruleId, "${Warnings.CONVENTIONAL_RANGE.warnText()} replace `rangeTo` with `..`: num.rangeTo(num)", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/SingleLineStatementsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/SingleLineStatementsRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.MORE_THAN_ONE_STATEMENT_PER_LI
 import org.cqfn.diktat.ruleset.rules.chapter3.SingleLineStatementsRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -35,10 +35,10 @@ class SingleLineStatementsRuleWarnTest : LintTestBase(::SingleLineStatementsRule
                     |    println(1); println(1)
                     |}
             """.trimMargin(),
-            LintError(1, 40, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} import com.pinterest.ktlint.core.KtLint; import com.pinterest.ktlint.core.LintError", true),
-            LintError(5, 13, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} goo(); hoo()", true),
-            LintError(14, 14, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} val a = 5; val b = 10", true),
-            LintError(15, 15, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} println(1); println(1)", true)
+            DiktatError(1, 40, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} import com.pinterest.ktlint.core.KtLint; import com.pinterest.ktlint.core.LintError", true),
+            DiktatError(5, 13, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} goo(); hoo()", true),
+            DiktatError(14, 14, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} val a = 5; val b = 10", true),
+            DiktatError(15, 15, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} println(1); println(1)", true)
         )
     }
 
@@ -52,8 +52,8 @@ class SingleLineStatementsRuleWarnTest : LintTestBase(::SingleLineStatementsRule
                     |    println(1);println(1)
                     |}
             """.trimMargin(),
-            LintError(2, 14, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} val a = 5;val b = 10", true),
-            LintError(3, 15, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} println(1);println(1)", true)
+            DiktatError(2, 14, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} val a = 5;val b = 10", true),
+            DiktatError(3, 15, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} println(1);println(1)", true)
         )
     }
 
@@ -68,7 +68,7 @@ class SingleLineStatementsRuleWarnTest : LintTestBase(::SingleLineStatementsRule
                     |   }; else { print(123) }
                     |}
             """.trimMargin(),
-            LintError(4, 5, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; else { print(123) }", true)
+            DiktatError(4, 5, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; else { print(123) }", true)
         )
     }
 
@@ -111,7 +111,7 @@ class SingleLineStatementsRuleWarnTest : LintTestBase(::SingleLineStatementsRule
                     |   }; abstract fun signal(): ProtocolState
                     |}
             """.trimMargin(),
-            LintError(7, 5, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; abstract fun signal(): ProtocolState", true)
+            DiktatError(7, 5, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; abstract fun signal(): ProtocolState", true)
         )
     }
 
@@ -128,8 +128,8 @@ class SingleLineStatementsRuleWarnTest : LintTestBase(::SingleLineStatementsRule
                     |   }; gr()
                     |}
             """.trimMargin(),
-            LintError(5, 9, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; gt()", true),
-            LintError(6, 5, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; gr()", true)
+            DiktatError(5, 9, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; gt()", true),
+            DiktatError(6, 5, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} }; gr()", true)
         )
     }
 
@@ -142,7 +142,7 @@ class SingleLineStatementsRuleWarnTest : LintTestBase(::SingleLineStatementsRule
                     |   ; grr()
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} ; grr()", true)
+            DiktatError(2, 4, ruleId, "${MORE_THAN_ONE_STATEMENT_PER_LINE.warnText()} ; grr()", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/SortRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/SortRuleWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_DECLARATIONS_ORDER
 import org.cqfn.diktat.ruleset.rules.chapter3.SortRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -55,7 +55,7 @@ class SortRuleWarnTest : LintTestBase(::SortRule) {
                     |   ;
                     |}
             """.trimMargin(),
-            LintError(1, 17, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
+            DiktatError(1, 17, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
         )
     }
 
@@ -85,7 +85,7 @@ class SortRuleWarnTest : LintTestBase(::SortRule) {
                     |   BLUE(0x0000FF),
                     |}
             """.trimMargin(),
-            LintError(1, 17, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
+            DiktatError(1, 17, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
         )
     }
 
@@ -100,7 +100,7 @@ class SortRuleWarnTest : LintTestBase(::SortRule) {
                     |   BLUE(0x0000FF)
                     |}
             """.trimMargin(),
-            LintError(1, 17, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
+            DiktatError(1, 17, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
         )
     }
 
@@ -134,7 +134,7 @@ class SortRuleWarnTest : LintTestBase(::SortRule) {
                     |   abstract fun signal(): ProtocolState
                     |}
             """.trimMargin(),
-            LintError(1, 21, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
+            DiktatError(1, 21, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} enum entries order is incorrect", true)
         )
     }
 
@@ -172,7 +172,7 @@ class SortRuleWarnTest : LintTestBase(::SortRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(4, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true)
+            DiktatError(4, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true)
         )
     }
 
@@ -193,8 +193,8 @@ class SortRuleWarnTest : LintTestBase(::SortRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(4, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true),
-            LintError(7, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true)
+            DiktatError(4, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true),
+            DiktatError(7, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true)
         )
     }
 
@@ -215,7 +215,7 @@ class SortRuleWarnTest : LintTestBase(::SortRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(7, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true)
+            DiktatError(7, 8, ruleId, "${WRONG_DECLARATIONS_ORDER.warnText()} constant properties inside companion object order is incorrect", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringConcatenationWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringConcatenationWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.StringConcatenationRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = "my string" + "string" + value + "other value"
                     |
             """.trimMargin(),
-            LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " \"my string\" + \"string\" + value + \"other value\"", canBeAutoCorrected)
         )
     }
@@ -35,7 +35,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = "my string" + 1 + 2 + 3
                     |
             """.trimMargin(),
-            LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " \"my string\" + 1 + 2 + 3", canBeAutoCorrected)
         )
     }
@@ -49,7 +49,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = (1 + 2).toString() + "my string" + 3
                     |
             """.trimMargin(),
-            LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " (1 + 2).toString() + \"my string\" + 3", canBeAutoCorrected)
         )
     }
@@ -63,7 +63,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = (1 + 2).toString() + "my string" + 3 + "string" + myObject + myObject
                     |
             """.trimMargin(),
-            LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " (1 + 2).toString() + \"my string\" + 3 + \"string\" + myObject + myObject", canBeAutoCorrected)
         )
     }
@@ -77,7 +77,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = (1 + 2).toString() + "my string" + ("string" + myObject) + myObject
                     |
             """.trimMargin(),
-            LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " (1 + 2).toString() + \"my string\" + (\"string\" + myObject) + myObject", canBeAutoCorrected)
         )
     }
@@ -91,7 +91,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     |     foo("my string" + "other string" + (1 + 2 + 3))
                     | }
             """.trimMargin(),
-            LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
@@ -105,7 +105,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = "my string" + "other string" + (1 + 2 + 3)
                     |
             """.trimMargin(),
-            LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " \"my string\" + \"other string\" + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
@@ -119,7 +119,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = "my string" + (1 + 2 + 3) + ("other string" + 3) + (1 + 2 + 3)
                     |
             """.trimMargin(),
-            LintError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(2, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + 2 + 3)", canBeAutoCorrected)
         )
     }
@@ -132,7 +132,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = "my string" + (1 + 2 + 3) + ("other string" + 3) + (1 + (2 + 3)) + ("third string" + ("str" + 5))
                     |
             """.trimMargin(),
-            LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " \"my string\" + (1 + 2 + 3) + (\"other string\" + 3) + (1 + (2 + 3)) +" +
                     " (\"third string\" + (\"str\" + 5))", canBeAutoCorrected)
         )
@@ -146,7 +146,7 @@ class StringConcatenationWarnTest : LintTestBase(::StringConcatenationRule) {
                     | val a = "my string" + ("third string" + ("str" + 5 * 12 / 100))
                     |
             """.trimMargin(),
-            LintError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
+            DiktatError(1, 10, ruleId, Warnings.STRING_CONCATENATION.warnText() +
                     " \"my string\" + (\"third string\" + (\"str\" + 5 * 12 / 100))", canBeAutoCorrected)
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringTemplateRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/StringTemplateRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.StringTemplateFormatRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.STRING_TEMPLATE_CURLY_BRACES
 import generated.WarningNames.STRING_TEMPLATE_QUOTES
 import org.junit.jupiter.api.Tag
@@ -40,11 +40,11 @@ class StringTemplateRuleWarnTest : LintTestBase(::StringTemplateFormatRule) {
                     |   val digitsWithLetters = "${'$'}{1.0}asd"
                     |}
             """.trimMargin(),
-            LintError(2, 20, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{a}", true),
-            LintError(3, 16, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{1.0}", true),
-            LintError(4, 19, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{1}", true),
-            LintError(5, 28, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{ref}", true),
-            LintError(6, 29, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{1.0}", true)
+            DiktatError(2, 20, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{a}", true),
+            DiktatError(3, 16, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{1.0}", true),
+            DiktatError(4, 19, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{1}", true),
+            DiktatError(5, 28, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{ref}", true),
+            DiktatError(6, 29, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{1.0}", true)
         )
     }
 
@@ -58,7 +58,7 @@ class StringTemplateRuleWarnTest : LintTestBase(::StringTemplateFormatRule) {
                     |   val z = a
                     |}
             """.trimMargin(),
-            LintError(2, 20, ruleId, "${Warnings.STRING_TEMPLATE_QUOTES.warnText()} ${'$'}a", true)
+            DiktatError(2, 20, ruleId, "${Warnings.STRING_TEMPLATE_QUOTES.warnText()} ${'$'}a", true)
         )
     }
 
@@ -74,7 +74,7 @@ class StringTemplateRuleWarnTest : LintTestBase(::StringTemplateFormatRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(4, 17, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{s}", true)
+            DiktatError(4, 17, ruleId, "${Warnings.STRING_TEMPLATE_CURLY_BRACES.warnText()} ${'$'}{s}", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/TrailingCommaWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/TrailingCommaWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TRAILING_COMMA
 import org.cqfn.diktat.ruleset.rules.chapter3.TrailingCommaRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -38,8 +38,8 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                     )
                 }
             """.trimMargin(),
-            LintError(4, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_ARGUMENT: 20", true),
-            LintError(10, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_ARGUMENT: \"blue\"", true),
+            DiktatError(4, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_ARGUMENT: 20", true),
+            DiktatError(10, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_ARGUMENT: \"blue\"", true),
             rulesConfigList = getRulesConfig("valueArgument")
         )
     }
@@ -59,8 +59,8 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                     lastName: String // trailing comma
                 )
             """.trimMargin(),
-            LintError(3, 21, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: val lastName: String // trailing comma", true),
-            LintError(8, 21, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: lastName: String // trailing comma", true),
+            DiktatError(3, 21, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: val lastName: String // trailing comma", true),
+            DiktatError(8, 21, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: lastName: String // trailing comma", true),
             rulesConfigList = getRulesConfig("valueParameter")
         )
     }
@@ -90,8 +90,8 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                     ) {}
                 }
             """.trimMargin(),
-            LintError(12, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: y: Iterable<Number>", true),
-            LintError(17, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: description: String", true),
+            DiktatError(12, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: y: Iterable<Number>", true),
+            DiktatError(17, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: description: String", true),
             rulesConfigList = getRulesConfig("valueParameter")
         )
     }
@@ -112,7 +112,7 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                     println(sum(8, 8, 8))
                 }
             """.trimMargin(),
-            LintError(5, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: z // trailing comma", true),
+            DiktatError(5, 25, ruleId, "${TRAILING_COMMA.warnText()} after VALUE_PARAMETER: z // trailing comma", true),
             rulesConfigList = getRulesConfig("valueParameter")
         )
     }
@@ -131,7 +131,7 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                         yValue // trailing comma
                     ]
             """.trimMargin(),
-            LintError(7, 25, ruleId, "${TRAILING_COMMA.warnText()} after REFERENCE_EXPRESSION: yValue", true),
+            DiktatError(7, 25, ruleId, "${TRAILING_COMMA.warnText()} after REFERENCE_EXPRESSION: yValue", true),
             rulesConfigList = getRulesConfig("referenceExpression")
         )
     }
@@ -188,9 +188,9 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                    when (x) {}
                }
             """.trimMargin(),
-            LintError(4, 21, ruleId, "${TRAILING_COMMA.warnText()} after WHEN_CONDITION_WITH_EXPRESSION: String::class", true),
-            LintError(12, 24, ruleId, "${TRAILING_COMMA.warnText()} after WHEN_CONDITION_IS_PATTERN: is String", true),
-            LintError(20, 24, ruleId, "${TRAILING_COMMA.warnText()} after WHEN_CONDITION_IN_RANGE: in 1..2", true),
+            DiktatError(4, 21, ruleId, "${TRAILING_COMMA.warnText()} after WHEN_CONDITION_WITH_EXPRESSION: String::class", true),
+            DiktatError(12, 24, ruleId, "${TRAILING_COMMA.warnText()} after WHEN_CONDITION_IS_PATTERN: is String", true),
+            DiktatError(20, 24, ruleId, "${TRAILING_COMMA.warnText()} after WHEN_CONDITION_IN_RANGE: in 1..2", true),
             rulesConfigList = getRulesConfig("whenConditions")
         )
     }
@@ -210,7 +210,7 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                 ],)
                 fun foo() {}
             """.trimMargin(),
-            LintError(7, 21, ruleId, "${TRAILING_COMMA.warnText()} after STRING_TEMPLATE: \"inMemoryCache\"", true),
+            DiktatError(7, 21, ruleId, "${TRAILING_COMMA.warnText()} after STRING_TEMPLATE: \"inMemoryCache\"", true),
             rulesConfigList = getRulesConfig("collectionLiteral")
         )
     }
@@ -230,8 +230,8 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                             >()
                 }
             """.trimMargin(),
-            LintError(6, 29, ruleId, "${TRAILING_COMMA.warnText()} after TYPE_PROJECTION: Iterable<Number...", true),
-            LintError(6, 38, ruleId, "${TRAILING_COMMA.warnText()} after TYPE_PROJECTION: Number", true),
+            DiktatError(6, 29, ruleId, "${TRAILING_COMMA.warnText()} after TYPE_PROJECTION: Iterable<Number...", true),
+            DiktatError(6, 38, ruleId, "${TRAILING_COMMA.warnText()} after TYPE_PROJECTION: Number", true),
             rulesConfigList = getRulesConfig("typeArgument")
         )
     }
@@ -246,7 +246,7 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                         MyValue // trailing comma
                         > {}
             """.trimMargin(),
-            LintError(3, 25, ruleId, "${TRAILING_COMMA.warnText()} after TYPE_PARAMETER: MyValue", true),
+            DiktatError(3, 25, ruleId, "${TRAILING_COMMA.warnText()} after TYPE_PARAMETER: MyValue", true),
             rulesConfigList = getRulesConfig("typeParameter")
         )
     }
@@ -281,8 +281,8 @@ class TrailingCommaWarnTest : LintTestBase(::TrailingCommaRule) {
                     printMeanValue()
                 }
             """.trimMargin(),
-            LintError(8, 25, ruleId, "${TRAILING_COMMA.warnText()} after DESTRUCTURING_DECLARATION_ENTRY: year", true),
-            LintError(17, 29, ruleId, "${TRAILING_COMMA.warnText()} after DESTRUCTURING_DECLARATION_ENTRY: year", true),
+            DiktatError(8, 25, ruleId, "${TRAILING_COMMA.warnText()} after DESTRUCTURING_DECLARATION_ENTRY: year", true),
+            DiktatError(17, 29, ruleId, "${TRAILING_COMMA.warnText()} after DESTRUCTURING_DECLARATION_ENTRY: year", true),
             rulesConfigList = getRulesConfig("destructuringDeclaration")
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/WhenMustHaveElseWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/WhenMustHaveElseWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.WhenMustHaveElseRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -40,7 +40,7 @@ class WhenMustHaveElseWarnTest : LintTestBase(::WhenMustHaveElseRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${Warnings.WHEN_WITHOUT_ELSE.warnText()} else was not found", true)
+            DiktatError(2, 5, ruleId, "${Warnings.WHEN_WITHOUT_ELSE.warnText()} else was not found", true)
         )
     }
 
@@ -123,7 +123,7 @@ class WhenMustHaveElseWarnTest : LintTestBase(::WhenMustHaveElseRule) {
                 |    }
                 |}
             """.trimMargin(),
-            LintError(3, 5, ruleId, "${Warnings.WHEN_WITHOUT_ELSE.warnText()} else was not found", true)
+            DiktatError(3, 5, ruleId, "${Warnings.WHEN_WITHOUT_ELSE.warnText()} else was not found", true)
         )
     }
 
@@ -140,7 +140,7 @@ class WhenMustHaveElseWarnTest : LintTestBase(::WhenMustHaveElseRule) {
                 |    }
                 |}
             """.trimMargin(),
-            LintError(3, 5, ruleId, "${Warnings.WHEN_WITHOUT_ELSE.warnText()} else was not found", true)
+            DiktatError(3, 5, ruleId, "${Warnings.WHEN_WITHOUT_ELSE.warnText()} else was not found", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/BlankLinesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/BlankLinesWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TOO_MANY_BLANK_LINES
 import org.cqfn.diktat.ruleset.rules.chapter3.files.BlankLinesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -58,8 +58,8 @@ class BlankLinesWarnTest : LintTestBase(::BlankLinesRule) {
                     |    fun bar() { }
                     |}
             """.trimMargin(),
-            LintError(1, 16, ruleId, consecutiveLinesWarn, true),
-            LintError(4, 16, ruleId, consecutiveLinesWarn, true)
+            DiktatError(1, 16, ruleId, consecutiveLinesWarn, true),
+            DiktatError(4, 16, ruleId, consecutiveLinesWarn, true)
         )
     }
 
@@ -77,9 +77,9 @@ class BlankLinesWarnTest : LintTestBase(::BlankLinesRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(1, 16, ruleId, blankLinesInBlockWarn(true), true),
-            LintError(3, 16, ruleId, blankLinesInBlockWarn(true), true),
-            LintError(5, 14, ruleId, blankLinesInBlockWarn(false), true)
+            DiktatError(1, 16, ruleId, blankLinesInBlockWarn(true), true),
+            DiktatError(3, 16, ruleId, blankLinesInBlockWarn(true), true),
+            DiktatError(5, 14, ruleId, blankLinesInBlockWarn(false), true)
         )
     }
 
@@ -96,8 +96,8 @@ class BlankLinesWarnTest : LintTestBase(::BlankLinesRule) {
                     |
                     |}
             """.trimMargin(),
-            LintError(3, 14, ruleId, blankLinesInBlockWarn(false), true),
-            LintError(5, 6, ruleId, blankLinesInBlockWarn(false), true)
+            DiktatError(3, 14, ruleId, blankLinesInBlockWarn(false), true),
+            DiktatError(5, 6, ruleId, blankLinesInBlockWarn(false), true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/NewlinesRuleWarnTest.kt
@@ -8,7 +8,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_NEWLINES
 import org.cqfn.diktat.ruleset.rules.chapter3.files.NewlinesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
@@ -54,9 +54,9 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    val b = if (condition) { bar(); baz()} else qux
                     |};
             """.trimMargin(),
-            LintError(6, 17, ruleId, "${REDUNDANT_SEMICOLON.warnText()} fun foo() {};", true),
-            LintError(7, 14, ruleId, "${REDUNDANT_SEMICOLON.warnText()} val a = 0;", true),
-            LintError(9, 2, ruleId, "${REDUNDANT_SEMICOLON.warnText()} };", true)
+            DiktatError(6, 17, ruleId, "${REDUNDANT_SEMICOLON.warnText()} fun foo() {};", true),
+            DiktatError(7, 14, ruleId, "${REDUNDANT_SEMICOLON.warnText()} val a = 0;", true),
+            DiktatError(9, 2, ruleId, "${REDUNDANT_SEMICOLON.warnText()} };", true)
         )
     }
 
@@ -142,11 +142,11 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |        foo
                     |}
             """.trimMargin(),
-            LintError(3, 9, ruleId, "$shouldBreakAfter &&", true),
-            LintError(8, 8, ruleId, "$shouldBreakBefore .", true),
-            LintError(10, 8, ruleId, "$shouldBreakBefore ?.", true),
-            LintError(12, 9, ruleId, "$shouldBreakBefore ?:", true),
-            LintError(14, 8, ruleId, "$shouldBreakBefore ::", true)
+            DiktatError(3, 9, ruleId, "$shouldBreakAfter &&", true),
+            DiktatError(8, 8, ruleId, "$shouldBreakBefore .", true),
+            DiktatError(10, 8, ruleId, "$shouldBreakBefore ?.", true),
+            DiktatError(12, 9, ruleId, "$shouldBreakBefore ?:", true),
+            DiktatError(14, 8, ruleId, "$shouldBreakBefore ::", true)
         )
     }
 
@@ -185,8 +185,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |        false)
                     |}
             """.trimMargin(),
-            LintError(3, 9, ruleId, "$shouldBreakAfter xor", true),
-            LintError(6, 9, ruleId, "$shouldBreakAfter xor", true)
+            DiktatError(3, 9, ruleId, "$shouldBreakAfter xor", true),
+            DiktatError(6, 9, ruleId, "$shouldBreakAfter xor", true)
         )
     }
 
@@ -213,11 +213,11 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    )
                     |}
             """.trimMargin(),
-            LintError(3, 9, ruleId, "$shouldBreakAfter or", true),
-            LintError(7, 9, ruleId, "$shouldBreakAfter xor", true),
-            LintError(8, 9, ruleId, "$shouldBreakAfter or", true),
-            LintError(12, 9, ruleId, "$shouldBreakAfter xor", true),
-            LintError(14, 9, ruleId, "$shouldBreakAfter or", true)
+            DiktatError(3, 9, ruleId, "$shouldBreakAfter or", true),
+            DiktatError(7, 9, ruleId, "$shouldBreakAfter xor", true),
+            DiktatError(8, 9, ruleId, "$shouldBreakAfter or", true),
+            DiktatError(12, 9, ruleId, "$shouldBreakAfter xor", true),
+            DiktatError(14, 9, ruleId, "$shouldBreakAfter or", true)
         )
     }
 
@@ -265,10 +265,10 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |        }?.qux()
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
-            LintError(2, 11, ruleId, "$functionalStyleWarn .", true),
-            LintError(3, 26, ruleId, "$functionalStyleWarn .", true),
-            LintError(5, 10, ruleId, "$functionalStyleWarn ?.", true),
+            DiktatError(2, 5, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
+            DiktatError(2, 11, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(3, 26, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(5, 10, ruleId, "$functionalStyleWarn ?.", true),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -297,7 +297,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |        = 43
                     |}
             """.trimMargin(),
-            LintError(5, 9, ruleId, "$shouldBreakAfter =", true)
+            DiktatError(5, 9, ruleId, "$shouldBreakAfter =", true)
         )
     }
 
@@ -313,8 +313,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |        , b)
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, commaWarn, true),
-            LintError(5, 9, ruleId, commaWarn, true)
+            DiktatError(2, 9, ruleId, commaWarn, true),
+            DiktatError(5, 9, ruleId, commaWarn, true)
         )
     }
 
@@ -330,8 +330,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    bar(a, b)
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, prevColonWarn, true),
-            LintError(4, 9, ruleId, prevColonWarn, true)
+            DiktatError(2, 9, ruleId, prevColonWarn, true),
+            DiktatError(4, 9, ruleId, prevColonWarn, true)
         )
     }
 
@@ -344,9 +344,9 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |      bar(a, b)
                     |}
             """.trimMargin(),
-            LintError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
+            DiktatError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
                     "should be aligned with it in declaration of <foo>", true),
-            LintError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <foo>", true)
+            DiktatError(1, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <foo>", true)
         )
     }
 
@@ -428,9 +428,9 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    ) { }
                     |}
             """.trimMargin(),
-            LintError(1, 16, ruleId, lparWarn, true),
-            LintError(3, 5, ruleId, lparWarn, true),
-            LintError(7, 5, ruleId, lparWarn, true)
+            DiktatError(1, 16, ruleId, lparWarn, true),
+            DiktatError(3, 5, ruleId, lparWarn, true),
+            DiktatError(7, 5, ruleId, lparWarn, true)
         )
     }
 
@@ -495,11 +495,11 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(3, 14, ruleId, lambdaWithArrowWarn, true),
-            LintError(7, 9, ruleId, lambdaWithArrowWarn, true),
-            LintError(11, 9, ruleId, lambdaWithArrowWarn, true),
-            LintError(13, 35, ruleId, lambdaWithArrowWarn, true),
-            LintError(16, 22, ruleId, lambdaWithoutArrowWarn, true)
+            DiktatError(3, 14, ruleId, lambdaWithArrowWarn, true),
+            DiktatError(7, 9, ruleId, lambdaWithArrowWarn, true),
+            DiktatError(11, 9, ruleId, lambdaWithArrowWarn, true),
+            DiktatError(13, 35, ruleId, lambdaWithArrowWarn, true),
+            DiktatError(16, 22, ruleId, lambdaWithoutArrowWarn, true)
         )
     }
 
@@ -541,7 +541,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    name
                     |}
             """.trimMargin(),
-            LintError(2, 35, ruleId, "$shouldBreakBefore .", true)
+            DiktatError(2, 35, ruleId, "$shouldBreakBefore .", true)
         )
     }
 
@@ -581,8 +581,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    ) { }
                     |}
             """.trimMargin(),
-            LintError(3, 14, ruleId, "${WRONG_NEWLINES.warnText()} argument list should be split into several lines", true),
-            LintError(7, 12, ruleId, "${WRONG_NEWLINES.warnText()} argument list should be split into several lines", true)
+            DiktatError(3, 14, ruleId, "${WRONG_NEWLINES.warnText()} argument list should be split into several lines", true),
+            DiktatError(7, 12, ruleId, "${WRONG_NEWLINES.warnText()} argument list should be split into several lines", true)
         )
     }
 
@@ -595,7 +595,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |    return "lorem ipsum"
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, singleReturnWarn, true)
+            DiktatError(2, 5, ruleId, singleReturnWarn, true)
         )
     }
 
@@ -682,7 +682,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                     |         }
                     |}
             """.trimMargin(),
-            LintError(19, 20, ruleId, "${WRONG_NEWLINES.warnText()} should follow functional style at .", true),
+            DiktatError(19, 20, ruleId, "${WRONG_NEWLINES.warnText()} should follow functional style at .", true),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -703,15 +703,15 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |          arg3: Int
                 |) { }
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
+            DiktatError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
                     "should be aligned with it in declaration of <Foo>", true),
-            LintError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
-            LintError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
+            DiktatError(3, 10, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
+            DiktatError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
                     "should be aligned with it in declaration of <Foo>", true),
-            LintError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
-            LintError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (arg1) should be placed on the new line or " +
+            DiktatError(4, 16, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <Foo>", true),
+            DiktatError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (arg1) should be placed on the new line or " +
                     "all other parameters should be aligned with it", true),
-            LintError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true)
+            DiktatError(4, 62, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true)
         )
     }
 
@@ -735,9 +735,9 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |        arg3: Int
                 |) { }
             """.trimMargin(),
-            LintError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
+            DiktatError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} first parameter should be placed on a separate line or all other parameters " +
                     "should be aligned with it in declaration of <bar>", true),
-            LintError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <bar>", true)
+            DiktatError(3, 8, ruleId, "${WRONG_NEWLINES.warnText()} value parameters should be placed on different lines in declaration of <bar>", true)
         )
     }
 
@@ -780,9 +780,9 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |
                 |}
             """.trimMargin(),
-            LintError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (\"id\") should be placed on the new line or " +
+            DiktatError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} first value argument (\"id\") should be placed on the new line or " +
                     "all other parameters should be aligned with it", true),
-            LintError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true),
+            DiktatError(1, 46, ruleId, "${WRONG_NEWLINES.warnText()} value arguments should be placed on different lines", true),
         )
     }
 
@@ -803,8 +803,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |
                 |class Foo : FooBase<Bar>() { }
             """.trimMargin(),
-            LintError(6, 13, ruleId, "${WRONG_NEWLINES.warnText()} supertype list entries should be placed on different lines in declaration of <Foo>", true),
-            LintError(9, 13, ruleId, "${WRONG_NEWLINES.warnText()} supertype list entries should be placed on different lines in declaration of <Foo>", true)
+            DiktatError(6, 13, ruleId, "${WRONG_NEWLINES.warnText()} supertype list entries should be placed on different lines in declaration of <Foo>", true),
+            DiktatError(9, 13, ruleId, "${WRONG_NEWLINES.warnText()} supertype list entries should be placed on different lines in declaration of <Foo>", true)
         )
     }
 
@@ -828,10 +828,10 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   x.map().gre().few().qwe()
                 |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
-            LintError(3, 22, ruleId, "${WRONG_NEWLINES.warnText()} should follow functional style at .", true),
-            LintError(13, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
-            LintError(13, 23, ruleId, "${WRONG_NEWLINES.warnText()} should follow functional style at .", true)
+            DiktatError(2, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
+            DiktatError(3, 22, ruleId, "${WRONG_NEWLINES.warnText()} should follow functional style at .", true),
+            DiktatError(13, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
+            DiktatError(13, 23, ruleId, "${WRONG_NEWLINES.warnText()} should follow functional style at .", true)
         )
     }
 
@@ -858,10 +858,10 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   .few()
                 |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
-            LintError(4, 22, ruleId, "$functionalStyleWarn .", true),
-            LintError(8, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
-            LintError(9, 22, ruleId, "$functionalStyleWarn .", true)
+            DiktatError(2, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
+            DiktatError(4, 22, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(8, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
+            DiktatError(9, 22, ruleId, "$functionalStyleWarn .", true)
         )
     }
 
@@ -893,9 +893,9 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   .few()
                 |}
             """.trimMargin(),
-            LintError(4, 10, ruleId, "$functionalStyleWarn .", true),
-            LintError(9, 11, ruleId, "$functionalStyleWarn .", true),
-            LintError(9, 17, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(4, 10, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(9, 11, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(9, 17, ruleId, "$functionalStyleWarn .", true),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -929,10 +929,10 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   .gre().few()
                 |}
             """.trimMargin(),
-            LintError(2, 7, ruleId, "$functionalStyleWarn .", true),
-            LintError(16, 10, ruleId, "$functionalStyleWarn .", true),
-            LintError(21, 7, ruleId, "$functionalStyleWarn .", true),
-            LintError(22, 10, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(2, 7, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(16, 10, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(21, 7, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(22, 10, ruleId, "$functionalStyleWarn .", true),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -954,7 +954,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   y.ds()?:gh()
                 |}
             """.trimMargin(),
-            LintError(4, 8, ruleId, "$shouldBreakBefore ?:", true)
+            DiktatError(4, 8, ruleId, "$shouldBreakBefore ?:", true)
         )
     }
 
@@ -969,7 +969,7 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |        goo().gor().goo()
                 |}
             """.trimMargin(),
-            LintError(3, 8, ruleId, "$shouldBreakBefore ?:", true)
+            DiktatError(3, 8, ruleId, "$shouldBreakBefore ?:", true)
         )
     }
 
@@ -986,8 +986,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   x.gf().fge().qwe().fd()
                 |}
             """.trimMargin(),
-            LintError(6, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
-            LintError(6, 22, ruleId, "$functionalStyleWarn .", true), rulesConfigList = rulesConfigList
+            DiktatError(6, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
+            DiktatError(6, 22, ruleId, "$functionalStyleWarn .", true), rulesConfigList = rulesConfigList
         )
     }
 
@@ -1014,8 +1014,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |       .qwe()
                 |}
             """.trimMargin(),
-            LintError(9, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
-            LintError(9, 29, ruleId, "$functionalStyleWarn .", true)
+            DiktatError(9, 4, ruleId, dotQuaOrSafeAccessOrPostfixExpression, true),
+            DiktatError(9, 29, ruleId, "$functionalStyleWarn .", true)
         )
     }
 
@@ -1049,9 +1049,9 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   foo ?: bar().qwe().qwe()
                 |}
             """.trimMargin(),
-            LintError(2, 14, ruleId, "$functionalStyleWarn ?:", true),
-            LintError(4, 8, ruleId, "$functionalStyleWarn ?:", true),
-            LintError(4, 22, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(2, 14, ruleId, "$functionalStyleWarn ?:", true),
+            DiktatError(4, 8, ruleId, "$functionalStyleWarn ?:", true),
+            DiktatError(4, 22, ruleId, "$functionalStyleWarn .", true),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -1066,8 +1066,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   a().b.c()!!
                 |}
             """.trimMargin(),
-            LintError(2, 11, ruleId, "$functionalStyleWarn .", true),
-            LintError(3, 9, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(2, 11, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(3, 9, ruleId, "$functionalStyleWarn .", true),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -1092,11 +1092,11 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |                       .qwe()
                 |}
             """.trimMargin(),
-            LintError(7, 22, ruleId, "$functionalStyleWarn .", true),
-            LintError(9, 15, ruleId, "$functionalStyleWarn ?:", true),
-            LintError(10, 16, ruleId, "$functionalStyleWarn ?:", true),
-            LintError(10, 24, ruleId, "$shouldBreakBefore .", true),
-            LintError(12, 16, ruleId, "$functionalStyleWarn ?:", true),
+            DiktatError(7, 22, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(9, 15, ruleId, "$functionalStyleWarn ?:", true),
+            DiktatError(10, 16, ruleId, "$functionalStyleWarn ?:", true),
+            DiktatError(10, 24, ruleId, "$shouldBreakBefore .", true),
+            DiktatError(12, 16, ruleId, "$functionalStyleWarn ?:", true),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -1135,10 +1135,10 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   goo(a?.b.c)
                 |}
             """.trimMargin(),
-            LintError(2, 10, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
-            LintError(3, 14, ruleId, "${COMPLEX_EXPRESSION.warnText()} ?.", false),
-            LintError(4, 14, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
-            LintError(5, 12, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
+            DiktatError(2, 10, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
+            DiktatError(3, 14, ruleId, "${COMPLEX_EXPRESSION.warnText()} ?.", false),
+            DiktatError(4, 14, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
+            DiktatError(5, 12, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
             rulesConfigList = rulesConfigListShort
         )
     }
@@ -1152,8 +1152,8 @@ class NewlinesRuleWarnTest : LintTestBase(::NewlinesRule) {
                 |   if(a().b().c()) {}
                 |}
             """.trimMargin(),
-            LintError(2, 14, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
-            LintError(2, 14, ruleId, "$functionalStyleWarn .", true),
+            DiktatError(2, 14, ruleId, "${COMPLEX_EXPRESSION.warnText()} .", false),
+            DiktatError(2, 14, ruleId, "$functionalStyleWarn .", true),
             rulesConfigList = rulesConfigListShort
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/TopLevelOrderRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/files/TopLevelOrderRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TOP_LEVEL_ORDER
 import org.cqfn.diktat.ruleset.rules.chapter3.files.TopLevelOrderRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -42,14 +42,14 @@ class TopLevelOrderRuleWarnTest : LintTestBase(::TopLevelOrderRule) {
                 |public const val g = 9.8
                 |object B {}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} class A {}", true),
-            LintError(2, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} lateinit var q: String", true),
-            LintError(3, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} interface B {}", true),
-            LintError(4, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} fun foo() {}", true),
-            LintError(5, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} fun String.foo() {}", true),
-            LintError(6, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} private val et = 0", true),
-            LintError(7, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} public const val g = 9.8", true),
-            LintError(8, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} object B {}", true)
+            DiktatError(1, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} class A {}", true),
+            DiktatError(2, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} lateinit var q: String", true),
+            DiktatError(3, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} interface B {}", true),
+            DiktatError(4, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} fun foo() {}", true),
+            DiktatError(5, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} fun String.foo() {}", true),
+            DiktatError(6, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} private val et = 0", true),
+            DiktatError(7, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} public const val g = 9.8", true),
+            DiktatError(8, 1, ruleId, "${TOP_LEVEL_ORDER.warnText()} object B {}", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/ExpectedIndentationError.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/ExpectedIndentationError.kt
@@ -4,7 +4,7 @@ import org.cqfn.diktat.common.config.rules.DIKTAT_RULE_SET_ID
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
 import org.cqfn.diktat.ruleset.junit.ExpectedLintError
 import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationRule.Companion.NAME_ID
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 
 /**
  * The expected indentation error (extracted from annotated code fragments).
@@ -32,8 +32,8 @@ class ExpectedIndentationError(override val line: Int,
         warnText(expectedIndent)(actualIndent)
     )
 
-    override fun asLintError(): LintError =
-        LintError(
+    override fun asLintError(): DiktatError =
+        DiktatError(
             line,
             column,
             "$DIKTAT_RULE_SET_ID:$NAME_ID",

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/IndentationRuleWarnTest.kt
@@ -14,7 +14,7 @@ import org.cqfn.diktat.ruleset.utils.indentation.IndentationConfig.Companion.IND
 import org.cqfn.diktat.util.LintTestBase
 import org.cqfn.diktat.util.TEST_FILE_NAME
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -68,7 +68,7 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(2, 1, ruleId, "${WRONG_INDENTATION.warnText()} tabs are not allowed for indentation", true)
+            DiktatError(2, 1, ruleId, "${WRONG_INDENTATION.warnText()} tabs are not allowed for indentation", true)
         )
     }
 
@@ -82,7 +82,7 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(2, 1, ruleId, warnText(4, 3), true)
+            DiktatError(2, 1, ruleId, warnText(4, 3), true)
         )
     }
 
@@ -97,7 +97,7 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = TEST_FILE_NAME,
-            LintError(3, 1, ruleId, "${WRONG_INDENTATION.warnText()} no newline at the end of file $TEST_FILE_NAME", true)
+            DiktatError(3, 1, ruleId, "${WRONG_INDENTATION.warnText()} no newline at the end of file $TEST_FILE_NAME", true)
         )
     }
 
@@ -112,7 +112,7 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = TEST_FILE_NAME,
-            LintError(3, 1, ruleId, "${WRONG_INDENTATION.warnText()} no newline at the end of file $TEST_FILE_NAME", true)
+            DiktatError(3, 1, ruleId, "${WRONG_INDENTATION.warnText()} no newline at the end of file $TEST_FILE_NAME", true)
         )
     }
 
@@ -129,7 +129,7 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = TEST_FILE_NAME,
-            LintError(5, 1, ruleId, "${WRONG_INDENTATION.warnText()} too many blank lines at the end of file $TEST_FILE_NAME", true)
+            DiktatError(5, 1, ruleId, "${WRONG_INDENTATION.warnText()} too many blank lines at the end of file $TEST_FILE_NAME", true)
         )
     }
 
@@ -210,9 +210,9 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(2, 1, ruleId, warnText(8, 14), true),
-            LintError(3, 1, ruleId, warnText(8, 14), true),
-            LintError(4, 1, ruleId, warnText(8, 14), true),
+            DiktatError(2, 1, ruleId, warnText(8, 14), true),
+            DiktatError(3, 1, ruleId, warnText(8, 14), true),
+            DiktatError(4, 1, ruleId, warnText(8, 14), true),
             rulesConfigList = rulesConfigList
         )
     }
@@ -299,8 +299,8 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(2, 1, ruleId, warnText(1, 0), true),
-            LintError(3, 1, ruleId, warnText(1, 0), true)
+            DiktatError(2, 1, ruleId, warnText(1, 0), true),
+            DiktatError(3, 1, ruleId, warnText(1, 0), true)
         )
     }
 
@@ -372,10 +372,10 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(3, 1, ruleId, warnText(8, 4), true),
-            LintError(6, 1, ruleId, warnText(8, 4), true),
-            LintError(10, 1, ruleId, warnText(8, 4), true),
-            LintError(12, 1, ruleId, warnText(8, 4), true)
+            DiktatError(3, 1, ruleId, warnText(8, 4), true),
+            DiktatError(6, 1, ruleId, warnText(8, 4), true),
+            DiktatError(10, 1, ruleId, warnText(8, 4), true),
+            DiktatError(12, 1, ruleId, warnText(8, 4), true)
         )
     }
 
@@ -498,9 +498,9 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(3, 1, ruleId, warnText(8, 12), true),
-            LintError(8, 1, ruleId, warnText(8, 4), true),
-            LintError(9, 1, ruleId, warnText(8, 4), true)
+            DiktatError(3, 1, ruleId, warnText(8, 12), true),
+            DiktatError(8, 1, ruleId, warnText(8, 4), true),
+            DiktatError(9, 1, ruleId, warnText(8, 4), true)
         )
     }
 
@@ -601,9 +601,9 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(4, 1, ruleId, warnText(12, 8), true),
-            LintError(7, 1, ruleId, warnText(12, 8), true),
-            LintError(10, 1, ruleId, warnText(12, 8), true)
+            DiktatError(4, 1, ruleId, warnText(12, 8), true),
+            DiktatError(7, 1, ruleId, warnText(12, 8), true),
+            DiktatError(10, 1, ruleId, warnText(12, 8), true)
         )
     }
 
@@ -693,9 +693,9 @@ class IndentationRuleWarnTest : LintTestBase(::IndentationRule) {
                 |}
                 |
             """.trimMargin(),
-            LintError(4, 1, ruleId, warnText(12, 8), true),
-            LintError(5, 1, ruleId, warnText(16, 12), true),
-            LintError(6, 1, ruleId, warnText(16, 12), true),
+            DiktatError(4, 1, ruleId, warnText(12, 8), true),
+            DiktatError(5, 1, ruleId, warnText(16, 12), true),
+            DiktatError(6, 1, ruleId, warnText(16, 12), true),
             rulesConfigList = rulesConfigList
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/WhiteSpaceRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/WhiteSpaceRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_WHITESPACE
 import org.cqfn.diktat.ruleset.rules.chapter3.files.WhiteSpaceRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -64,9 +64,9 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(3, 11, ruleId, keywordWarn("if", "("), true),
-            LintError(4, 14, ruleId, keywordWarn("for", "("), true),
-            LintError(5, 13, ruleId, keywordWarn("when", "("), true)
+            DiktatError(3, 11, ruleId, keywordWarn("if", "("), true),
+            DiktatError(4, 14, ruleId, keywordWarn("for", "("), true),
+            DiktatError(5, 13, ruleId, keywordWarn("when", "("), true)
         )
     }
 
@@ -79,7 +79,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    constructor (val a: Int)
                     |}
             """.trimMargin(),
-            LintError(2, 5, ruleId, "${WRONG_WHITESPACE.warnText()} keyword 'constructor' should not be separated from '(' with a whitespace", true)
+            DiktatError(2, 5, ruleId, "${WRONG_WHITESPACE.warnText()} keyword 'constructor' should not be separated from '(' with a whitespace", true)
         )
     }
 
@@ -97,9 +97,9 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(4, 14, ruleId, keywordWarn("else", "{"), true),
-            LintError(5, 13, ruleId, keywordWarn("try", "{"), true),
-            LintError(6, 17, ruleId, keywordWarn("finally", "{"), true)
+            DiktatError(4, 14, ruleId, keywordWarn("else", "{"), true),
+            DiktatError(5, 13, ruleId, keywordWarn("try", "{"), true),
+            DiktatError(6, 17, ruleId, keywordWarn("finally", "{"), true)
         )
     }
 
@@ -117,7 +117,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |     if (condition) bar() else  baz()
                     |}
             """.trimMargin(),
-            LintError(7, 33, ruleId, keywordWarn("else", "baz"), true)
+            DiktatError(7, 33, ruleId, keywordWarn("else", "baz"), true)
         )
     }
 
@@ -134,10 +134,10 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(1, 14, ruleId, lbraceWarn, true),
-            LintError(2, 14, ruleId, lbraceWarn, true),
-            LintError(3, 17, ruleId, lbraceWarn, true),
-            LintError(4, 16, ruleId, lbraceWarn, true)
+            DiktatError(1, 14, ruleId, lbraceWarn, true),
+            DiktatError(2, 14, ruleId, lbraceWarn, true),
+            DiktatError(3, 17, ruleId, lbraceWarn, true),
+            DiktatError(4, 16, ruleId, lbraceWarn, true)
         )
     }
 
@@ -156,7 +156,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |
                     |val lambda = { x: Int -> 2 * x }
             """.trimMargin(),
-            LintError(6, 10, ruleId, "${WRONG_WHITESPACE.warnText()} there should be no whitespace before '{' of lambda inside argument list", true)
+            DiktatError(6, 10, ruleId, "${WRONG_WHITESPACE.warnText()} there should be no whitespace before '{' of lambda inside argument list", true)
         )
     }
 
@@ -242,28 +242,28 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(1, 31, ruleId, tokenWarn(":", 0, 0, 1, 1), true),
-            LintError(1, 44, ruleId, tokenWarn(":", 0, null, 1, 1), true),
-            LintError(1, 59, ruleId, tokenWarn(":", null, 0, 1, 1), true),
-            LintError(2, 22, ruleId, tokenWarn("+", 0, null, 1, 1), true),
-            LintError(3, 23, ruleId, tokenWarn("+", 0, 0, 1, 1), true),
-            LintError(4, 24, ruleId, tokenWarn("+", null, 0, 1, 1), true),
-            LintError(7, 21, ruleId, tokenWarn(".", 1, null, 0, 0), true),
-            LintError(7, 31, ruleId, tokenWarn("::", 1, null, 0, 0), true),
-            LintError(7, 38, ruleId, tokenWarn("?.", 1, null, 0, 0), true),
-            LintError(7, 54, ruleId, tokenWarn("->", null, 0, 1, 1), true),
-            LintError(7, 74, ruleId, tokenWarn("!!", 1, null, 0, null), true),
-            LintError(8, 21, ruleId, tokenWarn(".", 1, 1, 0, 0), true),
-            LintError(8, 32, ruleId, tokenWarn("::", 1, 1, 0, 0), true),
-            LintError(8, 40, ruleId, tokenWarn("?.", 1, 1, 0, 0), true),
-            LintError(8, 56, ruleId, tokenWarn("->", 0, 0, 1, 1), true),
-            LintError(8, 76, ruleId, tokenWarn("!!", 1, null, 0, null), true),
-            LintError(8, 79, ruleId, tokenWarn(".", 1, null, 0, 0), true),
-            LintError(9, 20, ruleId, tokenWarn(".", null, 1, 0, 0), true),
-            LintError(9, 30, ruleId, tokenWarn("::", null, 1, 0, 0), true),
-            LintError(9, 37, ruleId, tokenWarn("?.", null, 1, 0, 0), true),
-            LintError(9, 53, ruleId, tokenWarn("->", 0, null, 1, 1), true),
-            LintError(9, 75, ruleId, tokenWarn(".", null, 1, 0, 0), true)
+            DiktatError(1, 31, ruleId, tokenWarn(":", 0, 0, 1, 1), true),
+            DiktatError(1, 44, ruleId, tokenWarn(":", 0, null, 1, 1), true),
+            DiktatError(1, 59, ruleId, tokenWarn(":", null, 0, 1, 1), true),
+            DiktatError(2, 22, ruleId, tokenWarn("+", 0, null, 1, 1), true),
+            DiktatError(3, 23, ruleId, tokenWarn("+", 0, 0, 1, 1), true),
+            DiktatError(4, 24, ruleId, tokenWarn("+", null, 0, 1, 1), true),
+            DiktatError(7, 21, ruleId, tokenWarn(".", 1, null, 0, 0), true),
+            DiktatError(7, 31, ruleId, tokenWarn("::", 1, null, 0, 0), true),
+            DiktatError(7, 38, ruleId, tokenWarn("?.", 1, null, 0, 0), true),
+            DiktatError(7, 54, ruleId, tokenWarn("->", null, 0, 1, 1), true),
+            DiktatError(7, 74, ruleId, tokenWarn("!!", 1, null, 0, null), true),
+            DiktatError(8, 21, ruleId, tokenWarn(".", 1, 1, 0, 0), true),
+            DiktatError(8, 32, ruleId, tokenWarn("::", 1, 1, 0, 0), true),
+            DiktatError(8, 40, ruleId, tokenWarn("?.", 1, 1, 0, 0), true),
+            DiktatError(8, 56, ruleId, tokenWarn("->", 0, 0, 1, 1), true),
+            DiktatError(8, 76, ruleId, tokenWarn("!!", 1, null, 0, null), true),
+            DiktatError(8, 79, ruleId, tokenWarn(".", 1, null, 0, 0), true),
+            DiktatError(9, 20, ruleId, tokenWarn(".", null, 1, 0, 0), true),
+            DiktatError(9, 30, ruleId, tokenWarn("::", null, 1, 0, 0), true),
+            DiktatError(9, 37, ruleId, tokenWarn("?.", null, 1, 0, 0), true),
+            DiktatError(9, 53, ruleId, tokenWarn("->", 0, null, 1, 1), true),
+            DiktatError(9, 75, ruleId, tokenWarn(".", null, 1, 0, 0), true)
         )
     }
 
@@ -302,14 +302,14 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    val x : Int
                     |}
             """.trimMargin(),
-            LintError(1, 19, ruleId, eolSpaceWarn, true),
-            LintError(2, 16, ruleId, tokenWarn(":", 1, 0, 0, 1), true),
-            LintError(2, 19, ruleId, tokenWarn(",", 1, 0, 0, 1), true),
-            LintError(2, 22, ruleId, tokenWarn(":", null, 0, 0, 1), true),
-            LintError(2, 27, ruleId, eolSpaceWarn, true),
-            LintError(3, 18, ruleId, tokenWarn(";", null, 0, 0, 1), true),
-            LintError(4, 19, ruleId, tokenWarn(";", 1, null, 0, 1), true),
-            LintError(7, 11, ruleId, tokenWarn(":", 1, null, 0, 1), true)
+            DiktatError(1, 19, ruleId, eolSpaceWarn, true),
+            DiktatError(2, 16, ruleId, tokenWarn(":", 1, 0, 0, 1), true),
+            DiktatError(2, 19, ruleId, tokenWarn(",", 1, 0, 0, 1), true),
+            DiktatError(2, 22, ruleId, tokenWarn(":", null, 0, 0, 1), true),
+            DiktatError(2, 27, ruleId, eolSpaceWarn, true),
+            DiktatError(3, 18, ruleId, tokenWarn(";", null, 0, 0, 1), true),
+            DiktatError(4, 19, ruleId, tokenWarn(";", 1, null, 0, 1), true),
+            DiktatError(7, 11, ruleId, tokenWarn(":", 1, null, 0, 1), true)
         )
     }
 
@@ -342,11 +342,11 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    val x = object: IFoo { /*...*/ }
                     |}
             """.trimMargin(),
-            LintError(1, 25, ruleId, tokenWarn(":", 0, null, 1, 1), true),
-            LintError(1, 31, ruleId, tokenWarn(":", 0, null, 1, 1), true),
-            LintError(3, 14, ruleId, tokenWarn(":", 0, null, 1, 1), true),
-            LintError(4, 27, ruleId, tokenWarn(":", 0, null, 1, 1), true),
-            LintError(6, 19, ruleId, tokenWarn(":", 0, null, 1, 1), true)
+            DiktatError(1, 25, ruleId, tokenWarn(":", 0, null, 1, 1), true),
+            DiktatError(1, 31, ruleId, tokenWarn(":", 0, null, 1, 1), true),
+            DiktatError(3, 14, ruleId, tokenWarn(":", 0, null, 1, 1), true),
+            DiktatError(4, 27, ruleId, tokenWarn(":", 0, null, 1, 1), true),
+            DiktatError(6, 19, ruleId, tokenWarn(":", 0, null, 1, 1), true)
         )
     }
 
@@ -360,7 +360,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    lateinit var x: Int ?
                     |}
             """.trimMargin(),
-            LintError(3, 25, ruleId, tokenWarn("?", 1, null, 0, null), true)
+            DiktatError(3, 25, ruleId, tokenWarn("?", 1, null, 0, null), true)
         )
     }
 
@@ -372,7 +372,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |val x = list[0]
                     |val y = list [0]
             """.trimMargin(),
-            LintError(2, 14, ruleId, tokenWarn("[", 1, null, 0, 0), true)
+            DiktatError(2, 14, ruleId, tokenWarn("[", 1, null, 0, 0), true)
         )
     }
 
@@ -407,11 +407,11 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(1, 15, ruleId, tokenWarn("(", 1, null, 0, 0), true),
-            LintError(2, 26, ruleId, tokenWarn("(", 1, null, 0, 0), true),
-            LintError(4, 13, ruleId, tokenWarn("(", 1, null, 0, 0), true),
-            LintError(5, 13, ruleId, tokenWarn("(", 1, null, 0, 0), true),
-            LintError(6, 31, ruleId, tokenWarn("(", 1, null, 0, 0), true)
+            DiktatError(1, 15, ruleId, tokenWarn("(", 1, null, 0, 0), true),
+            DiktatError(2, 26, ruleId, tokenWarn("(", 1, null, 0, 0), true),
+            DiktatError(4, 13, ruleId, tokenWarn("(", 1, null, 0, 0), true),
+            DiktatError(5, 13, ruleId, tokenWarn("(", 1, null, 0, 0), true),
+            DiktatError(6, 31, ruleId, tokenWarn("(", 1, null, 0, 0), true)
         )
     }
 
@@ -424,8 +424,8 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |fun bar() : String = "ipsum"
                     |fun baz() :String = "dolor"
             """.trimMargin(),
-            LintError(2, 11, ruleId, tokenWarn(":", 1, null, 0, 1), true),
-            LintError(3, 11, ruleId, tokenWarn(":", 1, 0, 0, 1), true)
+            DiktatError(2, 11, ruleId, tokenWarn(":", 1, null, 0, 1), true),
+            DiktatError(3, 11, ruleId, tokenWarn(":", 1, 0, 0, 1), true)
         )
     }
 
@@ -442,9 +442,9 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |               @get :Anno val bar: Type,
                     |               @param : Anno val baz: Type)
             """.trimMargin(),
-            LintError(5, 22, ruleId, tokenWarn(":", null, 1, 0, 0), true),
-            LintError(6, 21, ruleId, tokenWarn(":", 1, null, 0, 0), true),
-            LintError(7, 23, ruleId, tokenWarn(":", 1, 1, 0, 0), true)
+            DiktatError(5, 22, ruleId, tokenWarn(":", null, 1, 0, 0), true),
+            DiktatError(6, 21, ruleId, tokenWarn(":", 1, null, 0, 0), true),
+            DiktatError(7, 23, ruleId, tokenWarn(":", 1, 1, 0, 0), true)
         )
     }
 
@@ -457,7 +457,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    val codeFix = CodeFix(codeForm.initialCode!! ,codeFormHtml.ruleSet[0])
                     |}
             """.trimMargin(),
-            LintError(2, 50, ruleId, tokenWarn(",", 1, 0, 0, 1), true)
+            DiktatError(2, 50, ruleId, tokenWarn(",", 1, 0, 0, 1), true)
         )
     }
 
@@ -471,7 +471,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 13, ruleId, tokenWarn("(\"Text\")", 1, null, 0, null), true)
+            DiktatError(1, 13, ruleId, tokenWarn("(\"Text\")", 1, null, 0, null), true)
         )
     }
 
@@ -486,8 +486,8 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |   w=q
                     |}
             """.trimMargin(),
-            LintError(2, 9, ruleId, tokenWarn("=", 0, 0, 1, 1), true),
-            LintError(4, 5, ruleId, tokenWarn("=", 0, 0, 1, 1), true)
+            DiktatError(2, 9, ruleId, tokenWarn("=", 0, 0, 1, 1), true),
+            DiktatError(4, 5, ruleId, tokenWarn("=", 0, 0, 1, 1), true)
         )
     }
 
@@ -500,9 +500,9 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |
                     |val q =goo(text=ty)
             """.trimMargin(),
-            LintError(1, 10, ruleId, tokenWarn("=", 0, 0, 1, 1), true),
-            LintError(3, 7, ruleId, tokenWarn("=", null, 0, 1, 1), true),
-            LintError(3, 16, ruleId, tokenWarn("=", 0, 0, 1, 1), true)
+            DiktatError(1, 10, ruleId, tokenWarn("=", 0, 0, 1, 1), true),
+            DiktatError(3, 7, ruleId, tokenWarn("=", null, 0, 1, 1), true),
+            DiktatError(3, 16, ruleId, tokenWarn("=", 0, 0, 1, 1), true)
         )
     }
 
@@ -528,8 +528,8 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |   a[0]
                     |}
             """.trimMargin(),
-            LintError(1, 23, ruleId, tokenWarn("=", null, 0, 1, 1), true),
-            LintError(1, 24, ruleId, tokenWarn("[", 0, null, 1, 0), true)
+            DiktatError(1, 23, ruleId, tokenWarn("=", null, 0, 1, 1), true),
+            DiktatError(1, 24, ruleId, tokenWarn("[", 0, null, 1, 0), true)
         )
     }
 
@@ -554,7 +554,7 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |val q = foo({ it.baz() })
                     |val q = foo( { it.baz() })
             """.trimMargin(),
-            LintError(3, 14, ruleId,
+            DiktatError(3, 14, ruleId,
                 "${WRONG_WHITESPACE.warnText()} there should be no whitespace before '{' of lambda inside argument list", true)
         )
     }
@@ -586,12 +586,12 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                     |    list.map(:: operationReference)
                     |}
             """.trimMargin(),
-            LintError(2, 12, ruleId, tokenWarn("(", null, 1, 0, 0), true),
-            LintError(2, 14, ruleId, tokenWarn("::", null, 1, null, 0), true),
-            LintError(3, 15, ruleId, tokenWarn(",", null, 2, 0, 1), true),
-            LintError(3, 18, ruleId, tokenWarn("::", null, 1, null, 0), true),
-            LintError(4, 26, ruleId, tokenWarn("::", null, 1, null, 0), true),
-            LintError(5, 14, ruleId, tokenWarn("::", null, 1, null, 0), true)
+            DiktatError(2, 12, ruleId, tokenWarn("(", null, 1, 0, 0), true),
+            DiktatError(2, 14, ruleId, tokenWarn("::", null, 1, null, 0), true),
+            DiktatError(3, 15, ruleId, tokenWarn(",", null, 2, 0, 1), true),
+            DiktatError(3, 18, ruleId, tokenWarn("::", null, 1, null, 0), true),
+            DiktatError(4, 26, ruleId, tokenWarn("::", null, 1, null, 0), true),
+            DiktatError(5, 14, ruleId, tokenWarn("::", null, 1, null, 0), true)
         )
     }
 
@@ -612,8 +612,8 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                 |    return index ++
                 |}
             """.trimMargin(),
-            LintError(9, 5, ruleId, tokenWarn("--", null, 1, null, 0), true),
-            LintError(10, 18, ruleId, tokenWarn("++", 1, null, 0, null), true)
+            DiktatError(9, 5, ruleId, tokenWarn("--", null, 1, null, 0), true),
+            DiktatError(10, 18, ruleId, tokenWarn("++", 1, null, 0, null), true)
         )
     }
 
@@ -638,8 +638,8 @@ class WhiteSpaceRuleWarnTest : LintTestBase(::WhiteSpaceRule) {
                 |    list.map {it.text}
                 |}
             """.trimMargin(),
-            LintError(2, 14, ruleId, "${WRONG_WHITESPACE.warnText()} there should be a whitespace after {", true),
-            LintError(2, 22, ruleId, "${WRONG_WHITESPACE.warnText()} there should be a whitespace before }", true)
+            DiktatError(2, 14, ruleId, "${WRONG_WHITESPACE.warnText()} there should be a whitespace after {", true),
+            DiktatError(2, 22, ruleId, "${WRONG_WHITESPACE.warnText()} there should be a whitespace before }", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/junit/IndentationTestWarnExtension.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/spaces/junit/IndentationTestWarnExtension.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.chapter3.spaces.withCustomParameters
 import org.cqfn.diktat.ruleset.rules.chapter3.files.IndentationRule
 import org.cqfn.diktat.ruleset.utils.NEWLINE
 import org.cqfn.diktat.util.LintTestBase
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -23,7 +23,7 @@ import kotlin.math.min
 internal class IndentationTestWarnExtension(
     override val customConfig: Map<String, Any>,
     @Language("kotlin") override val actualCode: String,
-    private val expectedErrors: Array<LintError>
+    private val expectedErrors: Array<DiktatError>
 ) : LintTestBase(::IndentationRule), IndentationTestExtension {
 
     override fun beforeTestExecution(context: ExtensionContext) {
@@ -75,7 +75,7 @@ internal class IndentationTestWarnExtension(
          * ```
          */
         @Suppress("CUSTOM_GETTERS_SETTERS")
-        private val LintError.annotationText: String
+        private val DiktatError.annotationText: String
             get() {
                 @Suppress("WRONG_NEWLINES")  // False positives, see #1495.
                 val columnNumbers = decimalNumber
@@ -108,7 +108,7 @@ internal class IndentationTestWarnExtension(
 
         private val decimalNumber = Regex("""\b[+-]?(\d++)\b""")
 
-        private fun String.annotateWith(errors: List<LintError>): String =
+        private fun String.annotateWith(errors: List<DiktatError>): String =
             when {
                 errors.isEmpty() -> this
                 else -> {

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/AccurateCalculationsWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/AccurateCalculationsWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.FLOAT_IN_ACCURATE_CALCULATIONS
 import org.cqfn.diktat.ruleset.rules.chapter4.calculations.AccurateCalculationsRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -29,10 +29,10 @@ class AccurateCalculationsWarnTest : LintTestBase(::AccurateCalculationsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(3, 9, ruleId, warnText("1.0", "x == 1.0"), false),
-            LintError(4, 9, ruleId, warnText("1.0", "1.0 == x"), false),
-            LintError(5, 9, ruleId, warnText("1.0", "x.equals(1.0)"), false),
-            LintError(6, 9, ruleId, warnText("1.0", "1.0.equals(x)"), false)
+            DiktatError(3, 9, ruleId, warnText("1.0", "x == 1.0"), false),
+            DiktatError(4, 9, ruleId, warnText("1.0", "1.0 == x"), false),
+            DiktatError(5, 9, ruleId, warnText("1.0", "x.equals(1.0)"), false),
+            DiktatError(6, 9, ruleId, warnText("1.0", "1.0.equals(x)"), false)
         )
     }
 
@@ -50,10 +50,10 @@ class AccurateCalculationsWarnTest : LintTestBase(::AccurateCalculationsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(3, 9, ruleId, warnText("1.0", "x > 1.0"), false),
-            LintError(4, 9, ruleId, warnText("1.0", "1.0 > x"), false),
-            LintError(5, 9, ruleId, warnText("1.0", "x.compareTo(1.0)"), false),
-            LintError(6, 9, ruleId, warnText("1.0", "1.0.compareTo(x)"), false)
+            DiktatError(3, 9, ruleId, warnText("1.0", "x > 1.0"), false),
+            DiktatError(4, 9, ruleId, warnText("1.0", "1.0 > x"), false),
+            DiktatError(5, 9, ruleId, warnText("1.0", "x.compareTo(1.0)"), false),
+            DiktatError(6, 9, ruleId, warnText("1.0", "1.0.compareTo(x)"), false)
         )
     }
 
@@ -69,7 +69,7 @@ class AccurateCalculationsWarnTest : LintTestBase(::AccurateCalculationsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(4, 9, ruleId, warnText("x", "x == 1"), false)
+            DiktatError(4, 9, ruleId, warnText("x", "x == 1"), false)
         )
     }
 
@@ -88,7 +88,7 @@ class AccurateCalculationsWarnTest : LintTestBase(::AccurateCalculationsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(6, 13, ruleId, warnText("x", "x == 1"), false)
+            DiktatError(6, 13, ruleId, warnText("x", "x == 1"), false)
         )
     }
 
@@ -136,19 +136,19 @@ class AccurateCalculationsWarnTest : LintTestBase(::AccurateCalculationsRule) {
                     |    }
                     |}
             """.trimMargin(),
-            LintError(4, 9, ruleId, warnText("x", "x == 1"), false),
-            LintError(5, 9, ruleId, warnText("x", "x + 2"), false),
-            // LintError(6, 9, ruleId, warnText("x", "x++"), false),
-            LintError(7, 9, ruleId, warnText("x", "x += 2"), false),
-            LintError(8, 9, ruleId, warnText("x", "x - 2"), false),
-            // LintError(9, 9, ruleId, warnText("x", "x--"), false),
-            LintError(10, 9, ruleId, warnText("x", "x -= 2"), false),
-            LintError(11, 9, ruleId, warnText("x", "x * 2"), false),
-            LintError(12, 9, ruleId, warnText("x", "x *= 2"), false),
-            LintError(13, 9, ruleId, warnText("x", "x / 2"), false),
-            LintError(14, 9, ruleId, warnText("x", "x /= 2"), false),
-            LintError(15, 9, ruleId, warnText("x", "x % 2"), false),
-            LintError(16, 9, ruleId, warnText("x", "x %= 2"), false)
+            DiktatError(4, 9, ruleId, warnText("x", "x == 1"), false),
+            DiktatError(5, 9, ruleId, warnText("x", "x + 2"), false),
+            // DiktatError(6, 9, ruleId, warnText("x", "x++"), false),
+            DiktatError(7, 9, ruleId, warnText("x", "x += 2"), false),
+            DiktatError(8, 9, ruleId, warnText("x", "x - 2"), false),
+            // DiktatError(9, 9, ruleId, warnText("x", "x--"), false),
+            DiktatError(10, 9, ruleId, warnText("x", "x -= 2"), false),
+            DiktatError(11, 9, ruleId, warnText("x", "x * 2"), false),
+            DiktatError(12, 9, ruleId, warnText("x", "x *= 2"), false),
+            DiktatError(13, 9, ruleId, warnText("x", "x / 2"), false),
+            DiktatError(14, 9, ruleId, warnText("x", "x /= 2"), false),
+            DiktatError(15, 9, ruleId, warnText("x", "x % 2"), false),
+            DiktatError(16, 9, ruleId, warnText("x", "x %= 2"), false)
         )
     }
 
@@ -179,9 +179,9 @@ class AccurateCalculationsWarnTest : LintTestBase(::AccurateCalculationsRule) {
                     |    abs(1.0 - 0.999) == eps
                     |}
             """.trimMargin(),
-            LintError(11, 5, ruleId, warnText("1e-6", "abs(1.0 - 0.999) == 1e-6"), false),
-            LintError(11, 9, ruleId, warnText("1.0", "1.0 - 0.999"), false),
-            LintError(20, 9, ruleId, warnText("1.0", "1.0 - 0.999"), false)
+            DiktatError(11, 5, ruleId, warnText("1e-6", "abs(1.0 - 0.999) == 1e-6"), false),
+            DiktatError(11, 9, ruleId, warnText("1.0", "1.0 - 0.999"), false),
+            DiktatError(20, 9, ruleId, warnText("1.0", "1.0 - 0.999"), false)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NoVarRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NoVarRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter4.ImmutableValNoVarRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.SAY_NO_TO_VAR
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -42,7 +42,7 @@ class NoVarRuleWarnTest : LintTestBase(::ImmutableValNoVarRule) {
                     |     }
                     | }
             """.trimMargin(),
-            LintError(2, 6, ruleId, "${Warnings.SAY_NO_TO_VAR.warnText()} var a = emptyList()", false)
+            DiktatError(2, 6, ruleId, "${Warnings.SAY_NO_TO_VAR.warnText()} var a = emptyList()", false)
         )
     }
 
@@ -82,7 +82,7 @@ class NoVarRuleWarnTest : LintTestBase(::ImmutableValNoVarRule) {
                     |     return a
                     | }
             """.trimMargin(),
-            LintError(2, 6, ruleId, "${Warnings.SAY_NO_TO_VAR.warnText()} var a = 0", false)
+            DiktatError(2, 6, ruleId, "${Warnings.SAY_NO_TO_VAR.warnText()} var a = 0", false)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NullChecksRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/NullChecksRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter4.NullChecksRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 |     }
                 | }
             """.trimMargin(),
-            LintError(3, 10, ruleId, "${Warnings.AVOID_NULL_CHECKS.warnText()} use '.let/.also/?:/e.t.c' instead of myVar == null", true),
+            DiktatError(3, 10, ruleId, "${Warnings.AVOID_NULL_CHECKS.warnText()} use '.let/.also/?:/e.t.c' instead of myVar == null", true),
         )
     }
 
@@ -46,7 +46,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 |     }
                 | }
             """.trimMargin(),
-            LintError(3, 11, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
+            DiktatError(3, 11, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
                     " use '.let/.also/?:/e.t.c' instead of myVar == null", true),
         )
     }
@@ -63,7 +63,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 |     }
                 | }
             """.trimMargin(),
-            LintError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
+            DiktatError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
                     " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
         )
     }
@@ -82,7 +82,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 |                      }
                 | }
             """.trimMargin(),
-            LintError(2, 27, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
+            DiktatError(2, 27, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
                     " use '.let/.also/?:/e.t.c' instead of myVar != null", true),
         )
     }
@@ -100,7 +100,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 |     }
                 | }
             """.trimMargin(),
-            LintError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
+            DiktatError(2, 10, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
                     " use '.let/.also/?:/e.t.c' instead of myVar !== null", true),
         )
     }
@@ -171,7 +171,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 |      }
                 | }
             """.trimMargin(),
-            LintError(2, 10, ruleId, "${Warnings.AVOID_NULL_CHECKS.warnText()} use '.let/.also/?:/e.t.c'" +
+            DiktatError(2, 10, ruleId, "${Warnings.AVOID_NULL_CHECKS.warnText()} use '.let/.also/?:/e.t.c'" +
                     " instead of myVar != null", true),
         )
     }
@@ -185,7 +185,7 @@ class NullChecksRuleWarnTest : LintTestBase(::NullChecksRule) {
                 |     require(myVar != null)
                 | }
             """.trimMargin(),
-            LintError(2, 14, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
+            DiktatError(2, 14, ruleId, Warnings.AVOID_NULL_CHECKS.warnText() +
                     " use 'requireNotNull' instead of require(myVar != null)", true),
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/SmartCastRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/SmartCastRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter4.SmartCastRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.SMART_CAST_NEEDED
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
@@ -45,7 +45,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(5, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
+            DiktatError(5, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
         )
     }
 
@@ -86,7 +86,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(7, 25, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
+            DiktatError(7, 25, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
         )
     }
 
@@ -106,7 +106,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(7, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
+            DiktatError(7, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
         )
     }
 
@@ -123,7 +123,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(5, 19, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
+            DiktatError(5, 19, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
         )
     }
 
@@ -159,7 +159,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(8, 19, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
+            DiktatError(8, 19, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true)
         )
     }
 
@@ -186,8 +186,8 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(8, 19, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true),
-            LintError(13, 23, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} a as String", true)
+            DiktatError(8, 19, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true),
+            DiktatError(13, 23, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} a as String", true)
         )
     }
 
@@ -208,7 +208,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(5, 29, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
+            DiktatError(5, 29, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
         )
     }
 
@@ -278,8 +278,8 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(6, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true),
-            LintError(7, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} y as Int", true)
+            DiktatError(6, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as String", true),
+            DiktatError(7, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} y as Int", true)
         )
     }
 
@@ -338,7 +338,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(8, 25, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
+            DiktatError(8, 25, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
         )
     }
 
@@ -357,7 +357,7 @@ class SmartCastRuleWarnTest : LintTestBase(::SmartCastRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(6, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
+            DiktatError(6, 21, ruleId, "${Warnings.SMART_CAST_NEEDED.warnText()} x as Int", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/TypeAliasRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/TypeAliasRuleWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TYPE_ALIAS
 import org.cqfn.diktat.ruleset.rules.chapter4.TypeAliasRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ class TypeAliasRuleWarnTest : LintTestBase(::TypeAliasRule) {
                     | val b: MutableMap<String, MutableList<String>>
                     | val b = listof<Int>()
             """.trimMargin(),
-            LintError(1, 9, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
+            DiktatError(1, 9, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
         )
     }
 
@@ -38,8 +38,8 @@ class TypeAliasRuleWarnTest : LintTestBase(::TypeAliasRule) {
                     | var emitWarn: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
                     | var emitWarn: (offset: Int, (T) -> Boolean) -> Unit
             """.trimMargin(),
-            LintError(1, 16, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
-            LintError(2, 16, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
+            DiktatError(1, 16, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
+            DiktatError(2, 16, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
         )
     }
 
@@ -55,7 +55,7 @@ class TypeAliasRuleWarnTest : LintTestBase(::TypeAliasRule) {
                     | }
                     |
             """.trimMargin(),
-            LintError(4, 13, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
+            DiktatError(4, 13, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
         )
     }
 
@@ -69,7 +69,7 @@ class TypeAliasRuleWarnTest : LintTestBase(::TypeAliasRule) {
                     | val list: List<List<Int>>
                     |
             """.trimMargin(),
-            LintError(3, 12, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
+            DiktatError(3, 12, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
             rulesConfigList = rulesConfigListShortType
         )
     }
@@ -87,8 +87,8 @@ class TypeAliasRuleWarnTest : LintTestBase(::TypeAliasRule) {
                     |   }
                     | }
             """.trimMargin(),
-            LintError(2, 16, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
-            LintError(3, 11, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
+            DiktatError(2, 16, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
+            DiktatError(3, 11, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false)
         )
     }
 
@@ -121,7 +121,7 @@ class TypeAliasRuleWarnTest : LintTestBase(::TypeAliasRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 11, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
+            DiktatError(2, 11, ruleId, "${TYPE_ALIAS.warnText()} too long type reference", false),
             rulesConfigList = rulesConfigListShortType
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/VariableGenericTypeDeclarationRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter4/VariableGenericTypeDeclarationRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter4.VariableGenericTypeDeclarationRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.GENERIC_VARIABLE_WRONG_DECLARATION
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -43,11 +43,11 @@ class VariableGenericTypeDeclarationRuleWarnTest : LintTestBase(::VariableGeneri
                     |   val x = foo.bar<Bar>().baz<Some>()
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId,
+            DiktatError(2, 4, ruleId,
                 "${Warnings.GENERIC_VARIABLE_WRONG_DECLARATION.warnText()} type arguments are unnecessary in emptyMap<Int, String>()", true),
-            LintError(3, 4, ruleId,
+            DiktatError(3, 4, ruleId,
                 "${Warnings.GENERIC_VARIABLE_WRONG_DECLARATION.warnText()} val any = Array<Any>(3) { \"\" }", false),
-            LintError(4, 4, ruleId,
+            DiktatError(4, 4, ruleId,
                 "${Warnings.GENERIC_VARIABLE_WRONG_DECLARATION.warnText()} val x = foo.bar<Bar>().baz<Some>()", false)
         )
     }
@@ -105,7 +105,7 @@ class VariableGenericTypeDeclarationRuleWarnTest : LintTestBase(::VariableGeneri
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 25, ruleId,
+            DiktatError(2, 25, ruleId,
                 "${Warnings.GENERIC_VARIABLE_WRONG_DECLARATION.warnText()} type arguments are unnecessary in emptyMap<Int, String>()", true)
         )
     }
@@ -149,7 +149,7 @@ class VariableGenericTypeDeclarationRuleWarnTest : LintTestBase(::VariableGeneri
                     |   }
                     |}
             """.trimMargin(),
-            LintError(3, 8, ruleId,
+            DiktatError(3, 8, ruleId,
                 "${Warnings.GENERIC_VARIABLE_WRONG_DECLARATION.warnText()} type arguments are unnecessary in emptyMap<Int, String>()", true)
         )
     }
@@ -187,7 +187,7 @@ class VariableGenericTypeDeclarationRuleWarnTest : LintTestBase(::VariableGeneri
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 17, ruleId,
+            DiktatError(1, 17, ruleId,
                 "${Warnings.GENERIC_VARIABLE_WRONG_DECLARATION.warnText()} type arguments are unnecessary in emptyMap<Int, String>()", true)
         )
     }
@@ -203,7 +203,7 @@ class VariableGenericTypeDeclarationRuleWarnTest : LintTestBase(::VariableGeneri
                     |   }
                     |}
             """.trimMargin(),
-            LintError(3, 8, ruleId,
+            DiktatError(3, 8, ruleId,
                 "${Warnings.GENERIC_VARIABLE_WRONG_DECLARATION.warnText()} type arguments are unnecessary in emptyMap<Int, Map<String>>()", true)
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/AsyncAndSyncRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/AsyncAndSyncRuleTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.RUN_BLOCKING_INSIDE_ASYNC
 import org.cqfn.diktat.ruleset.rules.chapter5.AsyncAndSyncRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -41,8 +41,8 @@ class AsyncAndSyncRuleTest : LintTestBase(::AsyncAndSyncRule) {
                     |}
                     |
             """.trimMargin(),
-            LintError(11, 8, ruleId, "${RUN_BLOCKING_INSIDE_ASYNC.warnText()} runBlocking", false),
-            LintError(18, 4, ruleId, "${RUN_BLOCKING_INSIDE_ASYNC.warnText()} runBlocking", false)
+            DiktatError(11, 8, ruleId, "${RUN_BLOCKING_INSIDE_ASYNC.warnText()} runBlocking", false),
+            DiktatError(18, 4, ruleId, "${RUN_BLOCKING_INSIDE_ASYNC.warnText()} runBlocking", false)
         )
     }
 
@@ -68,7 +68,7 @@ class AsyncAndSyncRuleTest : LintTestBase(::AsyncAndSyncRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(4, 8, ruleId, "${RUN_BLOCKING_INSIDE_ASYNC.warnText()} runBlocking", false)
+            DiktatError(4, 8, ruleId, "${RUN_BLOCKING_INSIDE_ASYNC.warnText()} runBlocking", false)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/AvoidNestedFunctionsWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/AvoidNestedFunctionsWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter5.AvoidNestedFunctionsRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.AVOID_NESTED_FUNCTIONS
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -31,7 +31,7 @@ class AvoidNestedFunctionsWarnTest : LintTestBase(::AvoidNestedFunctionsRule) {
                     |
                     |}
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${Warnings.AVOID_NESTED_FUNCTIONS.warnText()} fun bar", false)
+            DiktatError(3, 4, ruleId, "${Warnings.AVOID_NESTED_FUNCTIONS.warnText()} fun bar", false)
         )
     }
 
@@ -63,8 +63,8 @@ class AvoidNestedFunctionsWarnTest : LintTestBase(::AvoidNestedFunctionsRule) {
                     |
                     |}
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${Warnings.AVOID_NESTED_FUNCTIONS.warnText()} fun bar", true),
-            LintError(4, 8, ruleId, "${Warnings.AVOID_NESTED_FUNCTIONS.warnText()} fun baz", true)
+            DiktatError(3, 4, ruleId, "${Warnings.AVOID_NESTED_FUNCTIONS.warnText()} fun bar", true),
+            DiktatError(4, 8, ruleId, "${Warnings.AVOID_NESTED_FUNCTIONS.warnText()} fun baz", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/CheckInverseMethodRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/CheckInverseMethodRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter5.CheckInverseMethodRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.INVERSE_FUNCTION_PREFERRED
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -38,7 +38,7 @@ class CheckInverseMethodRuleWarnTest : LintTestBase(::CheckInverseMethodRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 14, ruleId, "${Warnings.INVERSE_FUNCTION_PREFERRED.warnText()} isNotEmpty() instead of !isEmpty()", true)
+            DiktatError(2, 14, ruleId, "${Warnings.INVERSE_FUNCTION_PREFERRED.warnText()} isNotEmpty() instead of !isEmpty()", true)
         )
     }
 
@@ -53,7 +53,7 @@ class CheckInverseMethodRuleWarnTest : LintTestBase(::CheckInverseMethodRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 16, ruleId, "${Warnings.INVERSE_FUNCTION_PREFERRED.warnText()} isNotEmpty() instead of !isEmpty()", true)
+            DiktatError(2, 16, ruleId, "${Warnings.INVERSE_FUNCTION_PREFERRED.warnText()} isNotEmpty() instead of !isEmpty()", true)
         )
     }
 
@@ -68,7 +68,7 @@ class CheckInverseMethodRuleWarnTest : LintTestBase(::CheckInverseMethodRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 32, ruleId, "${Warnings.INVERSE_FUNCTION_PREFERRED.warnText()} isNotEmpty() instead of !isEmpty()", true)
+            DiktatError(2, 32, ruleId, "${Warnings.INVERSE_FUNCTION_PREFERRED.warnText()} isNotEmpty() instead of !isEmpty()", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/CustomLabelsTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/CustomLabelsTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.CUSTOM_LABEL
 import org.cqfn.diktat.ruleset.rules.chapter5.CustomLabel
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -44,8 +44,8 @@ class CustomLabelsTest : LintTestBase(::CustomLabel) {
                         }
                     }
             """.trimMargin(),
-            LintError(4, 39, ruleId, "${CUSTOM_LABEL.warnText()} @qwe", false),
-            LintError(16, 34, ruleId, "${CUSTOM_LABEL.warnText()} @qq", false)
+            DiktatError(4, 39, ruleId, "${CUSTOM_LABEL.warnText()} @qwe", false),
+            DiktatError(16, 34, ruleId, "${CUSTOM_LABEL.warnText()} @qq", false)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/FunctionArgumentsSizeWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/FunctionArgumentsSizeWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TOO_MANY_PARAMETERS
 import org.cqfn.diktat.ruleset.rules.chapter5.FunctionArgumentsSize
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -29,10 +29,10 @@ class FunctionArgumentsSizeWarnTest : LintTestBase(::FunctionArgumentsSize) {
                     |fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, myLambda: () -> Unit) = 10
                     |abstract fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int)
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false),
-            LintError(2, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false),
-            LintError(4, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false),
-            LintError(5, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false)
+            DiktatError(1, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false),
+            DiktatError(2, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false),
+            DiktatError(4, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false),
+            DiktatError(5, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 6, but allowed 5", false)
         )
     }
 
@@ -43,7 +43,7 @@ class FunctionArgumentsSizeWarnTest : LintTestBase(::FunctionArgumentsSize) {
             """
                     |fun foo(a: Int, b: Int) {}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 2, but allowed 1", false),
+            DiktatError(1, 1, ruleId, "${TOO_MANY_PARAMETERS.warnText()} foo has 2, but allowed 1", false),
             rulesConfigList = rulesConfigList
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/FunctionLengthWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/FunctionLengthWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.TOO_LONG_FUNCTION
 import org.cqfn.diktat.ruleset.rules.chapter5.FunctionLength
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -51,7 +51,7 @@ class FunctionLengthWarnTest : LintTestBase(::FunctionLength) {
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${TOO_LONG_FUNCTION.warnText()} max length is 5, but you have 7", false),
+            DiktatError(1, 1, ruleId, "${TOO_LONG_FUNCTION.warnText()} max length is 5, but you have 7", false),
             rulesConfigList = rulesConfigList
         )
     }
@@ -91,7 +91,7 @@ class FunctionLengthWarnTest : LintTestBase(::FunctionLength) {
                     |fun goo() =
                     |   10
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${TOO_LONG_FUNCTION.warnText()} max length is 2, but you have 4", false),
+            DiktatError(1, 1, ruleId, "${TOO_LONG_FUNCTION.warnText()} max length is 2, but you have 4", false),
             rulesConfigList = shortRulesConfigList
         )
     }
@@ -116,7 +116,7 @@ class FunctionLengthWarnTest : LintTestBase(::FunctionLength) {
                     |
                     |}
             """.trimMargin(),
-            LintError(5, 4, ruleId, "${TOO_LONG_FUNCTION.warnText()} max length is 2, but you have 8", false),
+            DiktatError(5, 4, ruleId, "${TOO_LONG_FUNCTION.warnText()} max length is 2, but you have 8", false),
             rulesConfigList = shortRulesConfigList
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/LambdaLengthWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/LambdaLengthWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter5.LambdaLengthRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -122,7 +122,7 @@ class LambdaLengthWarnTest : LintTestBase(::LambdaLengthRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(3, 13, ruleId, "${Warnings.TOO_MANY_LINES_IN_LAMBDA.warnText()} max length lambda without arguments is 3, but you have 6", false),
+            DiktatError(3, 13, ruleId, "${Warnings.TOO_MANY_LINES_IN_LAMBDA.warnText()} max length lambda without arguments is 3, but you have 6", false),
             rulesConfigList = rulesConfigList
         )
     }
@@ -147,7 +147,7 @@ class LambdaLengthWarnTest : LintTestBase(::LambdaLengthRule) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(4, 13, ruleId, "${Warnings.TOO_MANY_LINES_IN_LAMBDA.warnText()} max length lambda without arguments is 3, but you have 6", false),
+            DiktatError(4, 13, ruleId, "${Warnings.TOO_MANY_LINES_IN_LAMBDA.warnText()} max length lambda without arguments is 3, but you have 6", false),
             rulesConfigList = rulesConfigList
         )
     }
@@ -168,7 +168,7 @@ class LambdaLengthWarnTest : LintTestBase(::LambdaLengthRule) {
                     |       }
                     |   }
             """.trimMargin(),
-            LintError(3, 25, ruleId, "${Warnings.TOO_MANY_LINES_IN_LAMBDA.warnText()} max length lambda without arguments is 3, but you have 6", false),
+            DiktatError(3, 25, ruleId, "${Warnings.TOO_MANY_LINES_IN_LAMBDA.warnText()} max length lambda without arguments is 3, but you have 6", false),
             rulesConfigList = rulesConfigList
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/LambdaParameterOrderWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/LambdaParameterOrderWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.LAMBDA_IS_NOT_LAST_PARAMETER
 import org.cqfn.diktat.ruleset.rules.chapter5.LambdaParameterOrder
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -31,7 +31,7 @@ class LambdaParameterOrderWarnTest : LintTestBase(::LambdaParameterOrder) {
                     |
                     |fun foo(lambda1: () -> Unit, lambda2: (() -> Unit)?) {}
             """.trimMargin(),
-            LintError(1, 17, ruleId, "${LAMBDA_IS_NOT_LAST_PARAMETER.warnText()} foo", false)
+            DiktatError(1, 17, ruleId, "${LAMBDA_IS_NOT_LAST_PARAMETER.warnText()} foo", false)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/NestedFunctionBlockWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/NestedFunctionBlockWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.NESTED_BLOCK
 import org.cqfn.diktat.ruleset.rules.chapter5.NestedFunctionBlock
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -74,7 +74,7 @@ class NestedFunctionBlockWarnTest : LintTestBase(::NestedFunctionBlock) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${NESTED_BLOCK.warnText()} foo", false)
+            DiktatError(1, 1, ruleId, "${NESTED_BLOCK.warnText()} foo", false)
         )
     }
 
@@ -104,7 +104,7 @@ class NestedFunctionBlockWarnTest : LintTestBase(::NestedFunctionBlock) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${NESTED_BLOCK.warnText()} foo", false)
+            DiktatError(1, 1, ruleId, "${NESTED_BLOCK.warnText()} foo", false)
         )
     }
 
@@ -160,7 +160,7 @@ class NestedFunctionBlockWarnTest : LintTestBase(::NestedFunctionBlock) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(3, 8, ruleId, "${NESTED_BLOCK.warnText()} goo", false)
+            DiktatError(3, 8, ruleId, "${NESTED_BLOCK.warnText()} goo", false)
         )
     }
 
@@ -215,7 +215,7 @@ class NestedFunctionBlockWarnTest : LintTestBase(::NestedFunctionBlock) {
                         }
                     }
             """.trimMargin(),
-            LintError(4, 50, ruleId, "${NESTED_BLOCK.warnText()} { keyEvent ->...", false),
+            DiktatError(4, 50, ruleId, "${NESTED_BLOCK.warnText()} { keyEvent ->...", false),
             rulesConfigList = rulesConfigList
         )
     }
@@ -247,7 +247,7 @@ class NestedFunctionBlockWarnTest : LintTestBase(::NestedFunctionBlock) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${NESTED_BLOCK.warnText()} foo", false)
+            DiktatError(2, 4, ruleId, "${NESTED_BLOCK.warnText()} foo", false)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/OverloadingArgumentsFunctionWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/OverloadingArgumentsFunctionWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_OVERLOADING_FUNCTION_ARG
 import org.cqfn.diktat.ruleset.rules.chapter5.OverloadingArgumentsFunction
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -45,7 +45,7 @@ class OverloadingArgumentsFunctionWarnTest : LintTestBase(::OverloadingArguments
                     |   fun foo(){}
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${WRONG_OVERLOADING_FUNCTION_ARGUMENTS.warnText()} foo", false),
+            DiktatError(1, 1, ruleId, "${WRONG_OVERLOADING_FUNCTION_ARGUMENTS.warnText()} foo", false),
         )
     }
 
@@ -99,7 +99,7 @@ class OverloadingArgumentsFunctionWarnTest : LintTestBase(::OverloadingArguments
                     |fun foo(a: Double) {}
                     |fun foo(a: Double, b: Int) {}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${WRONG_OVERLOADING_FUNCTION_ARGUMENTS.warnText()} foo", false)
+            DiktatError(1, 1, ruleId, "${WRONG_OVERLOADING_FUNCTION_ARGUMENTS.warnText()} foo", false)
         )
     }
 
@@ -151,7 +151,7 @@ class OverloadingArgumentsFunctionWarnTest : LintTestBase(::OverloadingArguments
                             ?: false
                     }
             """.trimMargin(),
-            LintError(8, 21, ruleId, "${WRONG_OVERLOADING_FUNCTION_ARGUMENTS.warnText()} isComparisonWithAbs", false)
+            DiktatError(8, 21, ruleId, "${WRONG_OVERLOADING_FUNCTION_ARGUMENTS.warnText()} isComparisonWithAbs", false)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/ParameterNameInOuterLambdaRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter5/ParameterNameInOuterLambdaRuleWarnTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter5.ParameterNameInOuterLambdaRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -126,7 +126,7 @@ class ParameterNameInOuterLambdaRuleWarnTest : LintTestBase(::ParameterNameInOut
                     |   }
                     |}
             """.trimMargin(),
-            LintError(10, 8, ruleId, "${Warnings.PARAMETER_NAME_IN_OUTER_LAMBDA.warnText()} lambda without arguments has inner lambda", false),
+            DiktatError(10, 8, ruleId, "${Warnings.PARAMETER_NAME_IN_OUTER_LAMBDA.warnText()} lambda without arguments has inner lambda", false),
             rulesConfigList = rulesConfigList
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/AbstractClassesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/AbstractClassesWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.AbstractClassesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.CLASS_SHOULD_NOT_BE_ABSTRACT
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ class AbstractClassesWarnTest : LintTestBase(::AbstractClassesRule) {
                 |    fun func() {}
                 |}
             """.trimMargin(),
-            LintError(1, 37, ruleId, "${Warnings.CLASS_SHOULD_NOT_BE_ABSTRACT.warnText()} Some", true)
+            DiktatError(1, 37, ruleId, "${Warnings.CLASS_SHOULD_NOT_BE_ABSTRACT.warnText()} Some", true)
         )
     }
 
@@ -53,7 +53,7 @@ class AbstractClassesWarnTest : LintTestBase(::AbstractClassesRule) {
                 |    }
                 |}
             """.trimMargin(),
-            LintError(4, 32, ruleId, "${Warnings.CLASS_SHOULD_NOT_BE_ABSTRACT.warnText()} Inner", true)
+            DiktatError(4, 32, ruleId, "${Warnings.CLASS_SHOULD_NOT_BE_ABSTRACT.warnText()} Inner", true)
         )
     }
 
@@ -83,7 +83,7 @@ class AbstractClassesWarnTest : LintTestBase(::AbstractClassesRule) {
                 |    }
                 |}
             """.trimMargin(),
-            LintError(1, 58, ruleId, "${Warnings.CLASS_SHOULD_NOT_BE_ABSTRACT.warnText()} CoroutineTest", true)
+            DiktatError(1, 58, ruleId, "${Warnings.CLASS_SHOULD_NOT_BE_ABSTRACT.warnText()} CoroutineTest", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/AvoidUtilityClassWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/AvoidUtilityClassWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.AVOID_USING_UTILITY_CLASS
 import org.cqfn.diktat.ruleset.rules.chapter6.AvoidUtilityClass
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -43,8 +43,8 @@ class AvoidUtilityClassWarnTest : LintTestBase(::AvoidUtilityClass) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtil"),
-            LintError(11, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtils")
+            DiktatError(1, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtil"),
+            DiktatError(11, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtils")
         )
     }
 
@@ -79,7 +79,7 @@ class AvoidUtilityClassWarnTest : LintTestBase(::AvoidUtilityClass) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(2, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtils")
+            DiktatError(2, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtils")
         )
     }
 
@@ -112,7 +112,7 @@ class AvoidUtilityClassWarnTest : LintTestBase(::AvoidUtilityClass) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = "src/main/kotlin/org/cqfn/diktat/Example.kt",
-            LintError(1, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtils"),
+            DiktatError(1, 1, ruleId, "${AVOID_USING_UTILITY_CLASS.warnText()} StringUtils"),
         )
         lintMethodWithFile(
             """

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/CompactInitializationWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/CompactInitializationWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.COMPACT_OBJECT_INITIALIZATION
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.CompactInitialization
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -44,9 +44,9 @@ class CompactInitializationWarnTest : LintTestBase(::CompactInitialization) {
                 |    httpClient.doRequest()
                 |}
             """.trimMargin(),
-            LintError(3, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} url", true),
-            LintError(4, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} port", true),
-            LintError(5, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} timeout", true),
+            DiktatError(3, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} url", true),
+            DiktatError(4, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} port", true),
+            DiktatError(5, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} timeout", true),
         )
     }
 
@@ -67,9 +67,9 @@ class CompactInitializationWarnTest : LintTestBase(::CompactInitialization) {
                 |    httpClient.doRequest()
                 |}
             """.trimMargin(),
-            LintError(4, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} url", true),
-            LintError(6, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} port", true),
-            LintError(9, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} timeout", true),
+            DiktatError(4, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} url", true),
+            DiktatError(6, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} port", true),
+            DiktatError(9, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} timeout", true),
         )
     }
 
@@ -88,7 +88,7 @@ class CompactInitializationWarnTest : LintTestBase(::CompactInitialization) {
                 |    httpClient.doRequest()
                 |}
             """.trimMargin(),
-            LintError(7, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} timeout", true)
+            DiktatError(7, 5, ruleId, "${COMPACT_OBJECT_INITIALIZATION.warnText()} timeout", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/CustomGetterSetterWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/CustomGetterSetterWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.CustomGetterSetterRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.CUSTOM_GETTERS_SETTERS
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -27,8 +27,8 @@ class CustomGetterSetterWarnTest : LintTestBase(::CustomGetterSetterRule) {
                     |        get() = this.hashCode() * 2
                     |}
             """.trimMargin(),
-            LintError(3, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} set"),
-            LintError(7, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} get"),
+            DiktatError(3, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} set"),
+            DiktatError(7, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} get"),
         )
     }
 
@@ -80,7 +80,7 @@ class CustomGetterSetterWarnTest : LintTestBase(::CustomGetterSetterRule) {
                     |        get() = this.hashCode() * 2
                     |}
             """.trimMargin(),
-            LintError(7, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} get"),
+            DiktatError(7, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} get"),
         )
     }
 
@@ -98,8 +98,8 @@ class CustomGetterSetterWarnTest : LintTestBase(::CustomGetterSetterRule) {
                     |        get() = this.hashCode() * 2
                     |}
             """.trimMargin(),
-            LintError(3, 19, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} set"),
-            LintError(7, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} get"),
+            DiktatError(3, 19, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} set"),
+            DiktatError(7, 9, ruleId, "${Warnings.CUSTOM_GETTERS_SETTERS.warnText()} get"),
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.DataClassesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.USE_DATA_CLASS
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Some")
+            DiktatError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Some")
         )
     }
 
@@ -34,7 +34,7 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                     |class Some(val a: Int = 5)
                     |
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Some")
+            DiktatError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Some")
         )
     }
 
@@ -49,7 +49,7 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                     |          set(value: Int) { field = value}
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Test")
+            DiktatError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Test")
         )
     }
 
@@ -121,7 +121,7 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                     |class A(val map: Map<Int, Int>) {}
                     |
             """.trimMargin(),
-            LintError(5, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} A")
+            DiktatError(5, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} A")
         )
     }
 
@@ -156,8 +156,8 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                     |   fun foo() = 10
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} B"),
-            LintError(5, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Ab")
+            DiktatError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} B"),
+            DiktatError(5, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Ab")
         )
     }
 
@@ -263,7 +263,7 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                 |   val gitHubAuthToken: String = auth.toLowerCase()
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Credentials")
+            DiktatError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Credentials")
         )
     }
 
@@ -281,7 +281,7 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                 |   }
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Credentials")
+            DiktatError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Credentials")
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/EmptyPrimaryConstructorWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/EmptyPrimaryConstructorWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.EMPTY_PRIMARY_CONSTRUCTOR
 import org.cqfn.diktat.ruleset.rules.chapter6.AvoidEmptyPrimaryConstructor
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -41,8 +41,8 @@ class EmptyPrimaryConstructorWarnTest : LintTestBase(::AvoidEmptyPrimaryConstruc
                     |
                     |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${EMPTY_PRIMARY_CONSTRUCTOR.warnText()} Some", true),
-            LintError(8, 1, ruleId, "${EMPTY_PRIMARY_CONSTRUCTOR.warnText()} Some1", true)
+            DiktatError(1, 1, ruleId, "${EMPTY_PRIMARY_CONSTRUCTOR.warnText()} Some", true),
+            DiktatError(8, 1, ruleId, "${EMPTY_PRIMARY_CONSTRUCTOR.warnText()} Some1", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/ExtensionFunctionsInFileWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/ExtensionFunctionsInFileWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.ExtensionFunctionsInFileRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.EXTENSION_FUNCTION_WITH_CLASS
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ class ExtensionFunctionsInFileWarnTest : LintTestBase(::ExtensionFunctionsInFile
                 |
                 |}
             """.trimMargin(),
-            LintError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_WITH_CLASS.warnText()} fun coolStr")
+            DiktatError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_WITH_CLASS.warnText()} fun coolStr")
         )
     }
 
@@ -47,8 +47,8 @@ class ExtensionFunctionsInFileWarnTest : LintTestBase(::ExtensionFunctionsInFile
                 |
                 |}
             """.trimMargin(),
-            LintError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_WITH_CLASS.warnText()} fun coolStr"),
-            LintError(9, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_WITH_CLASS.warnText()} fun extMethod"),
+            DiktatError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_WITH_CLASS.warnText()} fun coolStr"),
+            DiktatError(9, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_WITH_CLASS.warnText()} fun extMethod"),
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/ExtensionFunctionsSameNameWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/ExtensionFunctionsSameNameWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.ExtensionFunctionsSameNameRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.EXTENSION_FUNCTION_SAME_SIGNATURE
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
@@ -31,10 +31,10 @@ class ExtensionFunctionsSameNameWarnTest : LintTestBase(::ExtensionFunctionsSame
                 |
                 |fun main() { printClassName(B()) }
             """.trimMargin(),
-            LintError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun B.foo[]"),
-            LintError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun D.foo[]"),
-            LintError(6, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun B.foo[]"),
-            LintError(7, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun D.foo[]"),
+            DiktatError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun B.foo[]"),
+            DiktatError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun D.foo[]"),
+            DiktatError(6, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun B.foo[]"),
+            DiktatError(7, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[] and fun D.foo[]"),
         )
     }
 
@@ -53,8 +53,8 @@ class ExtensionFunctionsSameNameWarnTest : LintTestBase(::ExtensionFunctionsSame
                 |
                 |fun main() { printClassName(B()) }
             """.trimMargin(),
-            LintError(4, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[some] and fun B.foo[some]"),
-            LintError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[some] and fun B.foo[some]")
+            DiktatError(4, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[some] and fun B.foo[some]"),
+            DiktatError(5, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo[some] and fun B.foo[some]")
         )
     }
 
@@ -145,8 +145,8 @@ class ExtensionFunctionsSameNameWarnTest : LintTestBase(::ExtensionFunctionsSame
                 |
                 |fun main() { printClassName(B()) }
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo() and fun B.foo()"),
-            LintError(2, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo() and fun B.foo()")
+            DiktatError(1, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo() and fun B.foo()"),
+            DiktatError(2, 1, ruleId, "${Warnings.EXTENSION_FUNCTION_SAME_SIGNATURE.warnText()} fun A.foo() and fun B.foo()")
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/ImplicitBackingPropertyWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/ImplicitBackingPropertyWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.ImplicitBackingPropertyRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.NO_CORRESPONDING_PROPERTY
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -50,7 +50,7 @@ class ImplicitBackingPropertyWarnTest : LintTestBase(::ImplicitBackingPropertyRu
                     |       set(value) { field = value }
                     |}
             """.trimMargin(),
-            LintError(3, 4, ruleId, "${Warnings.NO_CORRESPONDING_PROPERTY.warnText()} table has no corresponding property with name _table")
+            DiktatError(3, 4, ruleId, "${Warnings.NO_CORRESPONDING_PROPERTY.warnText()} table has no corresponding property with name _table")
         )
     }
 
@@ -160,7 +160,7 @@ class ImplicitBackingPropertyWarnTest : LintTestBase(::ImplicitBackingPropertyRu
                     |       }
                     |}
             """.trimMargin(),
-            LintError(2, 4, ruleId, "${Warnings.NO_CORRESPONDING_PROPERTY.warnText()} foo has no corresponding property with name _foo")
+            DiktatError(2, 4, ruleId, "${Warnings.NO_CORRESPONDING_PROPERTY.warnText()} foo has no corresponding property with name _foo")
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/InlineClassesWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/InlineClassesWarnTest.kt
@@ -7,7 +7,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.INLINE_CLASS_CAN_BE_USED
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.InlineClassesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -55,7 +55,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |   val config = Config()
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
             rulesConfigList = rulesConfigListSameVersion
         )
     }
@@ -69,7 +69,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |   val config = Config()
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
             rulesConfigList = rulesConfigListSameVersion
         )
     }
@@ -109,7 +109,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
             rulesConfigList = rulesConfigListSameVersion
         )
     }
@@ -162,7 +162,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |   val some = 3
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
             rulesConfigList = rulesConfigListSameVersion
         )
     }
@@ -189,7 +189,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class LocalCommandExecutor", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class LocalCommandExecutor", false),
             rulesConfigList = rulesConfigListSameVersion
         )
     }
@@ -203,7 +203,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class LocalCommandExecutor", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class LocalCommandExecutor", false),
             rulesConfigList = rulesConfigListSameVersion
         )
     }
@@ -218,7 +218,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |   val config = Config()
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
             rulesConfigList = rulesConfigListLateVersion
         )
 
@@ -237,7 +237,7 @@ class InlineClassesWarnTest : LintTestBase(::InlineClassesRule) {
                 |   val config = Config()
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
+            DiktatError(1, 1, ruleId, "${INLINE_CLASS_CAN_BE_USED.warnText()} class Some", false),
             rulesConfigList = rulesConfigListSameVersion
         )
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/PropertyAccessorFieldsWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/PropertyAccessorFieldsWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_NAME_OF_VARIABLE_INSIDE_
 import org.cqfn.diktat.ruleset.rules.chapter6.PropertyAccessorFields
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -70,9 +70,9 @@ class PropertyAccessorFieldsWarnTest : LintTestBase(::PropertyAccessorFields) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(4, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(values) {..."),
-            LintError(14, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} get() {..."),
-            LintError(20, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(values) {...")
+            DiktatError(4, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(values) {..."),
+            DiktatError(14, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} get() {..."),
+            DiktatError(20, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(values) {...")
         )
     }
 
@@ -112,9 +112,9 @@ class PropertyAccessorFieldsWarnTest : LintTestBase(::PropertyAccessorFields) {
                     |   get() = field
                     |}
             """.trimMargin(),
-            LintError(4, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(values) {..."),
-            LintError(18, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(valuess) {..."),
-            LintError(24, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(value) {...")
+            DiktatError(4, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(values) {..."),
+            DiktatError(18, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(valuess) {..."),
+            DiktatError(24, 4, ruleId, "${WRONG_NAME_OF_VARIABLE_INSIDE_ACCESSOR.warnText()} set(value) {...")
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/RunInScriptWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/RunInScriptWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.RUN_IN_SCRIPT
 import org.cqfn.diktat.ruleset.rules.chapter6.RunInScript
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -48,11 +48,11 @@ class RunInScriptWarnTest : LintTestBase(::RunInScript) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = "src/main/kotlin/org/cqfn/diktat/Example.kts",
-            LintError(10, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} foo/*df*/()", true),
-            LintError(12, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} foo( //dfdg...", true),
-            LintError(15, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} println(\"hello\")", true),
-            LintError(17, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} w.map { it -> it }", true),
-            LintError(19, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} tasks.register(\"a\") {...", true)
+            DiktatError(10, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} foo/*df*/()", true),
+            DiktatError(12, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} foo( //dfdg...", true),
+            DiktatError(15, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} println(\"hello\")", true),
+            DiktatError(17, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} w.map { it -> it }", true),
+            DiktatError(19, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} tasks.register(\"a\") {...", true)
         )
     }
 
@@ -133,7 +133,7 @@ class RunInScriptWarnTest : LintTestBase(::RunInScript) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = "src/main/kotlin/org/cqfn/diktat/builds.gradle.kts",
-            LintError(6, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} if(true) {...", true)
+            DiktatError(6, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} if(true) {...", true)
         )
     }
 
@@ -172,8 +172,8 @@ class RunInScriptWarnTest : LintTestBase(::RunInScript) {
             """.trimMargin(),
             tempDir = tempDir,
             fileName = "src/main/kotlin/org/cqfn/diktat/Example.kts",
-            LintError(1, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} version = \"0.1.0-SNAPSHOT\"", true),
-            LintError(7, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} foo/*df*/()", true)
+            DiktatError(1, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} version = \"0.1.0-SNAPSHOT\"", true),
+            DiktatError(7, 17, ruleId, "${RUN_IN_SCRIPT.warnText()} foo/*df*/()", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/SingleConstructorRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/SingleConstructorRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.SINGLE_CONSTRUCTOR_SHOULD_BE_P
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.SingleConstructorRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -38,7 +38,7 @@ class SingleConstructorRuleWarnTest : LintTestBase(::SingleConstructorRule) {
                 |    }
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${SINGLE_CONSTRUCTOR_SHOULD_BE_PRIMARY.warnText()} in class <Test>", true)
+            DiktatError(1, 1, ruleId, "${SINGLE_CONSTRUCTOR_SHOULD_BE_PRIMARY.warnText()} in class <Test>", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/SingleInitRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/SingleInitRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.SingleInitRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -38,7 +38,7 @@ class SingleInitRuleWarnTest : LintTestBase(::SingleInitRule) {
                 |    init { println("Dolor sit amet") }
                 |}
             """.trimMargin(),
-            LintError(1, 15, ruleId, "${Warnings.MULTIPLE_INIT_BLOCKS.warnText()} in class <Example> found 2 `init` blocks", true)
+            DiktatError(1, 15, ruleId, "${Warnings.MULTIPLE_INIT_BLOCKS.warnText()} in class <Example> found 2 `init` blocks", true)
         )
     }
 
@@ -54,7 +54,7 @@ class SingleInitRuleWarnTest : LintTestBase(::SingleInitRule) {
                 |    }
                 |}
             """.trimMargin(),
-            LintError(3, 5, ruleId, "${Warnings.MULTIPLE_INIT_BLOCKS.warnText()} `init` block has assignments that can be moved to declarations", true)
+            DiktatError(3, 5, ruleId, "${Warnings.MULTIPLE_INIT_BLOCKS.warnText()} `init` block has assignments that can be moved to declarations", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/StatelessClassesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/StatelessClassesRuleWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.classes.StatelessClassesRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.OBJECT_IS_PREFERRED
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -38,7 +38,7 @@ class StatelessClassesRuleWarnTest : LintTestBase(::StatelessClassesRule) {
                 |   fun some()
                 |}
             """.trimMargin(),
-            LintError(1, 1, ruleId, "${Warnings.OBJECT_IS_PREFERRED.warnText()} class Some", true)
+            DiktatError(1, 1, ruleId, "${Warnings.OBJECT_IS_PREFERRED.warnText()} class Some", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/TrivialPropertyAccessorsWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/TrivialPropertyAccessorsWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.TrivialPropertyAccessors
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -24,8 +24,8 @@ class TrivialPropertyAccessorsWarnTest : LintTestBase(::TrivialPropertyAccessors
                     |       set(value) { field = value }
                     |}
             """.trimMargin(),
-            LintError(3, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} get() { return field }", true),
-            LintError(4, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} set(value) { field = value }", true)
+            DiktatError(3, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} get() { return field }", true),
+            DiktatError(4, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} set(value) { field = value }", true)
         )
     }
 
@@ -39,7 +39,7 @@ class TrivialPropertyAccessorsWarnTest : LintTestBase(::TrivialPropertyAccessors
                     |       get() = field
                     |}
             """.trimMargin(),
-            LintError(3, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} get() = field", true)
+            DiktatError(3, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} get() = field", true)
         )
     }
 
@@ -86,7 +86,7 @@ class TrivialPropertyAccessorsWarnTest : LintTestBase(::TrivialPropertyAccessors
                     |       get
                     |}
             """.trimMargin(),
-            LintError(3, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} get", true)
+            DiktatError(3, 8, ruleId, "${Warnings.TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED.warnText()} get", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/UseLastIndexWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/UseLastIndexWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter6.UseLastIndex
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class UseLastIndexWarnTest : LintTestBase(::UseLastIndex) {
                     |val D = A.B.C.length - 1
                     |
             """.trimMargin(),
-            LintError(2, 9, ruleId, "${Warnings.USE_LAST_INDEX.warnText()} A.B.C.length - 1", true)
+            DiktatError(2, 9, ruleId, "${Warnings.USE_LAST_INDEX.warnText()} A.B.C.length - 1", true)
         )
     }
 
@@ -51,7 +51,7 @@ class UseLastIndexWarnTest : LintTestBase(::UseLastIndex) {
                     |var C = A.length - 19
                     |
             """.trimMargin(),
-            LintError(2, 12, ruleId, "${Warnings.USE_LAST_INDEX.warnText() } A.length   -       1", true)
+            DiktatError(2, 12, ruleId, "${Warnings.USE_LAST_INDEX.warnText() } A.length   -       1", true)
         )
     }
 
@@ -64,7 +64,7 @@ class UseLastIndexWarnTest : LintTestBase(::UseLastIndex) {
                     |var B = A.length-1
                     |
             """.trimMargin(),
-            LintError(2, 9, ruleId, "${Warnings.USE_LAST_INDEX.warnText()} A.length-1", true)
+            DiktatError(2, 9, ruleId, "${Warnings.USE_LAST_INDEX.warnText()} A.length-1", true)
         )
     }
 
@@ -95,7 +95,7 @@ class UseLastIndexWarnTest : LintTestBase(::UseLastIndex) {
                     |val M = "ASDFG".length
                     |
             """.trimMargin(),
-            LintError(4, 9, ruleId, "${Warnings.USE_LAST_INDEX.warnText()} \"AAAA\".length - 1", true)
+            DiktatError(4, 9, ruleId, "${Warnings.USE_LAST_INDEX.warnText()} \"AAAA\".length - 1", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/UselessSupertypeWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/UselessSupertypeWarnTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.USELESS_SUPERTYPE
 import org.cqfn.diktat.ruleset.rules.chapter6.UselessSupertype
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import generated.WarningNames
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -55,8 +55,8 @@ class UselessSupertypeWarnTest : LintTestBase(::UselessSupertype) {
                         }
                     }
             """.trimMargin(),
-            LintError(11, 35, ruleId, "${USELESS_SUPERTYPE.warnText()} Rectangle", true),
-            LintError(21, 35, ruleId, "${USELESS_SUPERTYPE.warnText()} Rectangle", true)
+            DiktatError(11, 35, ruleId, "${USELESS_SUPERTYPE.warnText()} Rectangle", true),
+            DiktatError(21, 35, ruleId, "${USELESS_SUPERTYPE.warnText()} Rectangle", true)
         )
     }
 
@@ -86,7 +86,7 @@ class UselessSupertypeWarnTest : LintTestBase(::UselessSupertype) {
 
                     }
             """.trimMargin(),
-            LintError(17, 35, ruleId, "${USELESS_SUPERTYPE.warnText()} KK", true)
+            DiktatError(17, 35, ruleId, "${USELESS_SUPERTYPE.warnText()} KK", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/junit/ExpectedLintError.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/junit/ExpectedLintError.kt
@@ -1,6 +1,6 @@
 package org.cqfn.diktat.ruleset.junit
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 
 /**
  * The common super-interface for expected lint errors (extracted from the
@@ -18,9 +18,9 @@ interface ExpectedLintError {
     val column: Int
 
     /**
-     * Converts this instance to a [LintError].
+     * Converts this instance to a [DiktatError].
      *
-     * @return the [LintError] which corresponds to this instance.
+     * @return the [DiktatError] which corresponds to this instance.
      */
-    fun asLintError(): LintError
+    fun asLintError(): DiktatError
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressAnnotatedExpressionTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressAnnotatedExpressionTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter3.CollapseIfStatementsRule
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import org.junit.jupiter.api.Test
 
 class SuppressAnnotatedExpressionTest : LintTestBase(::CollapseIfStatementsRule) {
@@ -26,8 +26,8 @@ class SuppressAnnotatedExpressionTest : LintTestBase(::CollapseIfStatementsRule)
                 |}
             """.trimMargin()
         lintMethod(code,
-            LintError(3, 8, ruleId, "${Warnings.COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
-            LintError(4, 12, ruleId, "${Warnings.COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            DiktatError(3, 8, ruleId, "${Warnings.COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            DiktatError(4, 12, ruleId, "${Warnings.COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/utils/SuppressTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.rules.chapter1.IdentifierNaming
 import org.cqfn.diktat.util.LintTestBase
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import org.junit.jupiter.api.Test
 
 class SuppressTest : LintTestBase(::IdentifierNaming) {
@@ -47,7 +47,7 @@ class SuppressTest : LintTestBase(::IdentifierNaming) {
                     |   }
                     |}
             """.trimMargin(),
-            LintError(12, 14, ruleId, "${Warnings.FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREEASA",
+            DiktatError(12, 14, ruleId, "${Warnings.FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREEASA",
                 true)
         )
     }
@@ -140,7 +140,7 @@ class SuppressTest : LintTestBase(::IdentifierNaming) {
                 }
             """.trimIndent()
         lintMethod(code,
-            LintError(3, 15, "$DIKTAT_RULE_SET_ID:${IdentifierNaming.NAME_ID}",
+            DiktatError(3, 15, "$DIKTAT_RULE_SET_ID:${IdentifierNaming.NAME_ID}",
                 "${Warnings.FUNCTION_NAME_INCORRECT_CASE.warnText()} methODTREE", true))
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/DiktatRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/DiktatRuleTest.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.ruleset.constants.Warnings.BLANK_LINE_BETWEEN_PROPERTIES
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_ORDER_IN_CLASS_LIKE_STRUCTURES
 import org.cqfn.diktat.ruleset.rules.chapter3.ClassLikeStructuresOrderRule
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import org.junit.jupiter.api.Test
 
 class DiktatRuleTest : LintTestBase(::ClassLikeStructuresOrderRule) {
@@ -36,7 +36,7 @@ class DiktatRuleTest : LintTestBase(::ClassLikeStructuresOrderRule) {
     @Test
     fun `check that if one inspection is enabled then rule will run`() {
         lintMethod(codeTemplate,
-            LintError(4, 4, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} some", true),
+            DiktatError(4, 4, ruleId, "${BLANK_LINE_BETWEEN_PROPERTIES.warnText()} some", true),
             rulesConfigList = rulesConfigOneRuleIsEnabled
         )
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/LintTestBase.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/LintTestBase.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.ktlint.lint
 import org.cqfn.diktat.ruleset.rules.DiktatRule
 import org.cqfn.diktat.util.DiktatRuleSetProviderTest.Companion.diktatRuleSetForTest
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import java.nio.file.Path
@@ -29,7 +29,7 @@ open class LintTestBase(private val ruleSupplier: (rulesConfigList: List<RulesCo
      * @see lintResult
      */
     fun lintMethod(@Language("kotlin") code: String,
-                   vararg expectedLintErrors: LintError,
+                   vararg expectedLintErrors: DiktatError,
                    rulesConfigList: List<RulesConfig>? = null,
     ) = doAssert(
         actualLintErrors = lintResult(code, rulesConfigList),
@@ -51,7 +51,7 @@ open class LintTestBase(private val ruleSupplier: (rulesConfigList: List<RulesCo
         @Language("kotlin") code: String,
         tempDir: Path,
         fileName: String,
-        vararg expectedLintErrors: LintError,
+        vararg expectedLintErrors: DiktatError,
         rulesConfigList: List<RulesConfig>? = null,
     ) {
         val file = tempDir.resolve(fileName).also {
@@ -75,7 +75,7 @@ open class LintTestBase(private val ruleSupplier: (rulesConfigList: List<RulesCo
      */
     fun lintMethodWithFile(
         file: Path,
-        vararg expectedLintErrors: LintError,
+        vararg expectedLintErrors: DiktatError,
         rulesConfigList: List<RulesConfig>? = null,
     ) = doAssert(
         actualLintErrors = lintResult(file, rulesConfigList),
@@ -84,9 +84,9 @@ open class LintTestBase(private val ruleSupplier: (rulesConfigList: List<RulesCo
     )
 
     private fun doAssert(
-        actualLintErrors: List<LintError>,
+        actualLintErrors: List<DiktatError>,
         description: String,
-        vararg expectedLintErrors: LintError,
+        vararg expectedLintErrors: DiktatError,
     ) {
         when {
             expectedLintErrors.size == 1 && actualLintErrors.size == 1 -> {
@@ -124,8 +124,8 @@ open class LintTestBase(private val ruleSupplier: (rulesConfigList: List<RulesCo
     private fun lintResult(
         file: Path,
         rulesConfigList: List<RulesConfig>? = null,
-    ): List<LintError> {
-        val lintErrors: MutableList<LintError> = mutableListOf()
+    ): List<DiktatError> {
+        val lintErrors: MutableList<DiktatError> = mutableListOf()
 
         lint(
             ruleSetSupplier = { rulesConfigList.toDiktatRuleSet() },
@@ -148,8 +148,8 @@ open class LintTestBase(private val ruleSupplier: (rulesConfigList: List<RulesCo
     protected fun lintResult(
         @Language("kotlin") code: String,
         rulesConfigList: List<RulesConfig>? = null,
-    ): List<LintError> {
-        val lintErrors: MutableList<LintError> = mutableListOf()
+    ): List<DiktatError> {
+        val lintErrors: MutableList<DiktatError> = mutableListOf()
 
         lint(
             ruleSetSupplier = { rulesConfigList.toDiktatRuleSet() },
@@ -163,7 +163,7 @@ open class LintTestBase(private val ruleSupplier: (rulesConfigList: List<RulesCo
     private fun List<RulesConfig>?.toDiktatRuleSet() = diktatRuleSetForTest(ruleSupplier, this ?: rulesConfigList)
 
     companion object {
-        private fun MutableList<LintError>.collector(): DiktatCallback = DiktatCallback { error, _ ->
+        private fun MutableList<DiktatError>.collector(): DiktatCallback = DiktatCallback { error, _ ->
             this += error
         }
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/SuppressingTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/SuppressingTest.kt
@@ -5,7 +5,7 @@ import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.IDENTIFIER_LENGTH
 import org.cqfn.diktat.ruleset.rules.chapter1.IdentifierNaming
 
-import com.pinterest.ktlint.core.LintError
+import org.cqfn.diktat.api.DiktatError
 import org.junit.jupiter.api.Test
 
 class SuppressingTest : LintTestBase(::IdentifierNaming) {
@@ -61,7 +61,7 @@ class SuppressingTest : LintTestBase(::IdentifierNaming) {
             """.trimIndent()
         lintMethod(
             code,
-            LintError(3,
+            DiktatError(3,
                 9,
                 ruleId,
                 "[IDENTIFIER_LENGTH] identifier's length is incorrect, it" +

--- a/diktat-ruleset/src/test/kotlin/com/pinterest/ktlint/core/KtLintTestUtils.kt
+++ b/diktat-ruleset/src/test/kotlin/com/pinterest/ktlint/core/KtLintTestUtils.kt
@@ -1,7 +1,0 @@
-/**
- * This class contains util methods for KtLint
- */
-
-package com.pinterest.ktlint.core
-
-typealias LintError = org.cqfn.diktat.api.DiktatError

--- a/diktat-ruleset/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
+++ b/diktat-ruleset/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTestBase.kt
@@ -7,7 +7,6 @@
 package org.cqfn.diktat.ruleset.smoke
 
 import org.cqfn.diktat.api.DiktatError
-import com.pinterest.ktlint.core.LintError
 import org.cqfn.diktat.common.config.rules.DIKTAT_COMMON
 import org.cqfn.diktat.common.config.rules.DIKTAT_RULE_SET_ID
 import org.cqfn.diktat.common.config.rules.RulesConfig
@@ -157,11 +156,18 @@ abstract class DiktatSmokeTestBase {
 
         assertUnfixedLintErrors { unfixedLintErrors ->
             Assertions.assertFalse(
-                unfixedLintErrors.contains(LintError(line = 1, col = 1, ruleId = "diktat-ruleset:${CommentsRule.NAME_ID}", detail = "${Warnings.COMMENTED_OUT_CODE.warnText()} /*"))
+                unfixedLintErrors.contains(
+                    DiktatError(
+                        line = 1,
+                        col = 1,
+                        ruleId = "diktat-ruleset:${CommentsRule.NAME_ID}",
+                        detail = "${Warnings.COMMENTED_OUT_CODE.warnText()} /*"
+                    )
+                )
             )
 
             Assertions.assertTrue(
-                unfixedLintErrors.contains(LintError(1, 1, "diktat-ruleset:${InlineClassesRule.NAME_ID}", "${Warnings.INLINE_CLASS_CAN_BE_USED.warnText()} class Some"))
+                unfixedLintErrors.contains(DiktatError(1, 1, "diktat-ruleset:${InlineClassesRule.NAME_ID}", "${Warnings.INLINE_CLASS_CAN_BE_USED.warnText()} class Some"))
             )
         }
     }
@@ -203,11 +209,11 @@ abstract class DiktatSmokeTestBase {
         fixAndCompare(configFilePath, "Example2Expected.kt", "Example2Test.kt")
         assertUnfixedLintErrors { unfixedLintErrors ->
             assertThat(unfixedLintErrors).containsExactlyInAnyOrder(
-                LintError(1, 1, "$DIKTAT_RULE_SET_ID:${HeaderCommentRule.NAME_ID}",
+                DiktatError(1, 1, "$DIKTAT_RULE_SET_ID:${HeaderCommentRule.NAME_ID}",
                     "${HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE.warnText()} there are 2 declared classes and/or objects", false),
-                LintError(15, 23, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}",
+                DiktatError(15, 23, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}",
                     "${KDOC_WITHOUT_PARAM_TAG.warnText()} createWithFile (containerName)", true),
-                LintError(31, 14, "$DIKTAT_RULE_SET_ID:${EmptyBlock.NAME_ID}",
+                DiktatError(31, 14, "$DIKTAT_RULE_SET_ID:${EmptyBlock.NAME_ID}",
                     "${EMPTY_BLOCK_STRUCTURE_ERROR.warnText()} empty blocks are forbidden unless it is function with override keyword", false)
             )
         }
@@ -229,23 +235,23 @@ abstract class DiktatSmokeTestBase {
         fixAndCompare(configFilePath, "Example1Expected.kt", "Example1Test.kt")
         assertUnfixedLintErrors { unfixedLintErrors ->
             assertThat(unfixedLintErrors).containsExactlyInAnyOrder(
-                LintError(1, 1, "$DIKTAT_RULE_SET_ID:${FileNaming.NAME_ID}", "${FILE_NAME_MATCH_CLASS.warnText()} Example1Test.kt vs Example", true),
-                LintError(1, 1, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
-                LintError(3, 6, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_TOP_LEVEL.warnText()} Example", false),
-                LintError(3, 26, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} isValid", false),
-                LintError(6, 9, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
-                LintError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
-                LintError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
+                DiktatError(1, 1, "$DIKTAT_RULE_SET_ID:${FileNaming.NAME_ID}", "${FILE_NAME_MATCH_CLASS.warnText()} Example1Test.kt vs Example", true),
+                DiktatError(1, 1, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
+                DiktatError(3, 6, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_TOP_LEVEL.warnText()} Example", false),
+                DiktatError(3, 26, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} isValid", false),
+                DiktatError(6, 9, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
+                DiktatError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
+                DiktatError(8, 8, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
                 /*
                  * This 2nd `MISSING_KDOC_ON_FUNCTION` is a duplicate caused by
                  * https://github.com/saveourtool/diktat/issues/1538.
                  */
-                LintError(6, 5, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
-                LintError(9, 3, "$DIKTAT_RULE_SET_ID:${EmptyBlock.NAME_ID}", EMPTY_BLOCK_STRUCTURE_ERROR.warnText() +
+                DiktatError(6, 5, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
+                DiktatError(9, 3, "$DIKTAT_RULE_SET_ID:${EmptyBlock.NAME_ID}", EMPTY_BLOCK_STRUCTURE_ERROR.warnText() +
                         " empty blocks are forbidden unless it is function with override keyword", false),
-                LintError(12, 10, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
-                LintError(14, 8, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
-                LintError(19, 20, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false)
+                DiktatError(12, 10, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
+                DiktatError(14, 8, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
+                DiktatError(19, 20, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false)
             )
         }
     }
@@ -328,7 +334,7 @@ abstract class DiktatSmokeTestBase {
         fixAndCompare(prepareOverriddenRulesConfig(), "kotlin-library-expected.gradle.kts", "kotlin-library.gradle.kts")
         assertUnfixedLintErrors { unfixedLintErrors ->
             assertThat(unfixedLintErrors).containsExactly(
-                LintError(
+                DiktatError(
                     2, 1, "$DIKTAT_RULE_SET_ID:${CommentsRule.NAME_ID}", "[COMMENTED_OUT_CODE] you should not comment out code, " +
                             "use VCS to save it in history and delete this block: import org.jetbrains.kotlin.gradle.dsl.jvm", false
                 )
@@ -351,15 +357,15 @@ abstract class DiktatSmokeTestBase {
         fixAndCompare(configFilePath, "Example1-2Expected.kt", "Example1-2Test.kt")
         assertUnfixedLintErrors { unfixedLintErrors ->
             assertThat(unfixedLintErrors).containsExactlyInAnyOrder(
-                LintError(1, 1, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
-                LintError(3, 1, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_TOP_LEVEL.warnText()} example", false),
-                LintError(3, 16, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} isValid", false),
-                LintError(6, 5, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
-                LintError(6, 5, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
-                LintError(8, 5, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
-                LintError(10, 4, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
-                LintError(13, 9, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
-                LintError(18, 40, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false)
+                DiktatError(1, 1, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
+                DiktatError(3, 1, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_TOP_LEVEL.warnText()} example", false),
+                DiktatError(3, 16, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} isValid", false),
+                DiktatError(6, 5, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
+                DiktatError(6, 5, "$DIKTAT_RULE_SET_ID:${KdocMethods.NAME_ID}", "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false),
+                DiktatError(8, 5, "$DIKTAT_RULE_SET_ID:${KdocComments.NAME_ID}", "${MISSING_KDOC_CLASS_ELEMENTS.warnText()} foo", false),
+                DiktatError(10, 4, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
+                DiktatError(13, 9, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false),
+                DiktatError(18, 40, "$DIKTAT_RULE_SET_ID:${KdocFormatting.NAME_ID}", "${KDOC_NO_EMPTY_TAGS.warnText()} @return", false)
             )
         }
     }


### PR DESCRIPTION
### What's done:
- inlined typealias for LintError
- inserted codecov token implicitly

