### PR TITLE
Fixed duplicate `@property` generation for parameter with ' in name

### DIFF
--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
@@ -483,6 +483,7 @@ class KdocComments(configRules: List<RulesConfig>) : DiktatRule(
             }
     }
 
+    @Suppress("UnsafeCallOnNullableType")
     private fun getParameterName(node: ASTNode) = node.findChildByType(IDENTIFIER)!!.text.replace("`", "")
 
     private fun findParameterTagInClassKdoc(kdocBeforeClass: ASTNode, parameterName: String) =

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentExpected.kt
@@ -309,3 +309,16 @@ class A<K : Any, P: Any, G: Any> constructor(
      */
     paramAddr: String,
 ) : B<K>(), C<P>, D<G> {}
+
+/**
+ * kdoc
+ * class
+ * comment
+ *
+ * @property as
+ * @property keyAs
+ */
+actual annotation class JsonSerialize(
+    actual val `as`: KClass<*>,
+    actual val keyAs: KClass<*>,
+)

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentNoKDocExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentNoKDocExpected.kt
@@ -238,3 +238,12 @@ class A<K : Any, P: Any, G: Any> constructor(
      */
     paramAddr: String,
 ) : B<K>(), C<P>, D<G> {}
+
+/**
+ * @property as
+ * @property keyAs
+ */
+actual annotation class JsonSerialize(
+    actual val `as`: KClass<*>,
+    actual val keyAs: KClass<*>,
+)

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentNoKDocTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentNoKDocTest.kt
@@ -223,3 +223,8 @@ class A<K : Any, P: Any, G: Any> constructor(
      */
     paramAddr: String,
 ) : B<K>(), C<P>, D<G> {}
+
+actual annotation class JsonSerialize(
+    actual val `as`: KClass<*>,
+    actual val keyAs: KClass<*>,
+)

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentPropertiesExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentPropertiesExpected.kt
@@ -263,3 +263,12 @@ class A<K : Any, P: Any, G: Any> constructor(
      */
     paramAddr: String,
 ) : B<K>(), C<P>, D<G> {}
+
+/**
+ * @property keyAs
+ * @property as
+ */
+actual annotation class JsonSerialize(
+    actual val `as`: KClass<*>,
+    actual val keyAs: KClass<*>,
+)

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentPropertiesTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentPropertiesTest.kt
@@ -289,3 +289,11 @@ class A<K : Any, P: Any, G: Any> constructor(
      */
     paramAddr: String,
 ) : B<K>(), C<P>, D<G> {}
+
+/**
+ * @property keyAs
+ */
+actual annotation class JsonSerialize(
+    actual val `as`: KClass<*>,
+    actual val keyAs: KClass<*>,
+)

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/ConstructorCommentTest.kt
@@ -308,3 +308,13 @@ class A<K : Any, P: Any, G: Any> constructor(
      */
     paramAddr: String,
 ) : B<K>(), C<P>, D<G> {}
+
+/**
+ * kdoc
+ * class
+ * comment
+ */
+actual annotation class JsonSerialize(
+    actual val `as`: KClass<*>,
+    actual val keyAs: KClass<*>,
+)


### PR DESCRIPTION
### What's done:
- fixed bug.
- added fix tests.

Closes #1719