### PR TITLE
Fix mergeDiktatReports

### DIFF
--- a/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/tasks/SarifReportMergeTask.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/gradle/tasks/SarifReportMergeTask.kt
@@ -99,7 +99,7 @@ internal fun Project.configureMergeReportsTask() {
 
     rootMergeSarifReportsTask.configure { reportMergeTask ->
         reportMergeTask.input.from(getGitHubActionReporterOutput())
-        reportMergeTask.dependsOn(diktatCheckTask)
+        reportMergeTask.mustRunAfter(diktatCheckTask)
     }
     diktatCheckTask.configure {
         it.finalizedBy(rootMergeSarifReportsTask)


### PR DESCRIPTION
### What's done:
- mustRunAfter instead of dependsOn to allow run `mergeDiktatReports` after failing diktatCheck

It closes #1733