### PR TITLE
Fixed BracesInConditionalsAndLoopsRule and added tests

### DIFF
--- a/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/BracesRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter3/BracesRuleFixTest.kt
@@ -4,14 +4,12 @@ import com.saveourtool.diktat.ruleset.rules.chapter3.BracesInConditionalsAndLoop
 import com.saveourtool.diktat.util.FixTestBase
 
 import generated.WarningNames
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 class BracesRuleFixTest : FixTestBase("test/paragraph3/braces", ::BracesInConditionalsAndLoopsRule) {
     @Test
     @Tag(WarningNames.NO_BRACES_IN_CONDITIONALS_AND_LOOPS)
-    @Disabled("https://github.com/saveourtool/diktat/issues/1737")
     fun `should add braces to if-else statements - 1`() {
         fixAndCompare("IfElseBraces1Expected.kt", "IfElseBraces1Test.kt")
     }
@@ -36,7 +34,6 @@ class BracesRuleFixTest : FixTestBase("test/paragraph3/braces", ::BracesInCondit
 
     @Test
     @Tag(WarningNames.NO_BRACES_IN_CONDITIONALS_AND_LOOPS)
-    @Disabled("https://github.com/saveourtool/diktat/issues/1737")
     fun `should add braces to do-while loops with empty body`() {
         fixAndCompare("DoWhileBracesExpected.kt", "DoWhileBracesTest.kt")
     }

--- a/diktat-rules/src/test/resources/test/paragraph3/braces/IfElseBraces1Expected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/braces/IfElseBraces1Expected.kt
@@ -27,7 +27,85 @@ fun foo3() {
 fun foo4() {
     if (x > 0) {
     } else {
-    } ;
+    };
+}
+
+fun foo5() {
+    if (x > 0)
+        {
+        foo()
+    } else
+        {
+        bar()
+    }
+}
+
+fun foo6() {
+    if (x > 0) {
+        foo()
+    } else if (y > 0) {
+        abc()
+    } else {
+        bar()
+    }
+}
+
+fun foo7() {
+    if (x > 0)
+        {
+        foo()
+    } else if (y > 0)
+        {
+        abc()
+    } else
+        {
+        bar()
+    }
+}
+
+fun foo8() {
+    if (x > 0) {
+        if (y > 0) foo() else abc()
+    } else {
+        bar()
+    }
+}
+
+fun foo9() {
+    if (x > 0) {
+        foo()
+    } else if (y > 0) {
+        abc()
+    } else {
+        bar()
+    }
+}
+
+fun foo10() {
+    if (x > 0) {
+        foo()
+    } else if (z > 0) {
+        if (y > 0) abc() else qwe()
+    } else {
+        bar()
+    }
+}
+
+fun foo11() {
+    if (x > 0) else bar()
+}
+
+fun foo12() {
+    if (x > 0) {
+        foo()
+    } else {
+    };
+}
+
+fun foo13() {
+    if (x > 0) {
+    } else {
+    };
 }
 
 fun foo() {

--- a/diktat-rules/src/test/resources/test/paragraph3/braces/IfElseBraces1Test.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/braces/IfElseBraces1Test.kt
@@ -25,6 +25,56 @@ fun foo4() {
     else ;
 }
 
+fun foo5() {
+    if (x > 0)
+        foo()
+    else
+        bar()
+}
+
+fun foo6() {
+    if (x > 0) foo()
+    else if (y > 0) abc()
+    else bar()
+}
+
+fun foo7() {
+    if (x > 0)
+        foo()
+    else if (y > 0)
+        abc()
+    else
+        bar()
+}
+
+fun foo8() {
+    if (x > 0) if (y > 0) foo() else abc()
+    else bar()
+}
+
+fun foo9() {
+    if (x > 0) foo()
+    else if (y > 0) abc() else bar()
+}
+
+fun foo10() {
+    if (x > 0) foo()
+    else if (z > 0) if (y > 0) abc() else qwe()
+    else bar()
+}
+
+fun foo11() {
+    if (x > 0) else bar()
+}
+
+fun foo12() {
+    if (x > 0) foo() else ;
+}
+
+fun foo13() {
+    if (x > 0) else ;
+}
+
 fun foo() {
     if (a) {
         bar()


### PR DESCRIPTION
### What's done:
- Reworked `insertEmptyBlock()` function for adding empty braces blocks to conditions and `do-while` loop with empty bodies.
- Added check for braces block existence to avoid duplicate braces block.
- Added tests for conditions including tests for cases of `else if` and cases of empty `if` and `else` bodies.

It's part of #1737
