### PR TITLE
serialVersionUID should be ignored in `CONSTANT_UPPERCASE`

### DIFF
--- a/diktat-analysis.yml
+++ b/diktat-analysis.yml
@@ -18,6 +18,8 @@
 # Checks that CONSTANT (treated as const val from companion object or class level) is in non UPPER_SNAKE_CASE
 - name: CONSTANT_UPPERCASE
   enabled: true
+  configuration:
+    exceptionConstNames: "serialVersionUID"
 # Checks that enum value is in upper SNAKE_CASE or in PascalCase depending on the config. UPPER_SNAKE_CASE is the default, but can be changed by 'enumStyle' config
 - name: ENUM_VALUE
   enabled: true

--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
@@ -152,6 +152,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
     )
 
     private fun checkVariableName(node: ASTNode): List<ASTNode> {
+        val exceptionConstNames = setOf("serialVersionUID")
         // special case for Destructuring declarations that can be treated as parameters in lambda:
         var namesOfVariables = extractVariableIdentifiers(node)
 
@@ -178,7 +179,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
                 // check for constant variables - check for val from companion object or on global file level
                 // it should be in UPPER_CASE, no need to raise this warning if it is one-letter variable
                 if (node.isConstant()) {
-                    if (!variableName.text.isUpperSnakeCase() && variableName.text.length > 1) {
+                    if (!variableName.text.isUpperSnakeCase() && variableName.text.length > 1 && !exceptionConstNames.contains(variableName.text)) {
                         CONSTANT_UPPERCASE.warnOnlyOrWarnAndFix(
                             configRules = configRules,
                             emit = emitWarn,

--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter1/IdentifierNaming.kt
@@ -152,7 +152,12 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
     )
 
     private fun checkVariableName(node: ASTNode): List<ASTNode> {
-        val exceptionConstNames = setOf("serialVersionUID")
+        val configuration = ConstantUpperCaseConfiguration(
+            configRules.getRuleConfig(CONSTANT_UPPERCASE)?.configuration
+                ?: emptyMap())
+
+        val exceptionNames = configuration.exceptionConstNames
+
         // special case for Destructuring declarations that can be treated as parameters in lambda:
         var namesOfVariables = extractVariableIdentifiers(node)
 
@@ -179,7 +184,7 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
                 // check for constant variables - check for val from companion object or on global file level
                 // it should be in UPPER_CASE, no need to raise this warning if it is one-letter variable
                 if (node.isConstant()) {
-                    if (!variableName.text.isUpperSnakeCase() && variableName.text.length > 1 && !exceptionConstNames.contains(variableName.text)) {
+                    if (!exceptionNames.contains(variableName.text) && !variableName.text.isUpperSnakeCase() && variableName.text.length > 1) {
                         CONSTANT_UPPERCASE.warnOnlyOrWarnAndFix(
                             configRules = configRules,
                             emit = emitWarn,
@@ -492,6 +497,10 @@ class IdentifierNaming(configRules: List<RulesConfig>) : DiktatRule(
             }
             style
         } ?: Style.SNAKE_CASE
+    }
+
+    class ConstantUpperCaseConfiguration(config: Map<String, String>) : RuleConfiguration(config) {
+        val exceptionConstNames = config["exceptionConstNames"]?.split(',') ?: emptyList()
     }
 
     class BooleanFunctionsConfiguration(config: Map<String, String>) : RuleConfiguration(config) {

--- a/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -41,6 +41,11 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
         RulesConfig(FUNCTION_BOOLEAN_PREFIX.name, true,
             mapOf("allowedPrefixes" to "equals, equivalent, foo"))
     )
+    private val rulesConfigConstantUpperCase = listOf(
+        RulesConfig(CONSTANT_UPPERCASE.name, true, mapOf(
+            "exceptionConstNames" to "serialVersionUID"
+        ))
+    )
 
     // ======== checks for generics ========
     @Test
@@ -205,7 +210,8 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                         private const val serialVersionUID: Long = -1
                     }
                 }
-            """.trimIndent()
+            """.trimIndent(),
+            rulesConfigList = rulesConfigConstantUpperCase
         )
     }
 

--- a/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/com/saveourtool/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -196,6 +196,36 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     }
 
     @Test
+    @Tag(WarningNames.CONSTANT_UPPERCASE)
+    fun `serialVersionUID should be ignored`() {
+        lintMethod(
+            """
+                class TestSerializableClass() : Serializable {
+                    companion object {
+                        private const val serialVersionUID: Long = -1
+                    }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.CONSTANT_UPPERCASE)
+    fun `should trigger when the name is not exception`() {
+        val code =
+            """
+                class TestSerializableClass() : Serializable {
+                    companion object {
+                        private const val serialVersion: Long = -1
+                    }
+                }
+            """.trimIndent()
+        lintMethod(code,
+            DiktatError(3, 27, ruleId, "${CONSTANT_UPPERCASE.warnText()} serialVersion", true)
+        )
+    }
+
+    @Test
     @Tags(Tag(WarningNames.IDENTIFIER_LENGTH), Tag(WarningNames.VARIABLE_NAME_INCORRECT))
     fun `check variable length (check - negative)`() {
         val code =


### PR DESCRIPTION
### What's done:
- Fixed `serialVersionUID`, which should be ignored in `CONSTANT_UPPERCASE`
- Added warning test

Closes #1847