### PR TITLE
Support of Kotlin 2.1 and corresponding Ktlint 1.5 update

### DIFF
--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -34,6 +34,7 @@ jobs:
             --build-cache
             -PgprUser=${{ github.actor }}
             -PgprKey=${{ secrets.GITHUB_TOKEN }}
+            --stacktrace
       - name: Upload SARIF report to Github
         uses: github/codeql-action/upload-sarif@v3
         if: ${{ always() }}

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -81,7 +81,7 @@ complexity:
     threshold: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false
-  ComplexMethod:
+  CyclomaticComplexMethod:
     active: true
     threshold: 15
     ignoreSingleWhenExpression: false
@@ -253,7 +253,6 @@ naming:
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
-    ignoreOverridden: true
   EnumNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -275,14 +274,12 @@ naming:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
     excludeClassPattern: '$^'
-    ignoreOverridden: true
     ignoreAnnotated: ['Composable']
   FunctionParameterNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
-    ignoreOverridden: true
   InvalidPackageDeclaration:
     active: false
     excludes: ['*.kts']
@@ -328,7 +325,6 @@ naming:
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
-    ignoreOverridden: true
 
 performance:
   active: true
@@ -351,8 +347,6 @@ potential-bugs:
     active: true
   DontDowncastCollectionTypes:
     active: true
-  DuplicateCaseInWhenExpression:
-    active: true
   EqualsAlwaysReturnsTrueOrFalse:
     active: true
   EqualsWithHashCodeExist:
@@ -365,7 +359,7 @@ potential-bugs:
     active: false
   IgnoredReturnValue:
     active: true
-    restrictToAnnotatedMethods: true
+    restrictToConfig: true
     returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
   ImplicitDefaultLocale:
     active: false
@@ -384,13 +378,8 @@ potential-bugs:
     ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     active: false
-  MissingWhenCase:
-    active: true
-    allowElseExpression: true
   NullableToStringCall:
     active: false
-  RedundantElseInWhen:
-    active: true
   UnconditionalJumpStatementInLoop:
     active: false
   UnnecessaryNotNullOperator:
@@ -437,10 +426,6 @@ style:
   ExpressionBodySyntax:
     active: false
     includeLineWrapping: false
-  ForbiddenComment:
-    active: true
-    values: ['TODO:', 'STOPSHIP:']
-    allowedPatterns: ''
   ForbiddenImport:
     active: false
     imports: []
@@ -486,8 +471,6 @@ style:
     ignoreEnums: false
     ignoreRanges: false
     ignoreExtensionFunctions: true
-  MandatoryBracesIfStatements:
-    active: false
   MandatoryBracesLoops:
     active: false
   MaxLineLength:
@@ -511,8 +494,6 @@ style:
   OptionalAbstractKeyword:
     active: true
   OptionalUnit:
-    active: false
-  OptionalWhenBraces:
     active: false
   PreferToOverPairSyntax:
     active: false

--- a/diktat-analysis.yml
+++ b/diktat-analysis.yml
@@ -10,7 +10,7 @@
     # or: "1, 2, 3, 4, 5, 6"
     disabledChapters: ""
     testDirs: test
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -2,6 +2,8 @@ import com.saveourtool.diktat.buildutils.configurePom
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.getCurrentOperatingSystem
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("DSL_SCOPE_VIOLATION", "RUN_IN_SCRIPT")  // https://github.com/gradle/gradle/issues/22797
@@ -31,13 +33,12 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
+    compilerOptions {
         // kotlin 1.4 api is the latest support version in kotlin 1.9
         // min supported Gradle is 7.0
-        languageVersion = "1.4"
-        apiVersion = "1.4"
-        jvmTarget = "1.8"
-        freeCompilerArgs = freeCompilerArgs - "-Werror"
+        languageVersion.set(KotlinVersion.KOTLIN_2_0)
+        apiVersion.set(KotlinVersion.KOTLIN_2_0)
+        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }
 

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatBaselineFactoryImpl.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatBaselineFactoryImpl.kt
@@ -6,6 +6,7 @@ import com.saveourtool.diktat.api.DiktatProcessorListener
 import com.saveourtool.diktat.ktlint.DiktatReporterImpl.Companion.wrap
 
 import com.pinterest.ktlint.cli.reporter.baseline.Baseline
