### PR TITLE
Support a full path in DiktatReporter

### DIFF
--- a/diktat-api/src/main/kotlin/com/saveourtool/diktat/DiktatRunnerArguments.kt
+++ b/diktat-api/src/main/kotlin/com/saveourtool/diktat/DiktatRunnerArguments.kt
@@ -21,7 +21,7 @@ import kotlin.io.path.inputStream
  */
 data class DiktatRunnerArguments(
     val configInputStream: InputStream,
-    val sourceRootDir: Path,
+    val sourceRootDir: Path?,
     val files: Collection<Path>,
     val baselineFile: Path?,
     val reporterType: String,
@@ -32,7 +32,7 @@ data class DiktatRunnerArguments(
 ) {
     constructor(
         configFile: Path,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
         files: Collection<Path>,
         baselineFile: Path?,
         reporterType: String,

--- a/diktat-api/src/main/kotlin/com/saveourtool/diktat/DiktatRunnerFactory.kt
+++ b/diktat-api/src/main/kotlin/com/saveourtool/diktat/DiktatRunnerFactory.kt
@@ -52,7 +52,7 @@ class DiktatRunnerFactory(
 
     private fun resolveBaseline(
         baselineFile: Path?,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
     ): Pair<DiktatBaseline, DiktatProcessorListener> = baselineFile
         ?.let { diktatBaselineFactory.tryToLoad(it, sourceRootDir) }
         ?.let { it to DiktatProcessorListener.empty }
@@ -68,7 +68,7 @@ class DiktatRunnerFactory(
         reporterOutput: OutputStream?,
         colorNameInPlain: String?,
         groupByFileInPlain: Boolean?,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
     ): DiktatReporter {
         val (outputStream, closeOutputStream) = reporterOutput?.let { it to true } ?: (System.`out` to false)
         return if (reporterType == diktatReporterFactory.plainId) {

--- a/diktat-api/src/main/kotlin/com/saveourtool/diktat/api/DiktatBaselineFactory.kt
+++ b/diktat-api/src/main/kotlin/com/saveourtool/diktat/api/DiktatBaselineFactory.kt
@@ -13,7 +13,7 @@ interface DiktatBaselineFactory {
      */
     fun tryToLoad(
         baselineFile: Path,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
     ): DiktatBaseline?
 
     /**
@@ -23,6 +23,6 @@ interface DiktatBaselineFactory {
      */
     fun generator(
         baselineFile: Path,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
     ): DiktatProcessorListener
 }

--- a/diktat-api/src/main/kotlin/com/saveourtool/diktat/api/DiktatReporterFactory.kt
+++ b/diktat-api/src/main/kotlin/com/saveourtool/diktat/api/DiktatReporterFactory.kt
@@ -8,7 +8,7 @@ typealias DiktatReporter = DiktatProcessorListener
 /**
  * A factory to create [DiktatReporter]
  */
-interface DiktatReporterFactory : Function4<String, OutputStream, Boolean, Path, DiktatReporter> {
+interface DiktatReporterFactory : Function4<String, OutputStream, Boolean, Path?, DiktatReporter> {
     /**
      * Set of supported IDs
      */
@@ -35,7 +35,7 @@ interface DiktatReporterFactory : Function4<String, OutputStream, Boolean, Path,
         id: String,
         outputStream: OutputStream,
         closeOutputStreamAfterAll: Boolean,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
     ): DiktatReporter
 
     /**
@@ -49,7 +49,7 @@ interface DiktatReporterFactory : Function4<String, OutputStream, Boolean, Path,
     fun createPlain(
         outputStream: OutputStream,
         closeOutputStreamAfterAll: Boolean,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
         colorName: String? = null,
         groupByFile: Boolean? = null,
     ): DiktatReporter

--- a/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
@@ -41,7 +41,7 @@ fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> =
     KotlinClosure1(action, this, this)
 
 /**
-  * @param diktatExtension
+ * @param diktatExtension
  * @return returns sourceRootDir as projectDir for sarif report
  */
 fun Project.getSourceRootDir(diktatExtension: DiktatExtension): Path? = when {

--- a/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
@@ -41,6 +41,7 @@ fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> =
     KotlinClosure1(action, this, this)
 
 /**
+  * @param diktatExtension
  * @return returns sourceRootDir as projectDir for sarif report
  */
 fun Project.getSourceRootDir(diktatExtension: DiktatExtension): Path? = when {
@@ -48,6 +49,7 @@ fun Project.getSourceRootDir(diktatExtension: DiktatExtension): Path? = when {
     diktatExtension.reporter == "sarif" -> projectDir.toPath()
     else -> null
 }
+
 /**
  * Create CLI flag to set reporter for ktlint based on [diktatExtension].
  * [DiktatExtension.githubActions] should have higher priority than a custom input.

--- a/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
@@ -10,6 +10,7 @@ import groovy.lang.Closure
 import org.gradle.api.Project
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 
 @Suppress(
     "MISSING_KDOC_TOP_LEVEL",
@@ -39,6 +40,13 @@ class KotlinClosure1<in T : Any?, V : Any>(
 fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> =
     KotlinClosure1(action, this, this)
 
+/**
+ * @return returns sourceRootDir as projectDir for sarif report
+ */
+fun Project.getSourceRootDir(diktatExtension: DiktatExtension): Path? = when {
+    diktatExtension.githubActions -> project.projectDir.toPath()
+    else -> null
+}
 /**
  * Create CLI flag to set reporter for ktlint based on [diktatExtension].
  * [DiktatExtension.githubActions] should have higher priority than a custom input.

--- a/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/Utils.kt
@@ -44,7 +44,8 @@ fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> =
  * @return returns sourceRootDir as projectDir for sarif report
  */
 fun Project.getSourceRootDir(diktatExtension: DiktatExtension): Path? = when {
-    diktatExtension.githubActions -> project.projectDir.toPath()
+    diktatExtension.githubActions -> projectDir.toPath()
+    diktatExtension.reporter == "sarif" -> projectDir.toPath()
     else -> null
 }
 /**

--- a/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/tasks/DiktatTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/tasks/DiktatTaskBase.kt
@@ -10,6 +10,7 @@ import com.saveourtool.diktat.ktlint.DiktatReporterFactoryImpl
 import com.saveourtool.diktat.plugin.gradle.DiktatExtension
 import com.saveourtool.diktat.plugin.gradle.getOutputFile
 import com.saveourtool.diktat.plugin.gradle.getReporterType
+import com.saveourtool.diktat.plugin.gradle.getSourceRootDir
 import com.saveourtool.diktat.ruleset.rules.DiktatRuleConfigReaderImpl
 import com.saveourtool.diktat.ruleset.rules.DiktatRuleSetFactoryImpl
 
@@ -79,7 +80,7 @@ abstract class DiktatTaskBase(
     private val diktatRunnerArguments by lazy {
         DiktatRunnerArguments(
             configFile = extension.diktatConfigFile.toPath(),
-            sourceRootDir = null,
+            sourceRootDir = project.getSourceRootDir(extension),
             files = actualInputs.files.map { it.toPath() },
             baselineFile = extension.baseline?.let { project.file(it).toPath() },
             reporterType = project.getReporterType(extension),

--- a/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/tasks/DiktatTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/tasks/DiktatTaskBase.kt
@@ -79,7 +79,7 @@ abstract class DiktatTaskBase(
     private val diktatRunnerArguments by lazy {
         DiktatRunnerArguments(
             configFile = extension.diktatConfigFile.toPath(),
-            sourceRootDir = project.projectDir.toPath(),
+            sourceRootDir = null,
             files = actualInputs.files.map { it.toPath() },
             baselineFile = extension.baseline?.let { project.file(it).toPath() },
             reporterType = project.getReporterType(extension),

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatBaselineFactoryImpl.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatBaselineFactoryImpl.kt
@@ -22,7 +22,7 @@ class DiktatBaselineFactoryImpl : DiktatBaselineFactory {
 
     override fun tryToLoad(
         baselineFile: Path,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
     ): DiktatBaseline? = loadBaseline(baselineFile.absolutePathString())
         .takeIf { it.status == Baseline.Status.VALID }
         ?.let { ktLintBaseline ->
@@ -34,6 +34,12 @@ class DiktatBaselineFactoryImpl : DiktatBaselineFactory {
             }
         }
 
-    override fun generator(baselineFile: Path, sourceRootDir: Path): DiktatProcessorListener =
-        baselineReporterProvider.get(baselineFile.outputStream(), closeOutAfterAll = true, emptyMap()).wrap(sourceRootDir)
+    override fun generator(
+        baselineFile: Path,
+        sourceRootDir: Path?,
+    ): DiktatProcessorListener = baselineReporterProvider.get(
+        baselineFile.outputStream(),
+        closeOutAfterAll = true,
+        emptyMap(),
+    ).wrap(sourceRootDir)
 }

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatReporterFactoryImpl.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatReporterFactoryImpl.kt
@@ -38,17 +38,17 @@ class DiktatReporterFactoryImpl : DiktatReporterFactory {
         get() = plainReporterProvider.id
 
     override val colorNamesInPlain: Set<String>
-        get() = Color.values().map { it.name }.toSet()
+        get() = Color.entries.map { it.name }.toSet()
 
     override fun invoke(
         id: String,
         outputStream: OutputStream,
         closeOutputStreamAfterAll: Boolean,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
     ): DiktatReporter {
         val reporterProvider = reporterProviders[id] ?: throw IllegalArgumentException("Not supported reporter id by ${DiktatBaselineFactoryImpl::class.simpleName}")
         if (reporterProvider is SarifReporterProvider) {
-            System.setProperty("user.home", sourceRootDir.pathString)
+            sourceRootDir?.let { System.setProperty("user.home", it.pathString) }
         }
         val opt = if (reporterProvider is PlainReporterProvider) {
             mapOf("color_name" to Color.DARK_GRAY.name)
@@ -61,7 +61,7 @@ class DiktatReporterFactoryImpl : DiktatReporterFactory {
     override fun createPlain(
         outputStream: OutputStream,
         closeOutputStreamAfterAll: Boolean,
-        sourceRootDir: Path,
+        sourceRootDir: Path?,
         colorName: String?,
         groupByFile: Boolean?,
     ): DiktatReporter {

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatReporterImpl.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatReporterImpl.kt
@@ -14,7 +14,7 @@ import java.nio.file.Path
  */
 class DiktatReporterImpl(
     private val ktLintReporter: ReporterV2,
-    private val sourceRootDir: Path,
+    private val sourceRootDir: Path?,
 ) : DiktatReporter {
     override fun beforeAll(files: Collection<Path>): Unit = ktLintReporter.beforeAll()
     override fun before(file: Path): Unit = ktLintReporter.before(file.relativePathStringTo(sourceRootDir))
@@ -31,7 +31,7 @@ class DiktatReporterImpl(
          * @param sourceRootDir
          * @return [DiktatReporter] which wraps __KtLint__'s [ReporterV2]
          */
-        fun ReporterV2.wrap(sourceRootDir: Path): DiktatReporter = DiktatReporterImpl(this, sourceRootDir)
+        fun ReporterV2.wrap(sourceRootDir: Path?): DiktatReporter = DiktatReporterImpl(this, sourceRootDir)
 
         /**
          * @return __KtLint__'s [ReporterV2]

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/KtLintUtils.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/KtLintUtils.kt
@@ -92,7 +92,7 @@ fun String.correctErrorDetail(canBeAutoCorrected: Boolean): String = if (canBeAu
  * @param sourceRootDir
  * @return relative path to [sourceRootDir] as [String]
  */
-fun Path.relativePathStringTo(sourceRootDir: Path): String = relativeTo(sourceRootDir).invariantSeparatorsPathString
+fun Path.relativePathStringTo(sourceRootDir: Path?): String = (sourceRootDir?.let { relativeTo(it) } ?: this).invariantSeparatorsPathString
 
 /**
  * @param out [OutputStream] for [ReporterV2]


### PR DESCRIPTION
### What's done:
- supported sourceRootDir as null in DiktatReporter
- pass sourceRootDir as null in gradle plugin

It closes #1795