### PR TITLE
fix(diktat-maven-plugin): Maven projects with non local parent POM

### DIFF
--- a/diktat-maven-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/maven/DiktatBaseMojo.kt
+++ b/diktat-maven-plugin/src/main/kotlin/com/saveourtool/diktat/plugin/maven/DiktatBaseMojo.kt
@@ -92,7 +92,7 @@ abstract class DiktatBaseMojo : AbstractMojo() {
                 if (excludes.isNotEmpty()) " and excluding $excludes" else ""
         )
 
-        val sourceRootDir = generateSequence(mavenProject) { it.parent }.last().basedir.toPath()
+        val sourceRootDir = getSourceRootDirTransitive()
         val reporters: List<Reporter> = (reporters?.getAll() ?: listOf(PlainReporter()))
             .let { all ->
                 if (githubActions && all.filterIsInstance<GitHubActionsReporter>().isEmpty()) {
@@ -137,6 +137,13 @@ abstract class DiktatBaseMojo : AbstractMojo() {
             .map { it.basedir.toPath().resolve(diktatConfigFile) }
             .firstOrNull { it.isRegularFile() }
     }
+
+    private fun getSourceRootDirTransitive(): Path = generateSequence(mavenProject) { project ->
+        val parent = project.parent
+        parent?.basedir?.let {
+            parent
+        }
+    }.last().basedir.toPath()
 
     private fun files(): List<Path> {
         val (excludedDirs, excludedFiles) = excludes.map(::File).partition { it.isDirectory }


### PR DESCRIPTION
In [1] support for mulimodule Maven projects are introduced. But fails for Maven projects with non local parent POM like Spring Boot projects:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  …
  <parent>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-starter-parent</artifactId>
    <version>3.2.4</version>
    <relativePath/> <!-- lookup parent from repository -->
  </parent>
  …
</project>
```

Invoke `mvn diktat:{check|fix}` fails with:
```
[ERROR] Failed to execute goal com.saveourtool.diktat:diktat-maven-plugin:2.0.0:fix (default-cli) on project …: Execution default-cli of goal com.saveourtool.diktat:diktat-maven-plugin:2.0.0:fix failed: Cannot invoke "java.io.File.toPath()" because the return value of "org.apache.maven.project.MavenProject.getBasedir()" is null -> [Help 1]
```

Fixes #1893.

[1]: https://github.com/saveourtool/diktat/commit/3c572f1e246a2ea8a20194fcb69b8446e6c4f1fb