+import com.pinterest.ktlint.cli.reporter.baseline.BaselineErrorHandling
 import com.pinterest.ktlint.cli.reporter.baseline.BaselineReporterProvider
 import com.pinterest.ktlint.cli.reporter.baseline.loadBaseline
 
@@ -23,7 +24,7 @@ class DiktatBaselineFactoryImpl : DiktatBaselineFactory {
     override fun tryToLoad(
         baselineFile: Path,
         sourceRootDir: Path?,
-    ): DiktatBaseline? = loadBaseline(baselineFile.absolutePathString())
+    ): DiktatBaseline? = loadBaseline(baselineFile.absolutePathString(), BaselineErrorHandling.LOG)
         .takeIf { it.status == Baseline.Status.VALID }
         ?.let { ktLintBaseline ->
             DiktatBaseline { file ->

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatProcessorFactoryImpl.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatProcessorFactoryImpl.kt
@@ -84,6 +84,7 @@ class DiktatProcessorFactoryImpl : DiktatProcessorFactory {
             callback: LintCallback,
         ): String {
             // this API method is significantly changed in Ktlint, so -werror was disabled due to it
+            @Suppress("Deprecation")
             val formatResult = format(code)
             lint(
                 code = Code(

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatProcessorFactoryImpl.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/DiktatProcessorFactoryImpl.kt
@@ -83,6 +83,7 @@ class DiktatProcessorFactoryImpl : DiktatProcessorFactory {
             code: Code,
             callback: LintCallback,
         ): String {
+            // this API method is significantly changed in Ktlint, so -werror was disabled due to it
             val formatResult = format(code)
             lint(
                 code = Code(

--- a/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/KtLintRuleWrapper.kt
+++ b/diktat-ktlint-engine/src/main/kotlin/com/saveourtool/diktat/ktlint/KtLintRuleWrapper.kt
@@ -23,6 +23,7 @@ class KtLintRuleWrapper(
     about = about,
     visitorModifiers = createVisitorModifiers(rule, prevRuleId),
 ) {
+    @Deprecated("Marked for removal in Ktlint 2.0. Please implement interface RuleAutocorrectApproveHandler.")
     override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,

--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter3/MultipleModifiersSequence.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/rules/chapter3/MultipleModifiersSequence.kt
@@ -97,7 +97,6 @@ class MultipleModifiersSequence(configRules: List<RulesConfig>) : DiktatRule(
             KtTokens.CROSSINLINE_KEYWORD, KtTokens.VARARG_KEYWORD, KtTokens.SUSPEND_KEYWORD, KtTokens.INNER_KEYWORD,
             KtTokens.OUT_KEYWORD, KtTokens.ENUM_KEYWORD, KtTokens.ANNOTATION_KEYWORD, KtTokens.COMPANION_KEYWORD,
             KtTokens.VALUE_KEYWORD, KtTokens.INLINE_KEYWORD, KtTokens.NOINLINE_KEYWORD, KtTokens.REIFIED_KEYWORD, KtTokens.INFIX_KEYWORD,
-            KtTokens.OPERATOR_KEYWORD, KtTokens.DATA_KEYWORD, KtTokens.IN_KEYWORD, KtTokens.HEADER_KEYWORD,
-            KtTokens.IMPL_KEYWORD)
+            KtTokens.OPERATOR_KEYWORD, KtTokens.DATA_KEYWORD, KtTokens.IN_KEYWORD)
     }
 }

--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/utils/KotlinParser.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/utils/KotlinParser.kt
@@ -2,7 +2,6 @@ package com.saveourtool.diktat.ruleset.utils
 
 import org.jetbrains.kotlin.KtNodeTypes.BLOCK
 import org.jetbrains.kotlin.KtNodeTypes.IMPORT_LIST
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles

--- a/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/utils/KotlinParser.kt
+++ b/diktat-rules/src/main/kotlin/com/saveourtool/diktat/ruleset/utils/KotlinParser.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.com.intellij.pom.PomTransaction
 import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
 import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
 import org.jetbrains.kotlin.com.intellij.psi.TokenType.ERROR_ELEMENT
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.lexer.KtTokens.IMPORT_KEYWORD
@@ -30,7 +31,7 @@ import sun.reflect.ReflectionFactory
 class KotlinParser {
     private val project: Project by lazy {
         val compilerConfiguration = CompilerConfiguration()
-        compilerConfiguration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)  // mute the output logging to process it themselves
+        compilerConfiguration.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)  // mute the output logging to process it themselves
         val pomModel: PomModel = object : UserDataHolderBase(), PomModel {
             override fun runTransaction(transaction: PomTransaction) {
                 (transaction as PomTransactionBase).run()

--- a/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
@@ -7,7 +7,7 @@
     # testDirs: test
     disabledChapters: ""
     testDirs: test
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/diktat-rules/src/main/resources/diktat-analysis.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis.yml
@@ -7,7 +7,7 @@
     # expected values:  disabledChapters: "Naming, Comments, General, Variables, Functions, Classes"
     # or: "1, 2, 3, 4, 5, 6"
     disabledChapters: ""
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/diktat-rules/src/test/kotlin/com/saveourtool/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/com/saveourtool/diktat/util/TestUtils.kt
@@ -22,11 +22,6 @@ import kotlin.contracts.contract
 
 internal const val TEST_FILE_NAME = "TestFileName.kt"
 
-private val debuggerPromptPrefixes: Array<out String> = arrayOf(
-    "Listening for transport dt_socket at address: ",
-    "Listening for transport dt_shmem at address: ",
-)
-
 /**
  * Casts a nullable value to a non-`null` one, similarly to the `!!`
  * operator.
@@ -41,59 +36,6 @@ internal fun <T : Any> T?.assertNotNull(lazyFailureMessage: () -> String = { "Ex
     }
 
     return this ?: fail(lazyFailureMessage())
-}
-
-/**
- * Calls the [block] callback giving it a sequence of all the lines in this file
- * and closes the reader once the processing is complete.
- *
- * If [filterDebuggerPrompt] is `true`, the JVM debugger prompt is filtered out
- * from the sequence of lines before it is consumed by [block].
- *
- * If [filterDebuggerPrompt] is `false`, this function behaves exactly as the
- * overloaded function from the standard library.
- *
- * @param filterDebuggerPrompt whether the JVM debugger prompt should be
- *   filtered out.
- * @param block the callback which consumes the lines produced by this [Reader].
- * @return the value returned by [block].
- */
-@OptIn(ExperimentalContracts::class)
-internal fun <T> Reader.useLines(
-    filterDebuggerPrompt: Boolean,
-    block: (Sequence<String>) -> T,
-): T {
-    contract {
-        callsInPlace(block, EXACTLY_ONCE)
-    }
-
-    return when {
-        filterDebuggerPrompt -> {
-            /*
-             * Transform the line consumer.
-             */
-            { lines ->
-                lines.filterNot(String::isDebuggerPrompt).let(block)
-            }
-        }
-
-        else -> block
-    }.let(this::useLines)
-}
-
-private fun String.isDebuggerPrompt(printIfTrue: Boolean = true): Boolean {
-    val isDebuggerPrompt = debuggerPromptPrefixes.any { prefix ->
-        this.startsWith(prefix)
-    }
-    if (isDebuggerPrompt && printIfTrue) {
-        /*
-         * Print the prompt to the standard out,
-         * so that the IDE can attach to the debugger.
-         */
-        @Suppress("DEBUG_PRINT")
-        println(this)
-    }
-    return isDebuggerPrompt
 }
 
 /**

--- a/examples/gradle-groovy-dsl/diktat-analysis.yml
+++ b/examples/gradle-groovy-dsl/diktat-analysis.yml
@@ -7,7 +7,7 @@
     # expected values:  disabledChapters: "Naming, Comments, General, Variables, Functions, Classes"
     # or: "1, 2, 3, 4, 5, 6"
     disabledChapters: ""
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/examples/gradle-kotlin-dsl-multiproject/build.gradle.kts
+++ b/examples/gradle-kotlin-dsl-multiproject/build.gradle.kts
@@ -2,7 +2,7 @@ import com.saveourtool.diktat.plugin.gradle.DiktatExtension
 import com.saveourtool.diktat.plugin.gradle.DiktatGradlePlugin
 
 plugins {
-    kotlin("jvm") version "1.9.25"
+    kotlin("jvm") version "2.1.0"
     id("com.saveourtool.diktat") version "2.0.0" apply false
 }
 

--- a/examples/gradle-kotlin-dsl-multiproject/diktat-analysis.yml
+++ b/examples/gradle-kotlin-dsl-multiproject/diktat-analysis.yml
@@ -7,7 +7,7 @@
     # expected values:  disabledChapters: "Naming, Comments, General, Variables, Functions, Classes"
     # or: "1, 2, 3, 4, 5, 6"
     disabledChapters: ""
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/examples/gradle-kotlin-dsl/diktat-analysis.yml
+++ b/examples/gradle-kotlin-dsl/diktat-analysis.yml
@@ -7,7 +7,7 @@
     # expected values:  disabledChapters: "Naming, Comments, General, Variables, Functions, Classes"
     # or: "1, 2, 3, 4, 5, 6"
     disabledChapters: ""
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/examples/maven-multiproject/diktat-analysis.yml
+++ b/examples/maven-multiproject/diktat-analysis.yml
@@ -7,7 +7,7 @@
     # expected values:  disabledChapters: "Naming, Comments, General, Variables, Functions, Classes"
     # or: "1, 2, 3, 4, 5, 6"
     disabledChapters: ""
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/examples/maven/diktat-analysis.yml
+++ b/examples/maven/diktat-analysis.yml
@@ -7,7 +7,7 @@
     # expected values:  disabledChapters: "Naming, Comments, General, Variables, Functions, Classes"
     # or: "1, 2, 3, 4, 5, 6"
     disabledChapters: ""
-    kotlinVersion: 1.9
+    kotlinVersion: 2.1
     srcDirectories: "main"
 # Checks that the Class/Enum/Interface name matches Pascal case
 - name: CLASS_NAME_INCORRECT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "1.9.25"
-kotlin-ksp = "1.9.25-1.0.20"
+kotlin = "2.1.0"
+kotlin-ksp = "2.1.0-1.0.29"
 serialization = "1.6.3"
-ktlint = "1.0.1"
+ktlint = "1.5.0"
 junit = "5.10.2"
 junit-platfrom = "1.10.2"
 guava = "33.0.0-jre"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ jbool = "1.24"
 kotlin-logging = "6.0.3"
 log4j2 = "2.23.1"
 kaml = "0.57.0"
-sarif4k = "0.5.0"
+sarif4k = "0.6.0"
 jupiter-itf-extension = "0.13.1"
 
 # executable jar

--- a/gradle/plugins/src/main/kotlin/com/saveourtool/diktat/buildutils/kotlin-jvm-configuration.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/diktat/buildutils/kotlin-jvm-configuration.gradle.kts
@@ -1,7 +1,6 @@
 package com.saveourtool.diktat.buildutils
 
 import org.gradle.api.tasks.testing.Test
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm")

--- a/gradle/plugins/src/main/kotlin/com/saveourtool/diktat/buildutils/kotlin-jvm-configuration.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com/saveourtool/diktat/buildutils/kotlin-jvm-configuration.gradle.kts
@@ -7,13 +7,6 @@ plugins {
     kotlin("jvm")
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs +
-                "-opt-in=kotlin.RequiresOptIn" + "-Werror"
-    }
-}
-
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(Versions.jdk))
@@ -21,6 +14,10 @@ java {
 }
 
 kotlin {
+    compilerOptions {
+        optIn.add("kotlin.RequiresOptIn")
+    }
+
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(Versions.jdk))
     }


### PR DESCRIPTION
### What's done:
- Occasionally Kotlin decided to remove several AST Nodes https://github.com/JetBrains/kotlin/commit/76592dcb556f811c476fcb3912a910bbd19ffe3b

- There also was such kind of bug caused by Kotlin2 in ktlint https://github.com/pinterest/ktlint/pull/2857

- Removed -Werror flag due to one deprecation warning which we are not able to fix

- Updated tests and Kotlin version to 2.1 in resources

- Fixed some detekt deprecation warnings

- Replaced gradle configuration with new compilerOptions API

- Removed unused methods which caused warnings

- Updated sarif4k:  it caused an error with missing 'void io.github.detekt.sarif4k.ToolComponent.<init>

Co-authored-by: akuleshov7 <andrewkuleshov7@gmail.com>
Co-authored-by: orchestr7 <bonycatbony@gmail.com>

