### PR TITLE
Fixed TrailingCommaRule and StringTemplateRuleFixTest

### DIFF
--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter3/StringTemplateFormatRule.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter3/StringTemplateFormatRule.kt
@@ -73,7 +73,7 @@ class StringTemplateFormatRule(configRules: List<RulesConfig>) : DiktatRule(
 
         if (identifierName != null && node.treeParent.text.trim('"', '$') == identifierName) {
             STRING_TEMPLATE_QUOTES.warnAndFix(configRules, emitWarn, isFixMode, node.text, node.startOffset, node) {
-                val identifier = node.findChildByType(REFERENCE_EXPRESSION)!!.copyElement()
+                val identifier = node.findChildByType(REFERENCE_EXPRESSION)!!
                 // node.treeParent is String template that we need to delete
                 node.treeParent.treeParent.addChild(identifier, node.treeParent)
                 node.treeParent.treeParent.removeChild(node.treeParent)

--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
@@ -101,7 +101,7 @@ class TrailingCommaRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     private fun ASTNode.checkTrailingComma(config: Boolean) {
-        val noCommaInSiblings = siblings(true).toList()
+        val noCommaInSiblings = siblings(true).toSet()
             .let { siblings ->
                 siblings.none { it.elementType == COMMA } && siblings.any { it.isWhiteSpaceWithNewline() || it.isPartOfComment() }
             }

--- a/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/StringTemplateRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/StringTemplateRuleFixTest.kt
@@ -4,14 +4,12 @@ import com.saveourtool.diktat.ruleset.rules.chapter3.StringTemplateFormatRule
 import com.saveourtool.diktat.util.FixTestBase
 
 import generated.WarningNames
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 class StringTemplateRuleFixTest : FixTestBase("test/paragraph3/string_template", ::StringTemplateFormatRule) {
     @Test
     @Tag(WarningNames.STRING_TEMPLATE_CURLY_BRACES)
-    @Disabled("https://github.com/saveourtool/diktat/issues/1737")
     fun `should fix enum order`() {
         fixAndCompare("StringTemplateExpected.kt", "StringTemplateTest.kt")
     }

--- a/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/StringTemplateRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/StringTemplateRuleWarnTest.kt
@@ -122,4 +122,20 @@ class StringTemplateRuleWarnTest : LintTestBase(::StringTemplateFormatRule) {
             """.trimMargin()
         )
     }
+
+    @Test
+    @Tag(STRING_TEMPLATE_QUOTES)
+    fun `should trigger on long string template`() {
+        lintMethod(
+            """
+                    |class Some {
+                    |   fun some() {
+                    |       val x = "asd"
+                    |       val trippleQuotes = ""${'"'}${'$'}x""${'"'}
+                    |   }
+                    |}
+            """.trimMargin(),
+            DiktatError(4, 31, ruleId, "${Warnings.STRING_TEMPLATE_QUOTES.warnText()} ${'$'}x", true)
+        )
+    }
 }

--- a/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/TrailingCommaFixTest.kt
+++ b/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/TrailingCommaFixTest.kt
@@ -30,7 +30,6 @@ class TrailingCommaFixTest : FixTestBase("test/paragraph3/trailing_comma", ::Tra
 
     @Test
     @Tag(WarningNames.TRAILING_COMMA)
-    @Disabled("https://github.com/saveourtool/diktat/issues/1737")
     fun `should add all trailing comma`() {
         fixAndCompare("TrailingCommaExpected.kt", "TrailingCommaTest.kt", config)
     }

--- a/diktat-rules/src/test/resources/test/paragraph3/string_template/StringTemplateExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/string_template/StringTemplateExpected.kt
@@ -12,7 +12,7 @@ class SomeClass {
 
         val binExpr = "${foo as Foo}"
 
-        val trippleQuotes = """$x"""
+        val trippleQuotes = x
 
         val test = """${'$'}"""
 


### PR DESCRIPTION
### What's done:
- add checking children to support case with comma before comment
- reused ASTFactory

It's part of #1737
